### PR TITLE
[ci] Add website workflow for external PRs

### DIFF
--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -15,7 +15,6 @@ on:
       - .prettier*
       - yarn.lock
   pull_request:
-    branches: [main]
     paths:
       - .github/workflows/website-staging.yml
       - website/**

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,7 +15,6 @@ on:
       - .prettier*
       - yarn.lock
   pull_request:
-    branches: [main]
     paths:
       - .github/workflows/website.yml
       - website/**

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,55 @@
+name: Website
+
+defaults:
+  run:
+    working-directory: website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/website.yml
+      - website/**
+      - packages/snack-sdk/**
+      - .eslint*
+      - .prettier*
+      - yarn.lock
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/website.yml
+      - website/**
+      - packages/snack-sdk/**
+      - .eslint*
+      - .prettier*
+      - yarn.lock
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn test --maxWorkers 1
+      - run: yarn lint --max-warnings 0
+      - run: yarn build

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,6 +50,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn tsc --noEmit
       - run: yarn test --maxWorkers 1
       - run: yarn lint --max-warnings 0
       - run: yarn build

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -53,4 +53,4 @@ jobs:
       - run: yarn tsc --noEmit
       - run: yarn test --maxWorkers 1
       - run: yarn lint --max-warnings 0
-      - run: yarn build
+      - run: ../node_modules/.bin/env-cmd -f deploy/development/snack.env yarn build

--- a/website/deploy/production/snack.env
+++ b/website/deploy/production/snack.env
@@ -1,4 +1,5 @@
 SERVER_URL=https://expo.io
+API_SERVER_URL=https://expo.io
 SENTRY_ENVIRONMENT=staging
 SNACK_SERVER_URL=https://snack.expo.io
 IMPORT_SERVER_URL=https://snackager.expo.io

--- a/website/deploy/staging/snack.env
+++ b/website/deploy/staging/snack.env
@@ -1,4 +1,5 @@
 SERVER_URL=https://staging.expo.io
+API_SERVER_URL=https://staging.exp.host
 SENTRY_ENVIRONMENT=staging
 SNACK_SERVER_URL=https://staging.snack.expo.io
 IMPORT_SERVER_URL=https://staging.snackager.expo.io


### PR DESCRIPTION
# Why

Adds a GitHub action workflow for the `website` which runs the build, tests and linter without the need of any secrets. This is intended for PRs that are created from external forks and don't have access to the secrets.

