### PR TITLE
[snack-sdk] Release Expo SDK 41

### DIFF
--- a/packages/snack-sdk/src/__fixtures__/snackager.ts
+++ b/packages/snack-sdk/src/__fixtures__/snackager.ts
@@ -39,6 +39,10 @@ const config: SnackagerConfig = {
       version: '8.2.1',
       peerDependencies,
     },
+    'expo-av@~8.6.0': {
+      version: '8.6.0',
+      peerDependencies,
+    },
     '@react-navigation/native@5.1.1': {
       peerDependencies,
     },

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -137,8 +137,8 @@ Object {
 exports[`dependencies resolves * after enabling 1`] = `
 Object {
   "expo-constants": Object {
-    "version": "~9.0.0",
-    "wantedVersion": "~9.0.0",
+    "version": "~9.1.1",
+    "wantedVersion": "~9.1.1",
   },
 }
 `;
@@ -146,8 +146,8 @@ Object {
 exports[`dependencies resolves * to wanted version 1`] = `
 Object {
   "expo-constants": Object {
-    "version": "~9.0.0",
-    "wantedVersion": "~9.0.0",
+    "version": "~9.1.1",
+    "wantedVersion": "~9.1.1",
   },
 }
 `;
@@ -200,23 +200,12 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~1.8.0",
+    "wantedVersion": "~1.10.2",
   },
 }
 `;
 
 exports[`dependencies updates preloaded module version when changing SDK version 1`] = `
