### PR TITLE
[tools] Add git-crypt

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+PATH_add bin
+
+source_local() {
+  file=./.envrc.local
+  if [[ -f "$file" ]]; then
+    source_env $file
+  fi
+  watch_file $file
+}
+
+source_local

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,15 @@
+name: Tools
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}

--- a/bin/lock
+++ b/bin/lock
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git-crypt lock

--- a/bin/unlock
+++ b/bin/unlock
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+KEYFILE=$HOME/.expo-internal/expo-git-crypt-key
+
+if [ ! -f "$KEYFILE" ]; then
+  echo "The git-crypt key for the Snack repository is missing. Run \`update-local-secrets\` in Universe first and then run \`unlock\` here again."
+  exit 1
+fi
+
+git-crypt unlock "$KEYFILE"


### PR DESCRIPTION
# Why

Add support for git-crypt. This allows the use of `lock` and `unlock` commands to lock/unlock secrets.

# How

- Add `lock` and `unlock` scripts to `/bin`
- Add path to `/bin` to env
- Add GH action to verify unlocking of secrets in CI

# Test Plan

- Go to root of repo
- `direnv allow`
- `unlock` runs
- `lock` runs