### PR TITLE
[sdk] Add `isFeatureSupported` helper function

### DIFF
--- a/docs/snack-sdk-api/README.md
+++ b/docs/snack-sdk-api/README.md
@@ -14,6 +14,8 @@
 
 ### Type aliases
 
+* [SDKFeature](README.md#sdkfeature)
+* [SDKVersion](README.md#sdkversion)
 * [SnackAssetFile](README.md#snackassetfile)
 * [SnackCodeFile](README.md#snackcodefile)
 * [SnackConnectedClient](README.md#snackconnectedclient)
@@ -40,11 +42,28 @@
 
 * [getPreloadedModules](README.md#getpreloadedmodules)
 * [getSupportedSDKVersions](README.md#getsupportedsdkversions)
+* [isFeatureSupported](README.md#isfeaturesupported)
 * [isModulePreloaded](README.md#ismodulepreloaded)
 * [isValidSemver](README.md#isvalidsemver)
 * [validateSDKVersion](README.md#validatesdkversion)
 
 ## Type aliases
+
+### SDKFeature
+
+Ƭ  **SDKFeature**: \"MULTIPLE\_FILES\" \| \"PROJECT\_DEPENDENCIES\" \| \"TYPESCRIPT\" \| \"UNIMODULE\_IMPORTS\" \| \"POSTMESSAGE\_TRANSPORT\" \| \"VERSIONED\_SNACKAGER\"
+
+Feature that is supported by the SDK (e.g. "TYPESCRIPT").
+
+___
+
+### SDKVersion
+
+Ƭ  **SDKVersion**: \"36.0.0\" \| \"37.0.0\" \| \"38.0.0\" \| \"39.0.0\" \| \"40.0.0\"
+
+Version of the sdk to use (e.g. "37.0.0").
+
+___
 
 ### SnackAssetFile
 
@@ -232,7 +251,7 @@ ___
 
 ### SnackOptions
 
-Ƭ  **SnackOptions**: { apiURL?: undefined \| string ; channel?: undefined \| string ; codeChangesDelay?: undefined \| number ; createTransport?: undefined \| (options: SnackTransportOptions) => SnackTransport ; dependencies?: [SnackDependencies](README.md#snackdependencies) ; description?: undefined \| string ; deviceId?: undefined \| string ; disabled?: undefined \| false \| true ; files?: [SnackFiles](README.md#snackfiles) ; host?: undefined \| string ; id?: undefined \| string ; name?: undefined \| string ; online?: undefined \| false \| true ; previewTimeout?: undefined \| number ; reloadTimeout?: undefined \| number ; sdkVersion?: SDKVersion ; snackagerURL?: undefined \| string ; transports?: undefined \| { [id:string]: SnackTransport;  } ; user?: [SnackUser](README.md#snackuser) ; verbose?: undefined \| false \| true  }
+Ƭ  **SnackOptions**: { apiURL?: undefined \| string ; channel?: undefined \| string ; codeChangesDelay?: undefined \| number ; createTransport?: undefined \| (options: SnackTransportOptions) => SnackTransport ; dependencies?: [SnackDependencies](README.md#snackdependencies) ; description?: undefined \| string ; deviceId?: undefined \| string ; disabled?: undefined \| false \| true ; files?: [SnackFiles](README.md#snackfiles) ; host?: undefined \| string ; id?: undefined \| string ; name?: undefined \| string ; online?: undefined \| false \| true ; previewTimeout?: undefined \| number ; reloadTimeout?: undefined \| number ; sdkVersion?: [SDKVersion](README.md#sdkversion) ; snackagerURL?: undefined \| string ; transports?: undefined \| { [id:string]: SnackTransport;  } ; user?: [SnackUser](README.md#snackuser) ; verbose?: undefined \| false \| true  }
 
 #### Type declaration:
 
@@ -253,7 +272,7 @@ Name | Type |
 `online?` | undefined \| false \| true |
 `previewTimeout?` | undefined \| number |
 `reloadTimeout?` | undefined \| number |
-`sdkVersion?` | SDKVersion |
+`sdkVersion?` | [SDKVersion](README.md#sdkversion) |
 `snackagerURL?` | undefined \| string |
 `transports?` | undefined \| { [id:string]: SnackTransport;  } |
 `user?` | [SnackUser](README.md#snackuser) |
@@ -291,7 +310,7 @@ ___
 
 ### SnackState
 
-Ƭ  **SnackState**: { channel: string ; connectedClients: [SnackConnectedClients](README.md#snackconnectedclients) ; dependencies: [SnackDependencies](README.md#snackdependencies) ; description: string ; deviceId?: undefined \| string ; disabled: boolean ; files: [SnackFiles](README.md#snackfiles) ; id?: undefined \| string ; missingDependencies: [SnackMissingDependencies](README.md#snackmissingdependencies) ; name: string ; online: boolean ; onlineName?: undefined \| string ; saveURL?: undefined \| string ; savedSDKVersion?: undefined \| string ; sdkVersion: SDKVersion ; sendBeaconCloseRequest?: [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) ; unsaved: boolean ; url: string ; user?: [SnackUser](README.md#snackuser) ; wantedDependencyVersions?: [SnackDependencyVersions](README.md#snackdependencyversions)  }
+Ƭ  **SnackState**: { channel: string ; connectedClients: [SnackConnectedClients](README.md#snackconnectedclients) ; dependencies: [SnackDependencies](README.md#snackdependencies) ; description: string ; deviceId?: undefined \| string ; disabled: boolean ; files: [SnackFiles](README.md#snackfiles) ; id?: undefined \| string ; missingDependencies: [SnackMissingDependencies](README.md#snackmissingdependencies) ; name: string ; online: boolean ; onlineName?: undefined \| string ; saveURL?: undefined \| string ; savedSDKVersion?: undefined \| string ; sdkVersion: [SDKVersion](README.md#sdkversion) ; sendBeaconCloseRequest?: [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) ; unsaved: boolean ; url: string ; user?: [SnackUser](README.md#snackuser) ; wantedDependencyVersions?: [SnackDependencyVersions](README.md#snackdependencyversions)  }
 
 #### Type declaration:
 
@@ -311,7 +330,7 @@ Name | Type | Description |
 `onlineName?` | undefined \| string | Name of the Snack as shown in the "Recently in Development" section in the Expo client. The online-name will be empty when the Snack is not "online". |
 `saveURL?` | undefined \| string | URL of the saved Snack. The URL is empty when no save "id" is available. |
 `savedSDKVersion?` | undefined \| string | Last saved (non-draft) Expo SDK version. |
-`sdkVersion` | SDKVersion | Expo SDK version. |
+`sdkVersion` | [SDKVersion](README.md#sdkversion) | Expo SDK version. |
 `sendBeaconCloseRequest?` | [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) | A close request that should be send using the browser `sendBeacon` API whenever the browser session is unloaded. This gives the Snack a last opportunity to gracefully close its connections so that the "Recently in Development" section in the Expo client no longer shows the Snack. |
 `unsaved` | boolean | Unsaved status of the Snack. Becomes `true` when the Snack code is changed and `false` whenever the Snack is saved. |
 `url` | string | Unique experience url which can be used to open the Expo client and connect to the Snack (e.g. "exp://expo.io/@snack/sdk.38.0.0-78173941"). |
@@ -342,7 +361,7 @@ Name | Type |
 
 ### getPreloadedModules
 
-▸ **getPreloadedModules**(`sdkVersion`: SDKVersion, `coreModulesOnly?`: undefined \| false \| true): object
+▸ **getPreloadedModules**(`sdkVersion`: [SDKVersion](README.md#sdkversion), `coreModulesOnly?`: undefined \| false \| true): object
 
 Returns the list of pre-loaded modules for the given SDK version.
 
@@ -350,7 +369,7 @@ Returns the list of pre-loaded modules for the given SDK version.
 
 Name | Type |
 ------ | ------ |
-`sdkVersion` | SDKVersion |
+`sdkVersion` | [SDKVersion](README.md#sdkversion) |
 `coreModulesOnly?` | undefined \| false \| true |
 
 **Returns:** object
@@ -359,17 +378,34 @@ ___
 
 ### getSupportedSDKVersions
 
-▸ **getSupportedSDKVersions**(): SDKVersion[]
+▸ **getSupportedSDKVersions**(): [SDKVersion](README.md#sdkversion)[]
 
 Returns the list of supported SDK versions.
 
-**Returns:** SDKVersion[]
+**Returns:** [SDKVersion](README.md#sdkversion)[]
+
+___
+
+### isFeatureSupported
+
+▸ **isFeatureSupported**(`feature`: [SDKFeature](README.md#sdkfeature), `sdkVersion`: string): boolean
+
+Checks whether a feature is supported by the given SDK version.
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`feature` | [SDKFeature](README.md#sdkfeature) |
+`sdkVersion` | string |
+
+**Returns:** boolean
 
 ___
 
 ### isModulePreloaded
 
-▸ **isModulePreloaded**(`name`: string, `sdkVersion`: SDKVersion, `coreModulesOnly?`: undefined \| false \| true): boolean
+▸ **isModulePreloaded**(`name`: string, `sdkVersion`: [SDKVersion](README.md#sdkversion), `coreModulesOnly?`: undefined \| false \| true): boolean
 
 Checks whether a specific module/dependency is preloaded for the given SDK version.
 
@@ -378,7 +414,7 @@ Checks whether a specific module/dependency is preloaded for the given SDK versi
 Name | Type |
 ------ | ------ |
 `name` | string |
-`sdkVersion` | SDKVersion |
+`sdkVersion` | [SDKVersion](README.md#sdkversion) |
 `coreModulesOnly?` | undefined \| false \| true |
 
 **Returns:** boolean
@@ -403,12 +439,12 @@ ___
 
 ### validateSDKVersion
 
-▸ **validateSDKVersion**(`sdkVersion`: SDKVersion): SDKVersion
+▸ **validateSDKVersion**(`sdkVersion`: [SDKVersion](README.md#sdkversion)): [SDKVersion](README.md#sdkversion)
 
 #### Parameters:
 
 Name | Type |
 ------ | ------ |
-`sdkVersion` | SDKVersion |
+`sdkVersion` | [SDKVersion](README.md#sdkversion) |
 
-**Returns:** SDKVersion
+**Returns:** [SDKVersion](README.md#sdkversion)

--- a/docs/snack-sdk-api/classes/snack.md
+++ b/docs/snack-sdk-api/classes/snack.md
@@ -325,7 +325,7 @@ ___
 
 ### setSDKVersion
 
-▸ **setSDKVersion**(`sdkVersion`: SDKVersion): void
+▸ **setSDKVersion**(`sdkVersion`: [SDKVersion](../README.md#sdkversion)): void
 
 Sets the Expo SDK version.
 
@@ -333,7 +333,7 @@ Sets the Expo SDK version.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`sdkVersion` | SDKVersion | Valid SDK version (e.g. "38.0.0")  |
+`sdkVersion` | [SDKVersion](../README.md#sdkversion) | Valid SDK version (e.g. "38.0.0")  |
 
 **Returns:** void
 

--- a/docs/snack-sdk-migration.md
+++ b/docs/snack-sdk-migration.md
@@ -84,7 +84,8 @@ const snack = new Snack({
 
 | Version 2             | Version 3                   | Description                                          |
 | --------------------- | --------------------------- | ---------------------------------------------------- |
-| `SDKVersions`         | `getSupportedSDKVersions`   | Updated to method called `getSupportedSDKVersions`.  |
+| `SDKVersions.version`         | `getSupportedSDKVersions`   | Updated to method called `getSupportedSDKVersions`.  |
+| `SDKVersions.sdkSupportsFeature` | `isFeatureSupported` | Updated to method called `isFeatureSupported`. |
 | `isModulePreloaded`   | `isModulePreloaded`         | Has been extended with optional 3rd parameter `coreModulesOnly`.                                          |
 | `preloadedModules`    | `getPreloadedModules`       | Updated to method called `getPreloadedModules`.      |
 | `dependencyUtils`     |                             | Field has been removed                               |

--- a/docs/snack-sdk.md
+++ b/docs/snack-sdk.md
@@ -2,8 +2,6 @@
 
 The Expo Snack SDK. Use this to create a custom web interface for https://snack.expo.io/. 
 
-<!--Interested in integrating the Snack SDK into your project?
-Check out https://forums.expo.io/c/snack for assistance and to receive updates about any upgrades to the SDK.-->
 
 ## Index <!-- omit in toc -->
 

--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `isFeatureSupported` helper function. ([#10](https://github.com/expo/snack/pull/10) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ### 🐛 Bug fixes
 
 ## 3.0.0 — 2020-12-04

--- a/packages/snack-sdk/src/__tests__/sdkversion-test.ts
+++ b/packages/snack-sdk/src/__tests__/sdkversion-test.ts
@@ -5,6 +5,7 @@ import Snack, {
   defaultConfig,
   isModulePreloaded,
   getPreloadedModules,
+  isFeatureSupported,
 } from './snack-sdk';
 
 describe('sdkVersion', () => {
@@ -125,5 +126,23 @@ describe('isValidSemver', () => {
   });
   it('is invalid for random string', () => {
     expect(isValidSemver('random-string')).toBe(false);
+  });
+});
+
+describe('isFeatureSupported', () => {
+  it('returns true for supported feature', () => {
+    expect(isFeatureSupported('TYPESCRIPT', '38.0.0')).toBe(true);
+  });
+  it('returns false for supported feature', () => {
+    expect(isFeatureSupported('TYPESCRIPT', '21.0.0')).toBe(false);
+  });
+  it('throws for invalid feature', () => {
+    expect(() =>
+      // @ts-ignore Type '"Bogus"' is not assignable to type 'SDKFeature'
+      isFeatureSupported('Bogus', '37.0.0')
+    ).toThrowError();
+  });
+  it('throws for invalid version', () => {
+    expect(() => isFeatureSupported('TYPESCRIPT', 'foo')).toThrowError();
   });
 });

--- a/packages/snack-sdk/src/index.ts
+++ b/packages/snack-sdk/src/index.ts
@@ -10,6 +10,7 @@ import {
   getPreloadedModules,
   isValidSemver,
   getSupportedSDKVersions,
+  isFeatureSupported,
 } from './sdk';
 
 export * from './transports';
@@ -23,6 +24,7 @@ export {
   getPreloadedModules,
   isValidSemver,
   getSupportedSDKVersions,
+  isFeatureSupported,
   defaultConfig,
   Snack,
 };

--- a/packages/snack-sdk/src/sdk.ts
+++ b/packages/snack-sdk/src/sdk.ts
@@ -1,7 +1,8 @@
 import semver from 'semver';
 
 import sdks from './sdks';
-import { SDKVersion } from './types';
+import features from './sdks/features';
+import { SDKVersion, SDKFeature } from './types';
 
 /**
  * Checks whether a specific module/dependency is preloaded for the given SDK version.
@@ -54,4 +55,17 @@ export function getSupportedSDKVersions(): SDKVersion[] {
  */
 export function isValidSemver(version: string): boolean {
   return version === 'latest' || !!semver.validRange(version);
+}
+
+/**
+ * Checks whether a feature is supported by the given SDK version.
+ */
+export function isFeatureSupported(feature: SDKFeature, sdkVersion: string): boolean {
+  const featureVersion = features[feature];
+  if (!featureVersion) {
+    throw new Error(
+      `Invalid SDKFeature, the following versions are supported: ${Object.keys(features)}`
+    );
+  }
+  return semver.gte(sdkVersion, featureVersion);
 }

--- a/packages/snack-sdk/src/sdks/features.ts
+++ b/packages/snack-sdk/src/sdks/features.ts
@@ -1,0 +1,11 @@
+// minimum SDK versions that support snack features
+const features = {
+  MULTIPLE_FILES: '21.0.0',
+  PROJECT_DEPENDENCIES: '25.0.0',
+  TYPESCRIPT: '31.0.0',
+  UNIMODULE_IMPORTS: '33.0.0',
+  POSTMESSAGE_TRANSPORT: '35.0.0',
+  VERSIONED_SNACKAGER: '37.0.0',
+};
+
+export default features;

--- a/packages/snack-sdk/src/sdks/types.ts
+++ b/packages/snack-sdk/src/sdks/types.ts
@@ -1,5 +1,9 @@
+/**
+ * Version of the sdk to use (e.g. "37.0.0").
+ */
 export type SDKVersion = '36.0.0' | '37.0.0' | '38.0.0' | '39.0.0' | '40.0.0';
 
+/** @internal */
 export type SDKSpec = {
   // Version-spec for the published "expo" package. This version is
   // used to fetch compatible package versions. The value is typically
@@ -25,3 +29,14 @@ export type SDKSpec = {
     [name: string]: '*';
   };
 };
+
+/**
+ * Feature that is supported by the SDK (e.g. "TYPESCRIPT").
+ */
+export type SDKFeature =
+  | 'MULTIPLE_FILES'
+  | 'PROJECT_DEPENDENCIES'
+  | 'TYPESCRIPT'
+  | 'UNIMODULE_IMPORTS'
+  | 'POSTMESSAGE_TRANSPORT'
+  | 'VERSIONED_SNACKAGER';

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -1,11 +1,7 @@
-import { SDKVersion } from './sdks/types';
+import { SDKVersion, SDKFeature } from './sdks/types';
 import { SnackTransport } from './transports';
 
-/**
- * @type SDKVersion
- * Version of the sdk to use (e.g. "37.0.0").
- */
-export { SDKVersion };
+export { SDKVersion, SDKFeature };
 
 /**
  * A non asset file that is included with the project.

--- a/packages/snack-sdk/typedoc.json
+++ b/packages/snack-sdk/typedoc.json
@@ -2,7 +2,8 @@
   "inputFiles": ["./src"],
   "exclude": [
     "**/*+(FileUploader|DevSession|DependencyResolver|Logger|WantedVersions|State|utils|defaultConfig|index).ts",
-    "**/sdks/**",
+    "**/sdks/index.*",
+    "**/sdks/features.*",
     "**/transports/**",
     "**/__tests__/**",
     "**/__mocks__/**",


### PR DESCRIPTION
# Why

Add `isFeatureSupported` method for checking whether older SDK support certain features such as "TYPESCRIPT". This feature is needed by www in order to migrate to snack-sdk 3.

# How

- Add `isFeatureSupported` global method
- Add tests for `isFeatureSupported`
- Update docs
- Updated Migration Guide
- Fixed SDKVersion type not documented
- Updated changelog

# Test Plan

- `yarn lint`
- `yarn build`
- `yarn test`
