### PR TITLE
[ci] Use default work-dir for sdk actions

### DIFF
--- a/.github/workflows/snack-sdk-legacy.yml
+++ b/.github/workflows/snack-sdk-legacy.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --ignore-scripts --frozen-lockfile
-        working-directory: /
+        working-directory: .
       - run: yarn install --ignore-scripts --frozen-lockfile
       - run: yarn lint --max-warnings 0
       - run: yarn flow check

--- a/.github/workflows/snack-sdk-legacy.yml
+++ b/.github/workflows/snack-sdk-legacy.yml
@@ -1,5 +1,9 @@
 name: SnackSDKLegacy
 
+defaults:
+  run:
+    working-directory: packages/snack-sdk-legacy
+
 on:
   workflow_dispatch: {}
   push:
@@ -28,11 +32,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install --ignore-scripts --frozen-lockfile
+        working-directory: /
       - run: yarn install --ignore-scripts --frozen-lockfile
-        working-directory: packages/snack-sdk-legacy
       - run: yarn lint --max-warnings 0
-        working-directory: packages/snack-sdk-legacy
       - run: yarn flow check
-        working-directory: packages/snack-sdk-legacy
       - run: yarn build
-        working-directory: packages/snack-sdk-legacy

--- a/.github/workflows/snack-sdk.yml
+++ b/.github/workflows/snack-sdk.yml
@@ -1,5 +1,9 @@
 name: SnackSDK
 
+defaults:
+  run:
+    working-directory: packages/snack-sdk
+
 on:
   workflow_dispatch: {}
   push:
@@ -35,10 +39,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install --ignore-scripts --frozen-lockfile
       - run: yarn test --maxWorkers 1
-        working-directory: packages/snack-sdk
       - run: yarn lint --max-warnings 0
-        working-directory: packages/snack-sdk
       - run: yarn build
-        working-directory: packages/snack-sdk
       - run: yarn doc:ci
-        working-directory: packages/snack-sdk


### PR DESCRIPTION
# Why

Use default working directory in github actions to simplify definition file.
