### PR TITLE
[tools] Terminal updates & cleaner logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "node": "12.16.2"
   },
   "scripts": {
-    "start": "yarn domain && yarn term",
-    "term": "cd packages/snack-term && yarn start && cd ..",
-    "domain": "chalet start && chalet add http://localhost:3011 -n snack.expo -f && chalet add http://localhost:3021 -n expo -f"
+    "start": "cd packages/snack-term && yarn start && cd .."
   },
   "workspaces": [
     "packages/snack-sdk",

--- a/packages/snack-proxies/package.json
+++ b/packages/snack-proxies/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "yarn domain && yarn watch",
     "domain": "chalet start && chalet add http://localhost:3021 -n expo -f",
-    "watch": "ts-node-dev --inspect=9221 src/index.ts",
+    "watch": "tsnd --inspect=9221 --quiet src/index.ts",
     "lint": "eslint ./src"
   },
   "volta": {

--- a/packages/snack-term/package.json
+++ b/packages/snack-term/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "@expo/spawn-async": "^1.5.0",
     "ink": "^3.0.8",
-    "react": "^17.0.1",
-    "strip-ansi": "^6.0.0"
+    "react": "^17.0.1"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7"

--- a/website/deploy/development/snack.env
+++ b/website/deploy/development/snack.env
@@ -1,7 +1,7 @@
 SERVER_URL=http://expo.test
 API_SERVER_URL=http://localhost:3020
 DEPLOY_ENVIRONMENT=staging
-IMPORT_SERVER_URL=https://staging.snackager.expo.io
+IMPORT_SERVER_URL=http://localhost:3022
 SENTRY_ENVIRONMENT=dev
 SNACK_SEGMENT_KEY=
 SNACK_AMPLITUDE_KEY=

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "yarn domain && yarn watch",
     "domain": "chalet start && chalet add http://localhost:3011 -n snack.expo -f",
-    "watch": "env-cmd -f deploy/development/snack.env ts-node-dev --require tsconfig-paths/register --inspect=9211 src/server/index.tsx",
+    "watch": "env-cmd -f deploy/development/snack.env tsnd --require tsconfig-paths/register --inspect=9211 --quiet src/server/index.tsx",
     "build": "env-cmd -e production yarn build:server && yarn build:client",
     "build:server": "babel --source-maps --extensions '.ts,.tsx' --out-dir build/ src/",
     "build:client": "webpack",


### PR DESCRIPTION
# Why

Improves `snack-term` to handle stderr and failed process startups. Also removes `strip-ansi` which was not used. Additionally this PR makes various yarn scripts consistents and cleans up no longer needed commands.
