### PR TITLE
dark mode: tweak hover color and add popup shadows

### DIFF
--- a/website/src/client/components/ThemeProvider.tsx
+++ b/website/src/client/components/ThemeProvider.tsx
@@ -76,7 +76,7 @@ const darkColors: Colors = {
   'soft-text': colors.black,
   background: darkGray[900],
   content: darkGray[800],
-  hover: darkGray[600],
+  hover: darkGray[700],
   disabled: darkGray[600],
   selected: colors.white,
   'selected-text': darkGray[800],
@@ -84,7 +84,7 @@ const darkColors: Colors = {
 };
 
 const darkShadows: Shadows = {
-  popover: 'none',
+  popover: shadows.popover,
   small: 'none',
 };
 


### PR DESCRIPTION
# Why

Currently the Dark Mode hover color is quite contrasting, in comparison to the hover color in Light Mode. This also contributes to the lower readability of few UI elements while active or hovered (for example `EditorFooter` sections):

<img width="404" alt="Screenshot 2021-02-20 183006" src="https://user-images.githubusercontent.com/719641/108603691-b9466e00-73a9-11eb-9492-3d226a950761.png">

<img width="401" alt="Screenshot 2021-02-20 182941" src="https://user-images.githubusercontent.com/719641/108603686-b21f6000-73a9-11eb-84da-ec3cc3c8f65c.png">

# How

In this PR I have changed the `hover` color value in `darkColors` to the shade a step darker, which improve a bit the readability and makes closer match to the Light Theme hover effect.

<img width="407" alt="Screenshot 2021-02-20 183342" src="https://user-images.githubusercontent.com/719641/108603790-4b4e7680-73aa-11eb-876a-04c827cf79cf.png">

Additionally I have added the `popup` shadow back in the Dark Mode. Since shadows are based on pure black color (`0 2px 6px rgba(0,0,0,0.15)`) I see no backdrafts from turning them back on. The current value isn't ideal (shadows are not that prominent as in Light Mode), but they helps a bit distinguish UI elements in certain situations, few examples:

<img width="305" alt="Screenshot 2021-02-20 184209" src="https://user-images.githubusercontent.com/719641/108604020-a59c0700-73ab-11eb-9a7f-23276a9b7ba2.png">

<img width="179" alt="Screenshot 2021-02-20 192717" src="https://user-images.githubusercontent.com/719641/108605026-b0f23100-73b1-11eb-9240-a9a242bc0c0c.png">

Maybe in Dark Mode popups should use `small` shadow, which is a bit more prominent (`0 5px 10px rgba(0,0,0,0.12)`), but it might be semantic not correct with goals behind `@expo/styleguide` package.

# Test Plan

I have tested the changes on the `localhost`.
