### PR TITLE
improve OS tabs appearance in Dark Mode, improve EmbeddedFooter

### DIFF
--- a/website/src/client/components/Shell/EmbeddedFooterShell.tsx
+++ b/website/src/client/components/Shell/EmbeddedFooterShell.tsx
@@ -25,7 +25,6 @@ const styles = StyleSheet.create({
     transition: 'background .2s',
     padding: '0 4px',
     fontSize: 12,
-    height: 26,
   },
 
   footerLoading: {

--- a/website/src/client/components/shared/ToggleButtons.tsx
+++ b/website/src/client/components/shared/ToggleButtons.tsx
@@ -88,11 +88,11 @@ const styles = StyleSheet.create({
   },
 
   active: {
-    backgroundColor: c('selected'),
-    borderColor: c('selected'),
-    color: c('selected-text'),
+    backgroundColor: c('primary'),
+    borderColor: c('primary'),
+    color: c('text'),
     ':hover': {
-      backgroundColor: c('selected'),
+      backgroundColor: c('primary'),
     },
   },
 

--- a/website/src/client/components/shared/ToggleButtons.tsx
+++ b/website/src/client/components/shared/ToggleButtons.tsx
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
   active: {
     backgroundColor: c('primary'),
     borderColor: c('primary'),
-    color: c('text'),
+    color: c('primary-text'),
     ':hover': {
       backgroundColor: c('primary'),
     },


### PR DESCRIPTION
# Why

Currently (like for switch) the OS tabs are using `selected` color, so in Dark mode it becomes white (in comparison to the purple in the Light Mode).

<img width="272" alt="Screenshot 2021-03-02 182937" src="https://user-images.githubusercontent.com/719641/109689104-42695c00-7b85-11eb-80fa-7539d4059eae.png">

Also the OS tabs in the Embedded Snack are affected. Not only the color is not that readable, but the tabs are also clipped at the bottom (especially visible in the Dark Mode).

<img width="304" alt="Screenshot 2021-03-02 182912" src="https://user-images.githubusercontent.com/719641/109689128-49906a00-7b85-11eb-8036-e85b14acce99.png">

# How

This small PR changes the tabs background and border colors to `primary` which make the purple in the Dark Mode too.

<img width="257" alt="Screenshot 2021-03-02 181941" src="https://user-images.githubusercontent.com/719641/109688894-13eb8100-7b85-11eb-8d4a-314601023ba4.png">

Additionally I have fixed the clipping issues by removing the hardcoded height of `EmbeddedFooter`. This change results in even (`4px`) padding from all the sides, which improves the overall appearance and fixes the clipping.

<img width="323" alt="Screenshot 2021-03-02 182153" src="https://user-images.githubusercontent.com/719641/109688910-16e67180-7b85-11eb-83db-79794d1d857a.png">

# Test Plan

Snack run on the `localhost`.