-Object {
-  "expo-av": Object {
-    "handle": "snackager-1/expo-av@8.1.0",
-    "peerDependencies": Object {},
-    "version": "~8.1.0",
-    "wantedVersion": "~8.1.0",
-  },
-}
-`;
-
-exports[`dependencies updates preloaded module version when changing SDK version 2`] = `
 Object {
   "expo-av": Object {
     "handle": "snackager-1/expo-av@8.2.1",
@@ -226,6 +215,20 @@ Object {
     },
     "version": "~8.2.1",
     "wantedVersion": "~8.2.1",
+  },
+}
+`;
+
+exports[`dependencies updates preloaded module version when changing SDK version 2`] = `
+Object {
+  "expo-av": Object {
+    "error": [Error: Failed to resolve dependency 'expo-av@~8.6.0' (Package 'expo-av@~8.6.0' not found in the registry)],
+    "peerDependencies": Object {
+      "react": "*",
+      "react-native": "*",
+    },
+    "version": "~8.6.0",
+    "wantedVersion": "~8.6.0",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -222,7 +222,7 @@ Object {
 exports[`dependencies updates preloaded module version when changing SDK version 2`] = `
 Object {
   "expo-av": Object {
-    "error": [Error: Failed to resolve dependency 'expo-av@~8.6.0' (Package 'expo-av@~8.6.0' not found in the registry)],
+    "handle": "snackager-1/expo-av@8.6.0",
     "peerDependencies": Object {
       "react": "*",
       "react-native": "*",

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://expo.io/@snack/sdk.37.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://expo.io/@snack/sdk.38.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/packages/snack-sdk/src/__tests__/dependencies-test.ts
+++ b/packages/snack-sdk/src/__tests__/dependencies-test.ts
@@ -196,7 +196,7 @@ describe('dependencies', () => {
 
   it('resolves * to wanted version', async () => {
     const snack = new Snack({
-      sdkVersion: '37.0.0',
+      sdkVersion: '38.0.0',
     });
     snack.updateDependencies({
       'expo-constants': { version: '*' },
@@ -207,7 +207,7 @@ describe('dependencies', () => {
 
   it('does not resolve * when disabled', async () => {
     const snack = new Snack({
-      sdkVersion: '37.0.0',
+      sdkVersion: '38.0.0',
       disabled: true,
     });
     snack.updateDependencies({
@@ -219,7 +219,7 @@ describe('dependencies', () => {
 
   it('resolves * after enabling', async () => {
     const snack = new Snack({
-      sdkVersion: '37.0.0',
+      sdkVersion: '38.0.0',
       disabled: true,
     });
     snack.updateDependencies({
@@ -233,12 +233,12 @@ describe('dependencies', () => {
 
   it('updates preloaded module version when changing SDK version', async () => {
     const snack = new Snack({
-      sdkVersion: '37.0.0',
+      sdkVersion: '38.0.0',
       dependencies: { 'expo-av': { version: '*' } },
     });
     const state1 = await snack.getStateAsync();
     expect(state1.dependencies).toMatchSnapshot();
-    snack.setSDKVersion('38.0.0');
+    snack.setSDKVersion('39.0.0');
     const state2 = await snack.getStateAsync();
     expect(state2.dependencies).toMatchSnapshot();
     expect(state1).not.toMatchObject(state2);

--- a/packages/snack-sdk/src/__tests__/devsession-test.ts
+++ b/packages/snack-sdk/src/__tests__/devsession-test.ts
@@ -51,7 +51,7 @@ describe('devsession', () => {
       apiURL: 'https://exp.host',
       host: 'expo.io',
       channel: '10spnBnPxi',
-      sdkVersion: '37.0.0',
+      sdkVersion: '38.0.0',
     });
     expect(snack.getState().sendBeaconCloseRequest).toBeUndefined();
     expect(fetch).not.toBeCalled();

--- a/packages/snack-sdk/src/__tests__/sdkversion-test.ts
+++ b/packages/snack-sdk/src/__tests__/sdkversion-test.ts
@@ -79,36 +79,36 @@ describe('getSupportedSDKVersions', () => {
 
 describe('isModulePreloaded', () => {
   it('returns true for internal modules', () => {
-    expect(isModulePreloaded('react-native', '37.0.0')).toBe(true);
+    expect(isModulePreloaded('react-native', '38.0.0')).toBe(true);
   });
 
   it('returns true for bundled modules', () => {
-    expect(isModulePreloaded('expo-asset', '37.0.0')).toBe(true);
+    expect(isModulePreloaded('expo-asset', '38.0.0')).toBe(true);
   });
 
   it('returns false when internalOnly is true', () => {
-    expect(isModulePreloaded('expo-asset', '37.0.0', true)).toBe(false);
+    expect(isModulePreloaded('expo-asset', '38.0.0', true)).toBe(false);
   });
 
   it('returns false for unknown modules', () => {
-    expect(isModulePreloaded('firestorter', '37.0.0')).toBe(false);
+    expect(isModulePreloaded('firestorter', '38.0.0')).toBe(false);
   });
 });
 
 describe('getPreloadedModules', () => {
   it('returns valid modules', () => {
-    const result = getPreloadedModules('37.0.0');
+    const result = getPreloadedModules('38.0.0');
     expect(Object.keys(result).length).toBeGreaterThan(10);
     Object.values(result).map((version) => expect(isValidSemver(version)).toBe(true));
   });
   it('returns different results for other SDK', () => {
-    const result = getPreloadedModules('37.0.0');
-    const result2 = getPreloadedModules('38.0.0');
+    const result = getPreloadedModules('38.0.0');
+    const result2 = getPreloadedModules('39.0.0');
     expect(result).not.toMatchObject(result2);
   });
   it('returns subset for internal modules', () => {
-    const result = getPreloadedModules('37.0.0');
-    const internal = getPreloadedModules('37.0.0', true);
+    const result = getPreloadedModules('38.0.0');
+    const internal = getPreloadedModules('38.0.0', true);
     expect(Object.keys(internal).length).toBeLessThan(Object.keys(result).length);
     expect(result).toMatchObject(internal);
   });
@@ -139,7 +139,7 @@ describe('isFeatureSupported', () => {
   it('throws for invalid feature', () => {
     expect(() =>
       // @ts-ignore Type '"Bogus"' is not assignable to type 'SDKFeature'
-      isFeatureSupported('Bogus', '37.0.0')
+      isFeatureSupported('Bogus', '38.0.0')
     ).toThrowError();
   });
   it('throws for invalid version', () => {

--- a/packages/snack-sdk/src/__tests__/url-test.ts
+++ b/packages/snack-sdk/src/__tests__/url-test.ts
@@ -41,8 +41,8 @@ describe('url', () => {
 
   it('updates url when changing sdk-version', async () => {
     const snack = new Snack(config);
-    snack.setSDKVersion('37.0.0');
-    expect(snack.getState().url).toBe(`exp://${host}/@snack/sdk.37.0.0-${channel}`);
+    snack.setSDKVersion('38.0.0');
+    expect(snack.getState().url).toBe(`exp://${host}/@snack/sdk.38.0.0-${channel}`);
   });
 
   it('reverts to unnamed url after changing sdk-version', async () => {
@@ -50,7 +50,7 @@ describe('url', () => {
       ...config,
       id,
     });
-    snack.setSDKVersion('37.0.0');
-    expect(snack.getState().url).toBe(`exp://${host}/@snack/sdk.37.0.0-${channel}`);
+    snack.setSDKVersion('38.0.0');
+    expect(snack.getState().url).toBe(`exp://${host}/@snack/sdk.38.0.0-${channel}`);
   });
 });

