### PR TITLE
[sdk] Add support for access token authentication

### DIFF
--- a/packages/snack-sdk/src/DevSession.ts
+++ b/packages/snack-sdk/src/DevSession.ts
@@ -1,6 +1,6 @@
 import { Logger } from './Logger';
 import { SnackState, SnackUser, SnackSendBeaconRequest } from './types';
-import { fetch } from './utils';
+import { createUserHeader, fetch } from './utils';
 
 export default class DevSession {
   private apiURL: string;
@@ -66,8 +66,8 @@ export default class DevSession {
       url,
       method: 'post',
       headers: {
-        ...(user?.sessionSecret ? { 'Expo-Session': user.sessionSecret } : {}),
         'Content-Type': 'application/json',
+        ...createUserHeader(user),
       },
     };
   }

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -43,7 +43,7 @@ import {
   SnackConnectedClients,
   SnackWindowRef,
 } from './types';
-import { createChannel, fetch, createURL, createError } from './utils';
+import { createChannel, fetch, createURL, createError, createUserHeader } from './utils';
 
 export type SnackOptions = {
   sdkVersion?: SDKVersion;
@@ -362,9 +362,7 @@ export default class Snack {
         body: JSON.stringify(payload),
         headers: {
           'Content-Type': 'application/json',
-          ...(user?.sessionSecret && !options?.ignoreUser
-            ? { 'Expo-Session': user.sessionSecret }
-            : {}),
+          ...(options?.ignoreUser ? {} : createUserHeader(user)),
         },
       });
       const data = await response.json();

--- a/packages/snack-sdk/src/__tests__/devsession-test.ts
+++ b/packages/snack-sdk/src/__tests__/devsession-test.ts
@@ -107,7 +107,7 @@ describe('devsession', () => {
       expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
-          Authorization: 'bearer sometoken',
+          Authorization: 'Bearer sometoken',
         }),
       }),
     );

--- a/packages/snack-sdk/src/__tests__/devsession-test.ts
+++ b/packages/snack-sdk/src/__tests__/devsession-test.ts
@@ -80,7 +80,7 @@ describe('devsession', () => {
   });
 
   it('sends notify with user session secret', async () => {
-    new Snack({
+    const snack = new Snack({
       apiURL: 'https://exp.host',
       online: true,
       deviceId: '1234',
@@ -92,12 +92,13 @@ describe('devsession', () => {
         headers: expect.objectContaining({
           'Expo-Session': '{"some":"json"}',
         }),
-      }),
+      })
     );
+    snack.setOnline(false);
   });
 
   it('sends notify with user access token', async () => {
-    new Snack({
+    const snack = new Snack({
       apiURL: 'https://exp.host',
       online: true,
       deviceId: '1234',
@@ -109,7 +110,8 @@ describe('devsession', () => {
         headers: expect.objectContaining({
           Authorization: 'Bearer sometoken',
         }),
-      }),
+      })
     );
-  })
+    snack.setOnline(false);
+  });
 });

--- a/packages/snack-sdk/src/__tests__/devsession-test.ts
+++ b/packages/snack-sdk/src/__tests__/devsession-test.ts
@@ -78,4 +78,38 @@ describe('devsession', () => {
     snack.setOnline(false);
     expect(fetch).toBeCalledTimes(3);
   });
+
+  it('sends notify with user session secret', async () => {
+    new Snack({
+      apiURL: 'https://exp.host',
+      online: true,
+      deviceId: '1234',
+      user: { sessionSecret: '{"some":"json"}' },
+    });
+    expect(fetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Expo-Session': '{"some":"json"}',
+        }),
+      }),
+    );
+  });
+
+  it('sends notify with user access token', async () => {
+    new Snack({
+      apiURL: 'https://exp.host',
+      online: true,
+      deviceId: '1234',
+      user: { accessToken: 'sometoken' },
+    });
+    expect(fetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'bearer sometoken',
+        }),
+      }),
+    );
+  })
 });

