### PR TITLE
[ci] Fix prune-gcr for Snackager CI actions 53f0682

### DIFF
--- a/.github/workflows/snackager-production.yml
+++ b/.github/workflows/snackager-production.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Use Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
       - name: Decrypt secrets
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
@@ -72,7 +77,9 @@ jobs:
         working-directory: ./
 
       - name: Prune docker images
-        run: prune-gcr snackager
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ./bin/prune-gcr snackager
+        working-directory: ./
 
       - name: Notify build on Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/snackager-staging.yml
+++ b/.github/workflows/snackager-staging.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Use Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
       - name: Decrypt secrets
         uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
         env:
@@ -69,6 +74,10 @@ jobs:
 
       - name: Build
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
+        working-directory: ./
+
+      - name: Prune docker images
+        run: ./bin/prune-gcr snackager --dry-run
         working-directory: ./
 
       - name: Add change cause


### PR DESCRIPTION
# Why

Fixes `prune-gcr` for the Snackager production github action.

# How

- Install python 2.7
- Execute `prune-gcr` from correct working directory
- Add `gcr-prune` dry-runs for staging and PRs

# Test Plan

- Staging and production CI actions run successfully