### PR TITLE
[website] set default SDK to v41

### DIFF
--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -10,5 +10,5 @@ export const versions: { [version: string]: boolean } = {
   '41.0.0': true,
 };
 
-export const DEFAULT_SDK_VERSION = '40.0.0';
+export const DEFAULT_SDK_VERSION = '41.0.0';
 export const TEST_SDK_VERSION = '38.0.0';


### PR DESCRIPTION
Refs #123

# Why

SDK v41 has been added to Snack, but v40 is still set as a default version on Snack load.

# How

This PR updates the `DEFAULT_SDK_VERSION` to v41, which is responsible for default the selected version on the website.

# Test Plan

Change has been tested by running Snack website on `localhost`

# Preview

<img width="440" alt="Screenshot 2021-04-20 134138" src="https://user-images.githubusercontent.com/719641/115390178-3fcad080-a1de-11eb-969f-c2300e37b62c.png">

CC @byCedric 
