### PR TITLE
[snackager] Fix packages using reanimated 2

### DIFF
--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -12,6 +12,7 @@ const cacheBusting: { version: number; packages: { [name: string]: number } } = 
    * */
   packages: {
     'react-native-reanimated': 1,
+    moti: 1,
   },
 };
 

--- a/snackager/src/utils/packageBundle.ts
+++ b/snackager/src/utils/packageBundle.ts
@@ -119,7 +119,9 @@ async function packageBundleUnsafe({
       // This is currently only done for the reanimated package itsself, but
       // in the future third-party packages may also contain worklets that would
       // need to be converted.
-      reanimatedPlugin: pkg.name === 'react-native-reanimated' && pkg.version >= '2',
+      reanimatedPlugin:
+        (pkg.name === 'react-native-reanimated' && pkg.version >= '2') ||
+        externals.includes('react-native-reanimated'),
     })
   );
 


### PR DESCRIPTION
# Why

Fixes `moti` not working on Snack because the `worklets` inside it are not compiled using the reanimated2 plugin.

# How

- Run reanimated2 plugin on all packages that have `react-native-reanimated` as a dependency (or detected external)
- Bust cache on `moti` package

# Test Plan

- Verified locally and confirmed the moti example works on both web and ios