### PR TITLE
[sdk] Export types using type keyword

### DIFF
--- a/packages/snack-sdk/src/index.ts
+++ b/packages/snack-sdk/src/index.ts
@@ -16,11 +16,8 @@ import {
 
 export * from './transports';
 export * from './types';
+export type { SnackOptions, SnackSaveOptions, SnackStateListener, SnackLogListener };
 export {
-  SnackOptions,
-  SnackSaveOptions,
-  SnackStateListener,
-  SnackLogListener,
   isModulePreloaded,
   getPreloadedModules,
   isValidSemver,

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -1,7 +1,7 @@
 import { SDKVersion, SDKFeature } from './sdks/types';
 import { SnackTransport } from './transports';
 
-export { SDKVersion, SDKFeature };
+export type { SDKVersion, SDKFeature };
 
 /**
  * A non asset file that is included with the project.


### PR DESCRIPTION
# Why

To allow TypeScript projects to import the sources directly.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
