### PR TITLE
Use staging environment variable in runtime workflow

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      EXPO_STAGING: 1
     strategy:
       matrix:
         node-version: [12.x]
@@ -54,7 +56,7 @@ jobs:
 
       - name: Deploy runtime to staging
         #  if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: EXPO_STAGING=1 expo publish --clear
+        run: expo publish --clear
 
       #- name: Notify Slack
       #  uses: 8398a7/action-slack@v3


### PR DESCRIPTION
# Why

This enables the GH action to authenticate with staging, instead of production.

# How

- Added global environment variable for the job

# Test Plan

- See if CI passes