### PR TITLE
[ci] Only notify slack when deploying website

### DIFF
--- a/.github/workflows/website-production.yml
+++ b/.github/workflows/website-production.yml
@@ -13,7 +13,7 @@ on:
   push:
     branches: [main]
     paths:
-      - .github/workflows/website.yml
+      - .github/workflows/website-production.yml
       - website/**
       - packages/snack-sdk/**
       - .eslint*
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - .github/workflows/website.yml
+      - .github/workflows/website-production.yml
       - website/**
       - packages/snack-sdk/**
       - .eslint*

--- a/.github/workflows/website-production.yml
+++ b/.github/workflows/website-production.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Notify build on Slack
         uses: 8398a7/action-slack@v3
-        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy != 'deploy'
+        if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy != 'deploy'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -75,5 +75,5 @@ jobs:
         with:
           channel: '#snack'
           status: ${{ job.status }}
-          author_name: Build and Deploy Snack website to Staging
+          author_name: Deploy Snack website to Staging
           fields: message,commit,author,took

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [main]
     paths:
-      - .github/workflows/website.yml
+      - .github/workflows/website-staging.yml
       - website/**
       - packages/snack-sdk/**
       - .eslint*
@@ -17,7 +17,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - .github/workflows/website.yml
+      - .github/workflows/website-staging.yml
       - website/**
       - packages/snack-sdk/**
       - .eslint*


### PR DESCRIPTION
# Why

Don't Notify slack when merely production build succeeds, but only when it fails or is deployed to production.

Also fixes the github workflows not re-run when changing them

