### PR TITLE
[sdk] Fix dependencies object modification & scoped dependency names

### DIFF
--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### 🎉 New features
 
+### 🐛 Bug fixes
+
+- Fix initial dependencies object modification ([#18](https://github.com/expo/snack/pull/18) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix scoped dependency names with subpaths not recognized as valid ([#18](https://github.com/expo/snack/pull/18) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 3.3.0 — 2021-01-06
 
 ### 🎉 New features

--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Fix initial dependencies object modification ([#18](https://github.com/expo/snack/pull/18) by [@IjzerenHein](https://github.com/IjzerenHein))
-- Fix scoped dependency names with subpaths not recognized as valid ([#18](https://github.com/expo/snack/pull/18) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix initial dependencies object modification ([#37](https://github.com/expo/snack/pull/37) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Fix scoped dependency names with subpaths not recognized as valid ([#37](https://github.com/expo/snack/pull/37) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ## 3.3.0 — 2021-01-06
 

--- a/packages/snack-sdk/src/DependencyResolver.ts
+++ b/packages/snack-sdk/src/DependencyResolver.ts
@@ -182,6 +182,10 @@ export function verifyDependency(name: string, version: string): SnackError | un
       const result = validate(names[0]);
       validForOldPackages = result.validForNewPackages;
       errors = result.errors;
+    } else if (names.length >= 2 && name.startsWith('@')) {
+      const result = validate(names[0] + '/' + names[1]);
+      validForOldPackages = result.validForNewPackages;
+      errors = result.errors;
     }
 
     if (!validForOldPackages) {

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -103,7 +103,7 @@ export default class Snack {
   constructor(options: SnackOptions) {
     const channel = createChannel(options.channel);
     const sdkVersion = validateSDKVersion(options.sdkVersion ?? defaultConfig.sdkVersion);
-    const dependencies = options.dependencies ?? {};
+    const dependencies = options.dependencies ? { ...options.dependencies } : {};
     this.apiURL = options.apiURL ?? defaultConfig.apiURL;
     this.host = options.host ?? defaultConfig.host;
     this.logger = options.verbose ? createLogger(true) : undefined;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -34,6 +34,8 @@ Object {
 }
 `;
 
+exports[`dependencies fails on incomplete scoped names 1`] = `[Error: Invalid dependency '@scopeonly' (name can only contain URL-friendly characters)]`;
+
 exports[`dependencies fails on invalid dependency name 1`] = `[Error: Invalid dependency '+-/.' (name can only contain URL-friendly characters)]`;
 
 exports[`dependencies fails on invalid dependency version 1`] = `[Error: Invalid dependency 'expo' (version '-- 2 4' is not a valid semver)]`;

--- a/packages/snack-sdk/src/__tests__/dependencies-test.ts
+++ b/packages/snack-sdk/src/__tests__/dependencies-test.ts
@@ -109,9 +109,32 @@ describe('dependencies', () => {
     expect(state.dependencies[name].error).toMatchSnapshot();
   });
 
+  it('fails on incomplete scoped names', async () => {
+    const snack = new Snack({});
+    const name = '@scopeonly';
+    snack.updateDependencies({
+      [name]: { version: '1.0.0' },
+    });
+    const state = snack.getState();
+    expect(Object.keys(state.dependencies).length).toBe(1);
+    expect(state.dependencies[name].error).toBeDefined();
+    expect(state.dependencies[name].error).toMatchSnapshot();
+  });
+
   it('succeeds on dependency name with subpath', async () => {
     const snack = new Snack({});
     const name = 'react-native-gesture-handler/DrawerLayout';
+    snack.updateDependencies({
+      [name]: { version: '1.6.0' },
+    });
+    const state = snack.getState();
+    expect(Object.keys(state.dependencies).length).toBe(1);
+    expect(state.dependencies[name].error).toBeUndefined();
+  });
+
+  it('succeeds on scoped dependency name with subpath', async () => {
+    const snack = new Snack({});
+    const name = '@expo/vector-icons/FontAwesome.ttf';
     snack.updateDependencies({
       [name]: { version: '1.6.0' },
     });


### PR DESCRIPTION
# Why

Fixes https://forums.expo.io/t/cannot-open-old-snack/47209/3, which was caused by the snack-sdk modifying the initial dependencies object and setting an error status on the faulty dependency. This in turn caused the `__INITIAL_DATA` obect to be modified and serialised to fail because the Error object could not be serialised.

The faulty dependency was indeed not really invalid. It was a scoped dependency name with a subpath, but that particular case was not correctly supported.

# How

- Fix (prevent) modification of initial dependencies object
- Add support for scoped dependency names with subpaths (eg. `@scope/name/subpath`)
- Add tests for scoped dependency names

# Test Plan

- All tests pass
- Verified modification fix in snack-web and confirmed it works
