### PR TITLE
[website] Fix website watcher and add start logs

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -9,8 +9,10 @@ module.exports = {
       script: './src/server/index.tsx',
       interpreter,
       interpreter_args: '--require tsconfig-paths/register',
-      watch: true,
       cwd: 'website',
+      watch: ['.'],
+      watch_delay: 1000,
+      ignore_watch: ['node_modules'],
     },
     /* {
       name: 'snack-bundler',

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -13,6 +13,9 @@ import routes from './routes';
 import sw from './sw';
 import createLogger from './utils/createLogger';
 
+const startTime = Date.now();
+console.log(`Starting Snack web server using NODE_ENV=${process.env.NODE_ENV} ...`);
+
 type ShutdownSignal = 'SIGHUP' | 'SIGINT' | 'SIGTERM' | 'SIGUSR2';
 
 const port = 3011;
@@ -104,7 +107,9 @@ const httpServer = app.listen(port, host, backlog, () => {
   const { address, port } = server.address() as AddressInfo;
 
   console.log(
-    `The Snack web server is listening on http://${address}:${port} using NODE_ENV=${process.env.NODE_ENV}`
+    `The Snack web server is listening on http://${address}:${port}, took ${
+      (Date.now() - startTime) / 1000
+    } seconds`
   );
 });
 


### PR DESCRIPTION
# Why

Fixes website app not recompiling code changes when started with `yarn start` from the root.

# How

- Add watch config for pm2
- Add logs to measure website startup