### PR TITLE
[website] Use Expo SDK 41 by default

### DIFF
--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -10,5 +10,5 @@ export const versions: { [version: string]: boolean } = {
   '41.0.0': true,
 };
 
-export const DEFAULT_SDK_VERSION = '40.0.0';
+export const DEFAULT_SDK_VERSION = '41.0.0';
 export const TEST_SDK_VERSION = '38.0.0';


### PR DESCRIPTION
# Why

Sets Expo SDK 41 as the default SDK for the Snack website.

# How

- See why

# Test Plan

- Verified reanimated2 and moti@0.10.1 examples work on SDK 41 (both web and native)
  - [X] Reanimated native (https://snack.expo.io/@hein_expo/rude-crackers)
  - [X] Reanimated web (https://snack.expo.io/@hein_expo/rude-crackers?platform=web)
  - [X] Moti native (https://snack.expo.io/@hein_expo/moti-starter)
  - [X] Moti web (https://snack.expo.io/@hein_expo/moti-starter?platform=web)