### PR TITLE
[website] Rename Expo Client -> Expo Go

### DIFF
--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -213,7 +213,7 @@ class Main extends React.Component<Props, State> {
       apiURL: nullthrows(process.env.API_SERVER_URL),
       snackagerURL,
       host:
-        // Use staging server in development, otherwise the Expo client and appetize
+        // Use staging server in development, otherwise the Expo Go app and appetize
         // can't access the runtime. Replace with ngrok url to test locally.
         process.env.NODE_ENV === 'development'
           ? 'staging.snack.expo.io'

--- a/website/src/client/components/DeviceInstructions/WhyNoQrBanner.tsx
+++ b/website/src/client/components/DeviceInstructions/WhyNoQrBanner.tsx
@@ -7,7 +7,7 @@ type Props = {
 export default function WhyNoQrBanner({ className }: Props) {
   return (
     <p className={className}>
-      * Expo client for iOS does not include a QR code scanner.
+      * Expo Go for iOS does not include a QR code scanner.
       <br />
       <a
         href="https://blog.expo.io/upcoming-limitations-to-ios-expo-client-8076d01aee1a"

--- a/website/src/client/components/DevicePreview/MyDeviceFrame.tsx
+++ b/website/src/client/components/DevicePreview/MyDeviceFrame.tsx
@@ -75,7 +75,7 @@ class MyDeviceFrame extends React.PureComponent<Props, State> {
               className={css(styles.link)}
               href={`${process.env.SERVER_URL}/client`}
               target="blank">
-              Expo Client
+              Expo Go app
             </a>{' '}
             and
             <br />
@@ -211,7 +211,7 @@ class MyDeviceFrame extends React.PureComponent<Props, State> {
         <>
           {viewer ? (
             <p className={css(styles.notConnectedText)}>
-              This app is visible on the "Projects" tab of your signed in Expo client
+              This Snack is visible on the "Projects" tab of your signed in Expo Go app
               {deviceId ? ', and on device ' : '. Or set a '}
               <button onClick={this.onClickDeviceId} className={css(styles.link)}>
                 {deviceId ? (
@@ -224,7 +224,7 @@ class MyDeviceFrame extends React.PureComponent<Props, State> {
             </p>
           ) : (
             <p className={css(styles.notConnectedText)}>
-              This app is visible on the "Projects" tab of Expo client with device ID
+              This Snack is visible on the "Projects" tab of Expo Go with device ID
               <span> </span>
               <button onClick={this.onClickDeviceId} className={css(styles.link)}>
                 <span className={css(styles.deviceIDText)}>{deviceId}</span>

--- a/website/src/client/components/EmbeddedEditorView.tsx
+++ b/website/src/client/components/EmbeddedEditorView.tsx
@@ -203,7 +203,7 @@ class EmbeddedEditorView extends React.PureComponent<Props, State> {
               target="_blank"
               rel="noopener noreferrer"
               href={isAndroid(userAgent) ? constants.links.playstore : constants.links.itunes}>
-              Download Expo client
+              Download Expo Go
             </a>
           </div>
         ) : null}

--- a/website/src/client/components/shared/OpenWithExpoButton.tsx
+++ b/website/src/client/components/shared/OpenWithExpoButton.tsx
@@ -15,7 +15,7 @@ const OpenWithExpoButton = ({ experienceURL, onDeviceConnectionAttempt }: Props)
     href={experienceURL}
     className={css(styles.button)}
     onClick={onDeviceConnectionAttempt}>
-    Open with Expo client
+    Open with Expo Go
   </ButtonLink>
 );
 


### PR DESCRIPTION
# Why

Rename "Expo Client" to "Expo Go"