### PR TITLE
fix line endings issues on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
# Why

Currently, on the Windows, IDEs and ESLint want to reformat EOL characters across all the repository files. This is due to OS differences in handling files.

<img width="698" alt="Screenshot 2021-02-24 185908" src="https://user-images.githubusercontent.com/719641/109044182-63880380-76d2-11eb-86bb-053da7e95c10.png">

# How

To fix this I have setup:
* `.gitattributes` file with basic configuration according to - https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings#per-repository-settings
* `.editorconfig` file, unfortunately it was also required, `.gitattributes` was not enough to get rid of the warnings - RN uses the same approach in theirs repository - https://github.com/facebook/react-native/blob/master/.editorconfig . You can read amore about `.editorconfig`  on the official website - https://editorconfig.org/.

To ensure backward compatibility and to remove the need to reformat all the repository files I have stick to `LF` EOL which is a default for macOS and other Unix systems. This should not cause any problem on Win machines. 

# Test Plan

Tested locally on my Windows machine.

### Preview after changes

<img width="701" alt="Screenshot 2021-02-24 185816" src="https://user-images.githubusercontent.com/719641/109044206-6aaf1180-76d2-11eb-85cc-a262614a4b37.png">

