### PR TITLE
QRCode: remove ability to select screen reader only URL

### DIFF
--- a/website/src/client/components/QRCode.tsx
+++ b/website/src/client/components/QRCode.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'aphrodite';
+import { StyleSheet, css } from 'aphrodite';
 import * as React from 'react';
 
 type Props = {
@@ -13,7 +13,7 @@ const QRCode = ({ experienceURL, size, className }: Props) => {
   return (
     <div className={className}>
       <ReactQRCode value={experienceURL} size={size ?? 200} />
-      <div style={styles.screenReaderUrl}>{experienceURL}</div>
+      <div className={css(styles.screenReaderUrl)}>{experienceURL}</div>
     </div>
   );
 };

--- a/website/src/client/components/QRCode.tsx
+++ b/website/src/client/components/QRCode.tsx
@@ -1,3 +1,4 @@
+import { StyleSheet } from 'aphrodite';
 import * as React from 'react';
 
 type Props = {
@@ -12,10 +13,17 @@ const QRCode = ({ experienceURL, size, className }: Props) => {
   return (
     <div className={className}>
       <ReactQRCode value={experienceURL} size={size ?? 200} />
-      {/* for screen readers */}
-      <div style={{ fontSize: 6, color: 'transparent' }}>{experienceURL}</div>
+      <div style={styles.screenReaderUrl}>{experienceURL}</div>
     </div>
   );
 };
+
+const styles = StyleSheet.create({
+  screenReaderUrl: {
+    fontSize: 6,
+    color: 'transparent',
+    userSelect: 'none',
+  },
+});
 
 export default QRCode;


### PR DESCRIPTION
# Why

Currently it's possible to use selection to make visible the Screen Reader only URL which is a part of `QRCode` component.

<img width="258" alt="bug" src="https://user-images.githubusercontent.com/719641/108627130-4c3be280-7454-11eb-9612-341155835b6f.png">

# How

This PR includes small CSS fix (utilizing `user-select`) which fixes the issue, additionally I have extracted the existing inline styles from the component and replaced comment just by setting self-explanatory name to the style variable name.

# Test Plan

I have tested the changes on `localhost` using existing `dev` pipeline.