### PR TITLE
[sdk] Fix `yarn test` when build folder exists

### DIFF
--- a/packages/snack-sdk/jest.config.js
+++ b/packages/snack-sdk/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
 };


### PR DESCRIPTION
# Why

Otherwise `yarn test` also tests the output of the build folder, which might be old and tends to produce ver vague errors.
