### PR TITLE
[website] Fix import button and rename to “main”

### DIFF
--- a/website/src/client/components/Import/ImportRepoModal.tsx
+++ b/website/src/client/components/Import/ImportRepoModal.tsx
@@ -133,28 +133,30 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { status } = this.state;
-    const importing = status === 'importing';
-    const error = status === 'error';
+    const { status, url, repo, path, branch, advanced } = this.state;
+    const isImporting = status === 'importing';
+    const isError = status === 'error';
 
     return (
       <ModalDialog
         visible={this.props.visible}
         onDismiss={this._hideImportModal}
         title="Import git repository">
-        {importing ? <ProgressIndicator duration={45000} className={css(styles.progress)} /> : null}
+        {isImporting ? (
+          <ProgressIndicator duration={45000} className={css(styles.progress)} />
+        ) : null}
         <form onSubmit={this._handleImportRepoClick}>
-          <p className={!error ? css(styles.paragraph) : css(styles.errorParagraph)}>
-            {!error
+          <p className={!isError ? css(styles.paragraph) : css(styles.errorParagraph)}>
+            {!isError
               ? 'Import an Expo project from a Git repository.'
               : 'An error occurred during import. This could be because the data provided was invalid, or because the repository referenced is not a properly formatted Expo project.'}
           </p>
-          {this.state.advanced ? (
+          {advanced ? (
             <>
               <h4 className={css(styles.subtitle)}>Repository URL</h4>
               <LargeInput
                 name="repo"
-                value={this.state.repo}
+                value={repo}
                 onChange={this._handleChange}
                 placeholder="https://github.com/ide/love-languages.git"
                 autoFocus
@@ -162,16 +164,16 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
               <h4 className={css(styles.subtitle)}>Folder path</h4>
               <LargeInput
                 name="path"
-                value={this.state.path}
+                value={path}
                 onChange={this._handleChange}
                 placeholder="/example/app"
               />
               <h4 className={css(styles.subtitle)}>Branch name</h4>
               <LargeInput
                 name="branch"
-                value={this.state.branch}
+                value={branch}
                 onChange={this._handleChange}
-                placeholder="master"
+                placeholder="main"
               />
             </>
           ) : (
@@ -179,9 +181,9 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
               <h4 className={css(styles.subtitle)}>Git URL</h4>
               <LargeTextArea
                 minRows={2}
-                value={this.state.url}
+                value={url}
                 onChange={this._handleChangeUrl}
-                placeholder="https://github.com/ide/love-languages/tree/master/example/app"
+                placeholder="https://github.com/ide/love-languages/tree/main/app"
                 autoFocus
               />
             </>
@@ -190,16 +192,11 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
             type="button"
             onClick={() => this.setState((state) => ({ advanced: !state.advanced }))}
             className={css(styles.advanced)}>
-            {this.state.advanced ? 'Hide' : 'Show'} advanced options
+            {advanced ? 'Hide' : 'Show'} advanced options
           </button>
           <div className={css(styles.buttons)}>
-            <Button
-              large
-              disabled={!this.state.url}
-              loading={importing}
-              type="submit"
-              variant="primary">
-              {importing ? 'Importing repository…' : 'Import repository'}
+            <Button large disabled={!repo} loading={isImporting} type="submit" variant="primary">
+              {isImporting ? 'Importing repository…' : 'Import repository'}
             </Button>
           </div>
         </form>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,11 +2752,6 @@ b64u-lite@^1.0.1:
   dependencies:
     b64-lite "^1.4.0"
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"


### PR DESCRIPTION
# Why

Fixes the Git Import button which is not enabled when entering the repo location through the "advanced" options.

![image](https://user-images.githubusercontent.com/6184593/107228278-c31cb880-6a1c-11eb-900f-fba60dae20e5.png)

# How

- Fix faulty button disabled prop
- Rename "master" to "main"

# Test Plan

- Verified button is enabled and works using Git url
- Verified button is enabled and works using advanced Repo url