--- a/packages/snack-sdk/src/__tests__/save-test.ts
+++ b/packages/snack-sdk/src/__tests__/save-test.ts
@@ -1,4 +1,4 @@
-import '../__mocks__/fetch';
+import fetch from '../__mocks__/fetch';
 import Snack from './snack-sdk';
 
 describe('save', () => {
@@ -123,5 +123,49 @@ describe('save', () => {
       },
     });
     await expect(snack.saveAsync()).rejects.toBeDefined();
+  });
+
+  it('saves snack with user session secret', async () => {
+    const snack = new Snack({
+      online: true,
+      user: { sessionSecret: '{"some":"json"}' },
+      files: {
+        'App.js': {
+          type: 'CODE',
+          contents: `console.log('hello world');`,
+        },
+      },
+    });
+    await snack.saveAsync();
+    expect(fetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Expo-Session': '{"some":"json"}',
+        }),
+      }),
+    );
+  });
+
+  it('saves snack with user access token', async () => {
+    const snack = new Snack({
+      online: true,
+      user: { accessToken: 'sometoken' },
+      files: {
+        'App.js': {
+          type: 'CODE',
+          contents: `console.log('hello world');`,
+        },
+      },
+    });
+    await snack.saveAsync();
+    expect(fetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sometoken',
+        }),
+      }),
+    );
   });
 });

--- a/packages/snack-sdk/src/__tests__/save-test.ts
+++ b/packages/snack-sdk/src/__tests__/save-test.ts
@@ -125,9 +125,8 @@ describe('save', () => {
     await expect(snack.saveAsync()).rejects.toBeDefined();
   });
 
-  it('saves snack with user session secret', async () => {
+  it('saves with session secret', async () => {
     const snack = new Snack({
-      online: true,
       user: { sessionSecret: '{"some":"json"}' },
       files: {
         'App.js': {
@@ -143,13 +142,12 @@ describe('save', () => {
         headers: expect.objectContaining({
           'Expo-Session': '{"some":"json"}',
         }),
-      }),
+      })
     );
   });
 
-  it('saves snack with user access token', async () => {
+  it('saves with access token', async () => {
     const snack = new Snack({
-      online: true,
       user: { accessToken: 'sometoken' },
       files: {
         'App.js': {
@@ -165,7 +163,7 @@ describe('save', () => {
         headers: expect.objectContaining({
           Authorization: 'Bearer sometoken',
         }),
-      }),
+      })
     );
   });
 });

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -121,6 +121,7 @@ export type SnackConnectedClients = {
  */
 export type SnackUser = {
   sessionSecret?: string;
+  accessToken?: string;
 };
 
 /**

--- a/packages/snack-sdk/src/utils.ts
+++ b/packages/snack-sdk/src/utils.ts
@@ -69,7 +69,7 @@ export function createUserHeader(user?: SnackUser): { [key: string]: string } {
   }
 
   if (user?.accessToken) {
-    return { Authorization: `bearer ${user.accessToken}` };
+    return { Authorization: `Bearer ${user.accessToken}` };
   }
 
   return {};

--- a/packages/snack-sdk/src/utils.ts
+++ b/packages/snack-sdk/src/utils.ts
@@ -1,7 +1,7 @@
 import fetchPonyfill from 'fetch-ponyfill';
 import { customAlphabet } from 'nanoid';
 
-import { SDKVersion, SnackError } from './types';
+import { SDKVersion, SnackError, SnackUser } from './types';
 
 const { fetch } = fetchPonyfill();
 export { fetch };
@@ -61,4 +61,16 @@ export function createError(config: {
   if (config.columnNumber) error.columnNumber = config.columnNumber;
   if (config.stack) error.stack = config.stack;
   return error;
+}
+
+export function createUserHeader(user?: SnackUser): { [key: string]: string } {
+  if (user?.sessionSecret) {
+    return { 'Expo-Session': user.sessionSecret };
+  }
+
+  if (user?.accessToken) {
+    return { Authorization: `bearer ${user.accessToken}` };
+  }
+
+  return {};
 }


### PR DESCRIPTION
# Why

Adds basic support for `user: { accessToken: '...' }` to programmatically interact with stored Snacks.

# How

- Added helper for the `Expo-Session` or `Authorization: bearer ...` headers.
- Added tests for devsession to send authenticated requests

# Test Plan

- Create a new snack
- Add `snack.setUser({ accessToken: '...' })`
- Save the snack
- Snack should be saved on account by only using the access token