### PR TITLE
[sdk] Publish initial snack-sdk@3 release

### DIFF
--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -7,3 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+## 3.0.0 — 2020-12-04
+
+- Initial release. ([#8](https://github.com/expo/snack/pull/8) by [@IjzerenHein](https://github.com/IjzerenHein))

--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 ## 3.0.0 — 2020-12-04
 
-- Initial release. ([#8](https://github.com/expo/snack/pull/8) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Initial release. ([#9](https://github.com/expo/snack/pull/9) by [@IjzerenHein](https://github.com/IjzerenHein))

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-sdk",
-  "version": "3.0.0-rc.27",
+  "version": "3.0.0",
   "description": "The Expo Snack SDK",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# Why

Publish initial snack-sdk@3.

# How

- Update version
- Update changelog

# Test Plan

- :eyes: