### PR TITLE
"Edit details" popup button style tweaks

### DIFF
--- a/website/src/client/components/EditorTitleName.tsx
+++ b/website/src/client/components/EditorTitleName.tsx
@@ -249,10 +249,14 @@ const styles = StyleSheet.create({
     width: '100%',
     background: 'none',
     outline: 0,
-    borderWidth: '1px 0 0 0',
-    borderColor: c('border'),
-    color: c('selected'),
+    border: 'none',
+    borderTop: `1px solid ${c('border')}`,
+    color: c('primary'),
     padding: '8px 16px',
     fontWeight: 'bold',
+
+    ':hover': {
+      backgroundColor: c('hover'),
+    },
   },
 });


### PR DESCRIPTION
# Why

Currently the "Edit details" button in the details popup it's hard to distinguish from  the regular text in Dark Mode. Additionally, despite being a clickable element, it doesn't contains the `hover` style. There is also a small issue in the `:active` state, where top border becomes `black` (at least on Windows Chrome).

# How

This PR tweaks a bit the appearance of "Edit details" button - switches the text color to `primary` (which affects only Dark Mode), add basic `hoover` color and rewrites the border style which seems to be the culprit for the border issue.

P.S. The `hover` effect readability in Dark Mode should improve after #93 merge.

# Test Plan

I have tested the changes on `localhost`.

# Preview
![et](https://user-images.githubusercontent.com/719641/108604842-9ec3c300-73b0-11eb-8193-16f1dd277af6.gif)
