### PR TITLE
[website] Unify keyboard shortcuts and appearance

### DIFF
--- a/website/src/client/components/Editor/themes/monaco-overrides.tsx
+++ b/website/src/client/components/Editor/themes/monaco-overrides.tsx
@@ -84,8 +84,11 @@ export default css`
 
   .snack-monaco-editor .monaco-menu .monaco-action-bar .keybinding {
     color: inherit;
-    font-size: inherit;
-    opacity: 0.3;
+    font-size: 80%;
+    font-family: monospace;
+    line-height: 18px;
+    opacity: 0.45;
+    margin-left: 8px
   }
 
   .snack-monaco-editor .monaco-menu .monaco-action-bar .keybinding,

--- a/website/src/client/components/Editor/themes/monaco-overrides.tsx
+++ b/website/src/client/components/Editor/themes/monaco-overrides.tsx
@@ -84,10 +84,10 @@ export default css`
 
   .snack-monaco-editor .monaco-menu .monaco-action-bar .keybinding {
     color: inherit;
-    font-size: 80%;
-    font-family: monospace;
+    font-size: 85%;
+    font-family: Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
     line-height: 18px;
-    opacity: 0.45;
+    opacity: 0.5;
     margin-left: 8px;
   }
 

--- a/website/src/client/components/Editor/themes/monaco-overrides.tsx
+++ b/website/src/client/components/Editor/themes/monaco-overrides.tsx
@@ -88,7 +88,7 @@ export default css`
     font-family: monospace;
     line-height: 18px;
     opacity: 0.45;
-    margin-left: 8px
+    margin-left: 8px;
   }
 
   .snack-monaco-editor .monaco-menu .monaco-action-bar .keybinding,

--- a/website/src/client/components/Editor/themes/monaco-overrides.tsx
+++ b/website/src/client/components/Editor/themes/monaco-overrides.tsx
@@ -85,7 +85,7 @@ export default css`
   .snack-monaco-editor .monaco-menu .monaco-action-bar .keybinding {
     color: inherit;
     font-size: 85%;
-    font-family: Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-family: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
     line-height: 18px;
     opacity: 0.5;
     margin-left: 8px;

--- a/website/src/client/components/EditorFooter.tsx
+++ b/website/src/client/components/EditorFooter.tsx
@@ -136,18 +136,16 @@ export default function EditorFooter(props: Props) {
         label={<span className={css(styles.buttonLabel)}>Editor</span>}
         content={
           <>
-            <div className={css(styles.buttonItem, styles.buttonItemEditorPane)}>
-              <IconButton
-                small
-                title="Show keyboard shortcuts"
-                label="Shortcuts"
-                onClick={onShowShortcuts}>
-                <svg width="18px" height="18px" viewBox="0 0 18 18">
-                  <path d="M3,0 L15,0 C16.6568542,-3.04359188e-16 18,1.34314575 18,3 L18,15 C18,16.6568542 16.6568542,18 15,18 L3,18 C1.34314575,18 -2.46162913e-15,16.6568542 -2.66453526e-15,15 L-1.77635684e-15,3 C-1.97926296e-15,1.34314575 1.34314575,-5.83819232e-16 3,-8.8817842e-16 Z M7.41949521,8.19170984 L7.41949521,5 L6,5 L6,13 L7.41949521,13 L7.41949521,9.68911917 L7.71192341,9.44041451 L11.0992167,13 L13,13 L8.7232376,8.62176166 L12.975631,5 L11.0809399,5 L7.41949521,8.19170984 Z" />
-                </svg>
-              </IconButton>
-              <ShortcutLabel combo={Shortcuts.shortcuts.combo} />
+            <div
+              className={css(styles.buttonItem, styles.buttonItemEditorPane)}
+              onClick={onShowShortcuts}>
+              <IconButton small title="Show keyboard shortcuts" label="Shortcuts" />
+              <ShortcutLabel
+                combo={Shortcuts.shortcuts.combo}
+                className={css(styles.buttonItemShortcut)}
+              />
             </div>
+            <div className={css(styles.menuSeparator)} />
             <ToggleSwitch checked={fileTreeShown} onChange={onToggleFileTree} label="Files" />
             <ToggleSwitch checked={panelsShown} onChange={() => onTogglePanels()} label="Panel" />
             <ToggleSwitch checked={theme !== 'light'} onChange={onToggleTheme} label="Dark theme" />
@@ -362,6 +360,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
 
+  buttonItemShortcut: {
+    userSelect: 'none',
+    cursor: 'pointer',
+    marginLeft: 12
+  },
+
   buttonItemEditorPane: {
     margin: '0 12px',
   },
@@ -382,5 +386,10 @@ const styles = StyleSheet.create({
     [`@media (min-width: ${constants.preview.minWidth}px)`]: {
       display: 'block',
     },
+  },
+
+  menuSeparator: {
+    margin: '6px 0',
+    borderBottom: `1px solid ${c('border')}`,
   },
 });

--- a/website/src/client/components/EditorFooter.tsx
+++ b/website/src/client/components/EditorFooter.tsx
@@ -363,7 +363,7 @@ const styles = StyleSheet.create({
   buttonItemShortcut: {
     userSelect: 'none',
     cursor: 'pointer',
-    marginLeft: 12
+    marginLeft: 12,
   },
 
   buttonItemEditorPane: {

--- a/website/src/client/components/KeyboardShortcuts.tsx
+++ b/website/src/client/components/KeyboardShortcuts.tsx
@@ -40,9 +40,7 @@ class KeyboardShortcuts extends React.PureComponent {
           {Object.entries(Shortcuts).map(([type, binding]) => (
             <tr key={type}>
               <td className={css(styles.shortcutCell, styles.shortcutLabelCell)}>
-                <kbd className={css(styles.shortcutLabel)}>
-                  <ShortcutLabel combo={binding.combo} />
-                </kbd>
+                <ShortcutLabel combo={binding.combo} />
               </td>
               <td className={css(styles.shortcutCell, styles.shortcutDescriptionCell)}>
                 {binding.description}
@@ -69,19 +67,10 @@ const styles = StyleSheet.create({
 
   shortcutLabelCell: {
     textAlign: 'right',
+    marginRight: 8,
   },
 
   shortcutDescriptionCell: {
     textAlign: 'left',
-  },
-
-  shortcutLabel: {
-    color: 'inherit',
-    fontFamily: 'inherit',
-    fontSize: 'inherit',
-    backgroundColor: 'transparent',
-    boxShadow: 'none',
-    padding: 0,
-    display: 'inline-block',
   },
 });

--- a/website/src/client/components/KeyboardShortcuts.tsx
+++ b/website/src/client/components/KeyboardShortcuts.tsx
@@ -40,7 +40,7 @@ class KeyboardShortcuts extends React.PureComponent {
           {Object.entries(Shortcuts).map(([type, binding]) => (
             <tr key={type}>
               <td className={css(styles.shortcutCell, styles.shortcutLabelCell)}>
-                <ShortcutLabel combo={binding.combo} />
+                <ShortcutLabel boxed combo={binding.combo} />
               </td>
               <td className={css(styles.shortcutCell, styles.shortcutDescriptionCell)}>
                 {binding.description}

--- a/website/src/client/components/shared/ContextMenu.tsx
+++ b/website/src/client/components/shared/ContextMenu.tsx
@@ -72,9 +72,7 @@ class ContextMenu extends React.PureComponent<Props> {
                 onHide();
               }}>
               <div>{label}</div>
-              {combo ? (
-                <ShortcutLabel combo={combo} className={css(styles.hint)} />
-              ) : null}
+              {combo ? <ShortcutLabel combo={combo} className={css(styles.hint)} /> : null}
             </button>
           </li>
         ))}

--- a/website/src/client/components/shared/ContextMenu.tsx
+++ b/website/src/client/components/shared/ContextMenu.tsx
@@ -73,9 +73,7 @@ class ContextMenu extends React.PureComponent<Props> {
               }}>
               <div>{label}</div>
               {combo ? (
-                <kbd className={css(styles.hint)}>
-                  <ShortcutLabel combo={combo} />
-                </kbd>
+                <ShortcutLabel combo={combo} className={css(styles.hint)} />
               ) : null}
             </button>
           </li>
@@ -140,12 +138,7 @@ const styles = StyleSheet.create({
   },
 
   hint: {
-    color: 'inherit',
-    fontFamily: 'inherit',
-    fontSize: 'inherit',
-    backgroundColor: 'transparent',
-    boxShadow: 'none',
     marginLeft: 24,
-    opacity: 0.3,
+    lineHeight: '24px',
   },
 });

--- a/website/src/client/components/shared/ShortcutLabel.tsx
+++ b/website/src/client/components/shared/ShortcutLabel.tsx
@@ -1,9 +1,13 @@
+import { css, StyleSheet } from 'aphrodite';
+import classnames from 'classnames';
 import findKey from 'lodash/findKey';
+import * as React from 'react';
 
 import { KeyMap } from './KeybindingsManager';
 
 type Props = {
   combo: number[];
+  className?: string;
 };
 
 type KeyName = keyof typeof KeyMap;
@@ -21,18 +25,33 @@ const KeyLabels: Partial<{ [key in KeyName]: string }> = {
   Tilde: '`',
 };
 
-export default function ShortcutLabel({ combo }: Props): any {
-  return combo
-    .map((code) => {
-      const name = findKey(KeyMap, (c) => c === code);
+export default function ShortcutLabel({ combo, className }: Props): any {
+  return (
+    <kbd className={classnames(css(styles.shortcutLabel), className)}>
+      {combo
+        .map((code) => {
+          const name = findKey(KeyMap, (c) => c === code);
 
-      // @ts-ignore
-      if (name && KeyLabels[name]) {
-        // @ts-ignore
-        return KeyLabels[name];
-      } else {
-        return name;
-      }
-    })
-    .join(isMac ? '' : '+');
+          // @ts-ignore
+          if (name && KeyLabels[name]) {
+            // @ts-ignore
+            return KeyLabels[name];
+          } else {
+            return name;
+          }
+        })
+        .join(isMac ? '' : '+')}
+    </kbd>
+  );
 }
+
+const styles = StyleSheet.create({
+  shortcutLabel: {
+    color: 'inherit',
+    fontFamily: 'monospace',
+    fontSize: '80%',
+    opacity: 0.45,
+    boxShadow: `none`,
+    display: 'inline-block',
+  },
+});

--- a/website/src/client/components/shared/ShortcutLabel.tsx
+++ b/website/src/client/components/shared/ShortcutLabel.tsx
@@ -67,7 +67,6 @@ const styles = StyleSheet.create({
     border: `1px solid ${c(`border`)}`,
     borderBottomWidth: 2,
     borderRadius: 3,
-    fontSize: '85%',
     opacity: 0.66,
   },
 });

--- a/website/src/client/components/shared/ShortcutLabel.tsx
+++ b/website/src/client/components/shared/ShortcutLabel.tsx
@@ -3,11 +3,13 @@ import classnames from 'classnames';
 import findKey from 'lodash/findKey';
 import * as React from 'react';
 
+import { c } from '../ThemeProvider';
 import { KeyMap } from './KeybindingsManager';
 
 type Props = {
   combo: number[];
   className?: string;
+  boxed?: boolean;
 };
 
 type KeyName = keyof typeof KeyMap;
@@ -25,9 +27,14 @@ const KeyLabels: Partial<{ [key in KeyName]: string }> = {
   Tilde: '`',
 };
 
-export default function ShortcutLabel({ combo, className }: Props): any {
+export default function ShortcutLabel({ combo, className, boxed = false }: Props): any {
   return (
-    <kbd className={classnames(css(styles.shortcutLabel), className)}>
+    <kbd
+      className={classnames(
+        css(styles.shortcutLabel),
+        boxed && css(styles.boxedShortcut),
+        className
+      )}>
       {combo
         .map((code) => {
           const name = findKey(KeyMap, (c) => c === code);
@@ -48,10 +55,19 @@ export default function ShortcutLabel({ combo, className }: Props): any {
 const styles = StyleSheet.create({
   shortcutLabel: {
     color: 'inherit',
-    fontFamily: 'monospace',
-    fontSize: '80%',
-    opacity: 0.45,
+    fontFamily: 'var(--font-monospace)',
+    fontSize: '90%',
+    opacity: 0.5,
     boxShadow: `none`,
     display: 'inline-block',
+    lineHeight: 'initial',
+  },
+  boxedShortcut: {
+    padding: '0.2rem 0.4rem',
+    border: `1px solid ${c(`border`)}`,
+    borderBottomWidth: 2,
+    borderRadius: 3,
+    fontSize: '85%',
+    opacity: 0.66,
   },
 });

--- a/website/src/server/pages/Document.tsx
+++ b/website/src/server/pages/Document.tsx
@@ -71,7 +71,7 @@ export default function Document(props: Props) {
             __html: css`
               :root {
                 --font-normal: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-                --font-monospace: Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+                --font-monospace: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
               }
 
               html {

--- a/website/src/server/pages/Document.tsx
+++ b/website/src/server/pages/Document.tsx
@@ -71,7 +71,8 @@ export default function Document(props: Props) {
             __html: css`
               :root {
                 --font-normal: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-                --font-monospace: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+                --font-monospace: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New',
+                  monospace;
               }
 
               html {

--- a/website/src/server/pages/Document.tsx
+++ b/website/src/server/pages/Document.tsx
@@ -71,8 +71,7 @@ export default function Document(props: Props) {
             __html: css`
               :root {
                 --font-normal: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-                --font-monospace: 'Fira Code', 'Fira Mono', Monaco, Menlo, 'Ubuntu Mono', Consolas,
-                  source-code-pro, monospace;
+                --font-monospace: Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
               }
 
               html {


### PR DESCRIPTION
# Why

Currently, depending on the place, keyboard shortcuts could look a bit differently. Not all of them have the same color shade or were using same font-family. Also differentiating the appearance more between the label and shortcut could help some users better distinguish bot parts of item/menu.

Also I was thinking about, and testing, addition of "button frame" in two forms:
* regular keyboard button (border + small radius + double border/box-shad at the bottom)
* pill style button (border + 50% radius)

But I wasn't happy with any of this solutions. They have made the shortcuts eye-heavy and they draw too much of user attention, so I have completely opt-out adding any frame in this changeset (but the refactored code should make a bit easier future experiments).

# How

This PR aims to unify the appearance of all keyboard shortcuts across the Snack, aims to help improve HTML semantics by always wrapping shortcuts with `<kbd>` tag (hence `ShortcutLabel` refactor).

I have also tweaked a bit `EditorFooter` settings menu by removing the "Shortcuts" icon (it was a bit confusing in my opinion), adding separator and ensuring that whole "Shortcuts" item is clickable (like the items with the `Toggler` inside). 

Monospaced font have been used to differentiate even more shortcut from the menu/option label. The changes also applies to the Monaco editor context menu shortcuts.

# Test Plan

I have tested the changes on `localhost`.

### Demo

![shkts](https://user-images.githubusercontent.com/719641/108560259-c5282680-72fc-11eb-83ce-b792bd1db1bb.gif)


