### PR TITLE
[sdk] Update SDK 40 & 39 versions

### DIFF
--- a/packages/snack-sdk/src/__fixtures__/bundledNativeModules.json
+++ b/packages/snack-sdk/src/__fixtures__/bundledNativeModules.json
@@ -313,7 +313,7 @@
     "@react-native-community/slider": "3.0.3",
     "expo-status-bar": "~1.0.2"
   },
-  "40.0.0-beta.2": {
+  "^40.0.0": {
     "@expo/vector-icons": "^10.0.0",
     "@react-native-community/netinfo": "5.9.7",
     "@react-native-community/async-storage": "~1.12.0",

--- a/packages/snack-sdk/src/sdks/index.ts
+++ b/packages/snack-sdk/src/sdks/index.ts
@@ -53,7 +53,7 @@ const sdks: { [version: string]: SDKSpec } = {
     coreModules: {
       ...assets,
       ...unimodules,
-      expo: '38.0.9',
+      expo: '38.0.10',
       react: '16.11.0',
       'react-native': '0.62.2',
       'react-dom': '*',
@@ -131,11 +131,11 @@ const sdks: { [version: string]: SDKSpec } = {
     },
   },
   '40.0.0': {
-    version: '40.0.0-beta.2',
+    version: '^40.0.0',
     coreModules: {
       ...assets,
       ...unimodules,
-      expo: '40.0.0-beta.2',
+      expo: '40.0.1',
       react: '16.13.1',
       'react-native': '0.63.2',
       'react-dom': '*',


### PR DESCRIPTION
# Why

Updates the SDK 40 version, which was still set to beta.2 instead of using the latest version.
