### PR TITLE
[ci] Add snack-sdk-legacy CI runner

### DIFF
--- a/.github/workflows/snack-sdk-legacy.yml
+++ b/.github/workflows/snack-sdk-legacy.yml
@@ -28,6 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn install --ignore-scripts --frozen-lockfile
         working-directory: packages/snack-sdk-legacy
       - run: yarn lint --max-warnings 0
         working-directory: packages/snack-sdk-legacy


### PR DESCRIPTION
# Why

To automatically verify that updates to snack-sdk-legacy don't have any lint or build errors.

# How

- Add CI config

# Test Plan

- :eyes: