### PR TITLE
[website] Fix logs panel text wrapping

### DIFF
--- a/website/src/client/components/EditorPanelLogs.tsx
+++ b/website/src/client/components/EditorPanelLogs.tsx
@@ -94,6 +94,7 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'row',
     flexWrap: 'wrap',
+    whiteSpace: 'pre',
   },
   item: {
     marginRight: 8,

--- a/website/src/client/components/shared/CollapsibleObject.tsx
+++ b/website/src/client/components/shared/CollapsibleObject.tsx
@@ -108,8 +108,7 @@ const styles = StyleSheet.create({
     margin: '0 4px',
     verticalAlign: 1,
     wordBreak: 'break-word',
-    //@ts-ignore
-    whiteSpace: 'break-spaces',
+    whiteSpace: 'normal',
   },
   triangle: {
     display: 'inline-block',

--- a/website/src/client/components/shared/CollapsibleObject.tsx
+++ b/website/src/client/components/shared/CollapsibleObject.tsx
@@ -107,6 +107,9 @@ const styles = StyleSheet.create({
   preview: {
     margin: '0 4px',
     verticalAlign: 1,
+    wordBreak: 'break-word',
+    //@ts-ignore
+    whiteSpace: 'break-spaces',
   },
   triangle: {
     display: 'inline-block',


### PR DESCRIPTION
# Why

Currently logging long value, like arrays or objects keys results in vertical scroll in the Logs panel and shifted a bit content.

### Before

<img width="995" alt="Screenshot 2021-04-19 133749" src="https://user-images.githubusercontent.com/719641/115231018-5f49f680-a115-11eb-98ca-e085578e52dc.png">

# How

This PR fixes the issues by adding few CSS lines. 

~Unfortunately `aphrodite` [package types](https://github.com/Khan/aphrodite/blob/master/typings/css-properties.d.ts#L1740) do not list `whiteSpace: 'break-spaces` option so I had to add the line ignore. `break-spaces` is not that new property and it's [widely supported](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space), but the `aphrodite` seems to be no longer maintained - types definitions are 3+ years old.~

After testing a bit, it looks like that `whiteSpace: 'normal'` yield the same layout result as `'break-spaces'`, so I have switched the values to avoid TS ignore comment. 🙂 

### After

<img width="992" alt="Screenshot 2021-04-19 133643" src="https://user-images.githubusercontent.com/719641/115231491-e8612d80-a115-11eb-95a6-c5bfdee994e1.png">

# Test Plan

Running Snack website on `localhost`.