### PR TITLE
[website] Show downgraded message when newer Expo SDK is requested

### DIFF
--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -928,7 +928,9 @@ class Main extends React.Component<Props, State> {
               uploadFileAsync={this._uploadAssetAsync}
               userAgent={this.props.userAgent}
               verbose={this.state.verbose}
-              wasUpgraded={this.state.wasUpgraded}
+              upgradedFromSDKVersion={
+                this.state.wasUpgraded ? this.state.initialSdkVersion : undefined
+              }
             />
           ) : isEmbedded ? (
             <EmbeddedShell />

--- a/website/src/client/components/EditorViewProps.tsx
+++ b/website/src/client/components/EditorViewProps.tsx
@@ -55,7 +55,7 @@ export type EditorViewProps = {
   uploadFileAsync: (file: File) => Promise<string>;
   setDeviceId: (deviceId: string) => void;
   deviceId: string | undefined;
-  wasUpgraded: boolean;
+  upgradedFromSDKVersion?: string;
   autosaveEnabled: boolean;
   payerCode: string | undefined;
   userAgent: string;


### PR DESCRIPTION
# Why

Shows a downgraded message when requesting an Expo SDK version that is not yet supported (eg. 41)

![image](https://user-images.githubusercontent.com/6184593/114881022-e9871780-9e02-11eb-84bc-c2534024dc00.png)

# How

- Add downgraded message
- Cleanup banner code a bit

# Test Plan

- Verified locally
- All tests pass