### PR TITLE
[snackager] Add package specific cache-busting

### DIFF
--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -1,0 +1,21 @@
+const cacheBusting: { version: number; packages: { [name: string]: number } } = {
+  /**
+   * Main version. Incrementing this causes all cached bundles
+   * to be invalidated and rebuild when requested.
+   * */
+  version: 1,
+  /**
+   * Package specific invalidations.
+   * Adding or updating a version causes all cached bundled
+   * of the given package to be invalidated and rebuild when
+   * requested.
+   * */
+  packages: {
+    'react-native-reanimated': 1,
+  },
+};
+
+export default function getCachePrefix(name: string): string {
+  const packageVersion = cacheBusting.packages[name];
+  return `${cacheBusting.version}${packageVersion ? `-${packageVersion}` : ''}`;
+}

--- a/snackager/src/config.ts
+++ b/snackager/src/config.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 type Config = {
-  snackager_version: number;
   port: number;
   registry: string;
   tmpdir: string;
@@ -36,7 +35,6 @@ function env(varName: string): string {
 }
 
 const config: Config = {
-  snackager_version: 1,
   registry: 'https://registry.yarnpkg.com',
   port: parseInt(process.env.PORT ?? '3012', 10),
   tmpdir: path.join(process.env.TMPDIR ?? '/tmp', 'snackager'),

--- a/snackager/src/utils/fetchBundle.ts
+++ b/snackager/src/utils/fetchBundle.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import path from 'path';
 import raven from 'raven';
 
+import getCachePrefix from '../cache-busting';
 import config from '../config';
 import { createRedisClient } from '../external/redis';
 import logger from '../logger';
@@ -60,17 +61,16 @@ export default async function fetchBundle({
   versionSnackager,
 }: Options): Promise<BundleResponse> {
   const fullName = `${pkg.name}${deep ? `/${deep}` : ''}`;
+  const cachePrefix = getCachePrefix(fullName);
   const buildStatusRedisId =
-    `snackager/buildStatus/${config.snackager_version}/` +
+    `snackager/buildStatus/${cachePrefix}/` +
     `${fullName}@${version}-${platforms.join(',')}`.replace(/\//g, '~');
   const latestCompletedVersionRedisId =
-    `snackager/latestVersion/${config.snackager_version}/` + fullName.replace(/\//g, '~');
+    `snackager/latestVersion/${cachePrefix}/` + fullName.replace(/\//g, '~');
 
-  const handle = versionSnackager ? `snackager-${config.snackager_version}/${hash}` : hash;
+  const handle = versionSnackager ? `snackager-${cachePrefix}/${hash}` : hash;
   const latestHandle =
-    versionSnackager && latestHash
-      ? `snackager-${config.snackager_version}/${latestHash}`
-      : latestHash;
+    versionSnackager && latestHash ? `snackager-${cachePrefix}/${latestHash}` : latestHash;
 
   const logMetadata = { pkg, redisId: buildStatusRedisId };
 


### PR DESCRIPTION
# Why

The `react-native-reanimated2` native bundles are invalid because they internalized `react-native/Libraries/Renderer/shims/ReactNative`. This was fixed by PR #126 This PR adds support for package specific cache-busting to Snackager and invalidates the current caches for `react-native-reanimated2`.

# How

- Extend the cache-handle to include an additional suffix (e.g. `-1`) to invalidate current caches
- Bust cache for `react-native-reanimated`

# Test Plan

- Verified locally
- `yarn start`
- Open website and add `react-native-reanimated` to the dependencies
- Watched how Snackager rebuild the package
- Removing and re-adding the package returned the newly cached package