### PR TITLE
[snackager] Add Yarn platform ignore flags in CI

### DIFF
--- a/snackager/src/__integration-tests__/bundleAsync.ts
+++ b/snackager/src/__integration-tests__/bundleAsync.ts
@@ -61,7 +61,12 @@ export default async function bundleAsync(
   testedPackages.push(packageSpec);
   const cacheHit = await restoreLockfile(packageSpec, packagedir);
   if (cacheHit) {
-    await installPackage(packagedir, ['--frozen-lockfile']);
+    await installPackage(packagedir, [
+      // CI is running Linux, while we develop on MacOS/Windows.
+      // Don't quit when there is a platform mismatch
+      '--ignore-platform',
+      '--frozen-lockfile',
+    ]);
   } else {
     await installPackage(packagedir);
     await saveLockfile(packageSpec, packagedir);


### PR DESCRIPTION
# Why

With the shim addition from PR #126, I noticed the Snackager bundle snapshots raising false errors.

What's (probably) happening here is that the lock file, generated on macOS, contains platform incompatible modules for Linux.  This should not stop Yarn from installing in our test, even though we run on Linux.

# How

- Added `--ignore-platform` in our tests when a lock file is used

# Test Plan

See if CI passes.