### PR TITLE
[sdk] Add `standardizeDependencies` helper function

### DIFF
--- a/docs/snack-sdk-api/README.md
+++ b/docs/snack-sdk-api/README.md
@@ -45,6 +45,7 @@
 * [isFeatureSupported](README.md#isfeaturesupported)
 * [isModulePreloaded](README.md#ismodulepreloaded)
 * [isValidSemver](README.md#isvalidsemver)
+* [standardizeDependencies](README.md#standardizedependencies)
 * [validateSDKVersion](README.md#validatesdkversion)
 
 ## Type aliases
@@ -434,6 +435,22 @@ Name | Type |
 `version` | string |
 
 **Returns:** boolean
+
+___
+
+### standardizeDependencies
+
+▸ **standardizeDependencies**(`dependencies`: any): [SnackDependencies](README.md#snackdependencies)
+
+Converts older dependency formats into the SnackDependencies type.
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`dependencies` | any |
+
+**Returns:** [SnackDependencies](README.md#snackdependencies)
 
 ___
 

--- a/docs/snack-sdk-migration.md
+++ b/docs/snack-sdk-migration.md
@@ -88,7 +88,7 @@ const snack = new Snack({
 | `SDKVersions.sdkSupportsFeature` | `isFeatureSupported` | Updated to method called `isFeatureSupported`. |
 | `isModulePreloaded`   | `isModulePreloaded`         | Has been extended with optional 3rd parameter `coreModulesOnly`.                                          |
 | `preloadedModules`    | `getPreloadedModules`       | Updated to method called `getPreloadedModules`.      |
-| `dependencyUtils`     |                             | Field has been removed                               |
+| `dependencyUtils`     | `standardizeDependencies`   | Replaced by method `standardizeDependencies`.        |
 | `supportedModules`    |                             | Field has been removed.                              |
 | `getSupportedVersion` |  | Method has been removed.              |
 |                       | `isValidSemver`             | Checks whether a string is a valid semantic version. |

--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add `isFeatureSupported` helper function. ([#10](https://github.com/expo/snack/pull/10) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Add `standardizeDependencies` helper function. ([#11](https://github.com/expo/snack/pull/11) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ### 🐛 Bug fixes
 

--- a/packages/snack-sdk/src/__tests__/dependencies-test.ts
+++ b/packages/snack-sdk/src/__tests__/dependencies-test.ts
@@ -1,5 +1,5 @@
 import '../__mocks__/fetch';
-import Snack from './snack-sdk';
+import Snack, { standardizeDependencies } from './snack-sdk';
 
 describe('dependencies', () => {
   it('resolves dependency', async () => {
@@ -252,5 +252,51 @@ describe('dependencies', () => {
     });
     const state = await snack.getStateAsync();
     expect(state.missingDependencies).toMatchSnapshot();
+  });
+});
+
+describe('standardizeDependencies', () => {
+  it('converts v1 dependencies', () => {
+    expect(
+      standardizeDependencies({
+        dep1: '1.2.3',
+      })
+    ).toMatchObject({
+      dep1: {
+        version: '1.2.3',
+      },
+    });
+  });
+  it('converts v2 dependencies', () => {
+    expect(
+      standardizeDependencies({
+        dep1: {
+          version: '1.2.3',
+          peerDependencies: {
+            peerDep2: {
+              version: '4.5.6',
+            },
+          },
+        },
+      })
+    ).toMatchObject({
+      dep1: {
+        version: '1.2.3',
+        peerDependencies: {
+          peerDep2: '4.5.6',
+        },
+      },
+    });
+  });
+  it('returns v3 dependencies untouched', () => {
+    const deps = {
+      dep1: {
+        version: '1.2.3',
+        peerDependencies: {
+          peerDep2: '4.5.6',
+        },
+      },
+    };
+    expect(standardizeDependencies(deps)).toBe(deps);
   });
 });

--- a/packages/snack-sdk/src/index.ts
+++ b/packages/snack-sdk/src/index.ts
@@ -11,6 +11,7 @@ import {
   isValidSemver,
   getSupportedSDKVersions,
   isFeatureSupported,
+  standardizeDependencies,
 } from './sdk';
 
 export * from './transports';
@@ -25,6 +26,7 @@ export {
   isValidSemver,
   getSupportedSDKVersions,
   isFeatureSupported,
+  standardizeDependencies,
   defaultConfig,
   Snack,
 };


### PR DESCRIPTION
# Why

Add `standardizeDependencies` method for converting older Snack `dependencies` formats. This feature is needed by www in order to migrate to snack-sdk 3.

# How

- Add `standardizeDependencies` global method
- Add tests for `standardizeDependencies`
- Update docs
- Updated Migration Guide
- Updated changelog

# Test Plan

- `yarn lint`
- `yarn build`
- `yarn test`
