### PR TITLE
[website] Fix dependency and linter warnings on test files

### DIFF
--- a/website/src/client/components/DependencyManager.tsx
+++ b/website/src/client/components/DependencyManager.tsx
@@ -20,7 +20,7 @@ import {
   getPackageJsonDependencies,
 } from '../utils/dependencies';
 import { openEmbeddedSessionFullScreen } from '../utils/embeddedSession';
-import { isScript, isPackageJson } from '../utils/fileUtilities';
+import { isScript, isPackageJson, isTest } from '../utils/fileUtilities';
 import type { FileDependencies } from '../utils/findDependencies';
 import { EditorViewProps } from './EditorViewProps';
 import Toast from './shared/Toast';
@@ -87,6 +87,7 @@ export function withDependencyManager<Props extends EditorViewProps>(
           if (
             file.type === 'CODE' &&
             isScript(path) &&
+            !isTest(path) &&
             file.contents !== state.files[path]?.contents
           ) {
             uncheckedFiles.add(path);

--- a/website/src/client/components/EditorView.tsx
+++ b/website/src/client/components/EditorView.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { Viewer, SnackFiles, Annotation, SDKVersion } from '../types';
 import Analytics from '../utils/Analytics';
 import { isMobile } from '../utils/detectPlatform';
-import { isScript, isJson } from '../utils/fileUtilities';
+import { isScript, isJson, isTest } from '../utils/fileUtilities';
 import lintFile from '../utils/lintFile';
 import prettierCode from '../utils/prettierCode';
 import AssetViewer from './AssetViewer';
@@ -195,7 +195,7 @@ class EditorView extends React.Component<Props, State> {
     // Lint other files if they have changed
     for (const path in files) {
       const file = files[path];
-      if (file.type === 'CODE' && file.contents !== lintedFiles[path]?.code) {
+      if (!isTest(path) && file.type === 'CODE' && file.contents !== lintedFiles[path]?.code) {
         const annotations = await lintFile(path, files);
         newLintedFiles = newLintedFiles ?? { ...lintedFiles };
         newLintedFiles[path] = {
@@ -230,7 +230,7 @@ class EditorView extends React.Component<Props, State> {
     const { selectedFile, files } = this.props;
     const file = files[selectedFile];
 
-    if (file && file.type === 'CODE') {
+    if (file?.type === 'CODE') {
       let code: string;
       if (isJson(selectedFile)) {
         code = JSON.stringify(JSON.parse(file.contents), null, 2);

--- a/website/src/client/utils/fileUtilities.tsx
+++ b/website/src/client/utils/fileUtilities.tsx
@@ -66,3 +66,14 @@ export function isJS(name: string): boolean {
 export function isTS(name: string): boolean {
   return isScript(name) && !isJS(name);
 }
+
+export function isTest(name: string): boolean {
+  name = name.toLocaleLowerCase();
+  return (
+    name.includes('__tests__') ||
+    name.includes('__integration-tests__') ||
+    name.includes('__mocks__') ||
+    name.includes('.test') ||
+    name.includes('.spec')
+  );
+}


### PR DESCRIPTION
# Why

Fixes dependency error on `react-test-renderer` and linter warnings/errors on tests.

*see `react-test-renderer` error and `it` & `define` warninga*
![image](https://user-images.githubusercontent.com/6184593/107246351-7642dd00-6a30-11eb-8caf-91a6f4d7cc71.png)

# How

- Exclude test files from dependency scanning
- Exclude test files from linting

# Test Plan

- After changes errors and warnings in the tests are gone

![image](https://user-images.githubusercontent.com/6184593/107246241-56131e00-6a30-11eb-92a7-4da7141549e5.png)