--- a/packages/snack-sdk/src/defaultConfig.ts
+++ b/packages/snack-sdk/src/defaultConfig.ts
@@ -6,7 +6,7 @@ export const host: string = 'expo.io';
 export const webPlayerURL: string =
   'https://snack-web-player.s3.us-west-1.amazonaws.com/v2/%%SDK_VERSION%%';
 
-export const sdkVersion: SDKVersion = '40.0.0';
+export const sdkVersion: SDKVersion = '41.0.0';
 
 export const SnackIdentityState: SnackState = {
   sdkVersion,

--- a/packages/snack-sdk/src/sdks/index.ts
+++ b/packages/snack-sdk/src/sdks/index.ts
@@ -22,32 +22,6 @@ const unimodules: { [name: string]: '*' } = {
 };
 
 const sdks: { [version: string]: SDKSpec } = {
-  '37.0.0': {
-    version: '^37.0.0',
-    coreModules: {
-      ...assets,
-      ...unimodules,
-      expo: '37.0.12',
-      react: '16.9.0',
-      'react-native': '0.61.4',
-      'react-dom': '*',
-      'react-native-web': '*',
-    },
-    bundledModules: {
-      '@expo/vector-icons': '*',
-      'expo-asset': '*',
-      'expo-barcode-scanner': '*',
-      'expo-camera': '*',
-      'expo-constants': '*',
-      'expo-file-system': '*',
-      'expo-font': '*',
-      'expo-gl': '*',
-      'expo-image-picker': '*',
-      'expo-linear-gradient': '*',
-      'prop-types': '*',
-      'react-native-gesture-handler': '*',
-    },
-  },
   '38.0.0': {
     version: '^38.0.0',
     coreModules: {

--- a/packages/snack-sdk/src/sdks/types.ts
+++ b/packages/snack-sdk/src/sdks/types.ts
@@ -1,7 +1,7 @@
 /**
- * Version of the sdk to use (e.g. "37.0.0").
+ * Version of the sdk to use (e.g. "38.0.0").
  */
-export type SDKVersion = '37.0.0' | '38.0.0' | '39.0.0' | '40.0.0' | '41.0.0';
+export type SDKVersion = '38.0.0' | '39.0.0' | '40.0.0' | '41.0.0';
 
 /** @internal */
 export type SDKSpec = {


### PR DESCRIPTION
# Why

This is a stacked PR on top of #123, but for the `snack-sdk` instead. 

# How

- Dropped support for SDK 37
- Switched to SDK 41 by default
- Updated all tests and snapshots to include 38 or higher

# Test Plan

- `$ yarn test`
- Make sure staging is working as expected using the test plan from #121
