### PR TITLE
[proxy] Add Snackager proxy

### DIFF
--- a/docs/hosts-ports.md
+++ b/docs/hosts-ports.md
@@ -9,6 +9,7 @@ The following hosts and ports are used by Snack.
 | localhost:3001 | staging.expo.io | expo.io | The Expo website. |
 | localhost:3020 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo API server. Located in `./packages/snack-proxies`. |
 | localhost:3021 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo website. Located in `./packages/snack-proxies`. |
+| localhost:3022 | - | - | Proxy server that forwards and logs all requests to the local or staging Snackager service. Located in `./packages/snack-proxies`. |
 
 <!-- | localhost:3023 | - | - | Proxy server that forwards and logs requests for the web-player. Located in `./packages/snack-proxies`. |
 | localhost:3024 | - | - | Proxy server that forwards and logs requests for the web-player CDN. Located in `./packages/snack-proxies`. | -->

--- a/packages/snack-proxies/src/index.ts
+++ b/packages/snack-proxies/src/index.ts
@@ -15,6 +15,12 @@ Promise.all([
     localURL: 'http://localhost:3001',
     stagingURL: 'https://staging.expo.io',
   }),
+  createProxy({
+    name: 'snackager',
+    port: 3022,
+    localURL: 'http://localhost:3012',
+    stagingURL: 'https://staging.snackager.expo.io',
+  }),
   /* createProxy({
     name: 'webplayer',
     port: 3023,

--- a/website/README.md
+++ b/website/README.md
@@ -37,7 +37,7 @@ yarn start
 
 ### Snackager (package bundler)
 
-Start the `snackager` server and append `local_snackager=true` to the query arguments of the URL.
+Start the `snackager` server. `snack-proxies` automatically detects the locally running Snackager server and routes all trafic to it when possible.
 
 ```sh
 # expo/universe
@@ -45,8 +45,6 @@ cd server/snackager
 yarn
 yarn start
 ```
-
-And open http://snack.expo.test?local_snackager=true
 
 ### Snack web-player
 

--- a/website/deploy/development/snack.env
+++ b/website/deploy/development/snack.env
@@ -1,7 +1,7 @@
 SERVER_URL=http://expo.test
 API_SERVER_URL=http://localhost:3020
 DEPLOY_ENVIRONMENT=staging
-IMPORT_SERVER_URL=https://staging.snackager.expo.io
+IMPORT_SERVER_URL=http://localhost:3022
 SENTRY_ENVIRONMENT=dev
 SNACK_SEGMENT_KEY=
 SNACK_AMPLITUDE_KEY=

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -190,10 +190,7 @@ class Main extends React.Component<Props, State> {
     const isWorker = true;
     const sendCodeOnChangeEnabled = true;
     const sessionSecret = props.getSessionSecret();
-    const snackagerURL =
-      props.query.local_snackager === 'true'
-        ? 'http://localhost:3001'
-        : nullthrows(process.env.IMPORT_SERVER_URL);
+    const snackagerURL = nullthrows(process.env.IMPORT_SERVER_URL);
 
     this._snack = new Snack({
       disabled: true,

--- a/website/src/client/types.tsx
+++ b/website/src/client/types.tsx
@@ -105,7 +105,6 @@ export type QueryStateParams = {
   preview?: 'true' | 'false';
   platform?: Platform;
   theme?: ThemeName;
-  local_snackager?: 'true' | 'false';
   supportedPlatforms?: string;
   appetizePayerCode?: string;
   verbose?: 'true' | 'false';

--- a/website/src/client/utils/reloadURL.tsx
+++ b/website/src/client/utils/reloadURL.tsx
@@ -25,7 +25,6 @@ function pickQueryStateParams(queryParams: QueryParams) {
       case 'platform':
       case 'theme':
       case 'supportedPlatforms':
-      case 'local_snackager':
       case 'appetizePayerCode':
       case 'verbose':
       case 'hideQueryParams':


### PR DESCRIPTION
# Why

Adds a proxy for Snackager. The proxy allows for seeing the requests sent to Snackager and automatically switches to the local running Snackager when possible. This removes the need for the `local_snackager` query argument in the `website`.

# How

- Add Snackager proxy
- Update docs
- Remove `local_snackager` query arg for website

```
│ $ ts-node-dev --inspect=9221 src/index.ts                                                                                                                                                                                   │
│ [INFO] 15:48:37 ts-node-dev ver. 1.1.1 (using ts-node ver. 9.1.1, typescript ver. 4.1.3)                                                                                                                                    │
│ Starting "expo-www" proxy on port 3020...                                                                                                                                                                                   │
│ Starting "expo-website" proxy on port 3021...                                                                                                                                                                               │
│ Starting "snackager" proxy on port 3022...                                                                                                                                                                                  │
│ Listening for "expo-www" connections on port 3020, proxying to -> https://staging.exp.host                                                                                                                                  │
│ Listening for "expo-website" connections on port 3021, proxying to -> https://staging.expo.io                                                                                                                               │
│ Listening for "snackager" connections on port 3022, proxying to -> https://staging.snackager.expo.io                                                                                                                        │
│ All proxies started
```