### PR TITLE
[website] Use jsdelivr CDN for resources

### DIFF
--- a/website/resources.json
+++ b/website/resources.json
@@ -1,5 +1,5 @@
 {
-  "normalize": "https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css",
-  "babel-polyfill": "https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js",
-  "typescript": "https://cdnjs.cloudflare.com/ajax/libs/typescript/2.4.2/typescript.min.js"
+  "normalize": "https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css",
+  "babel-polyfill": "https://cdn.jsdelivr.net/npm/babel-polyfill@6.26.0/dist/polyfill.min.js",
+  "typescript": "https://cdn.jsdelivr.net/npm/typescript@2.4.2/lib/typescript.min.js"
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/snack-web/pull/43

# How

- Update resource urls to jsdelivr
- Scanned code for any other cloudflare usage, but didn't find any

# Test Plan

- Confirmed locally that all resources url still load
- All tests pass