### PR TITLE
[tools] Fix terminal line wrapping

### DIFF
--- a/packages/snack-term/src/Terminal.tsx
+++ b/packages/snack-term/src/Terminal.tsx
@@ -61,6 +61,23 @@ export default function SnackTerminal(props: Props) {
     };
   }, []);
 
+  // Wrap logs to new lines
+  const lines: Log[] = [];
+  const maxLineWidth = width - 4;
+  for (let i = 0; i < logs.length; i++) {
+    const log = logs[i];
+    if (log.message.length < maxLineWidth) {
+      lines.push(log);
+    } else {
+      let { message, color } = logs[i];
+      while (message.length > maxLineWidth) {
+        lines.push({ message: message.slice(0, maxLineWidth), color });
+        message = message.slice(maxLineWidth);
+      }
+      lines.push({ message, color });
+    }
+  }
+
   return (
     <Box flexDirection="column" width={width} height={height}>
       <Box flexDirection="row" justifyContent="flex-start">
@@ -77,7 +94,7 @@ export default function SnackTerminal(props: Props) {
         width={width}
         height={height - 1}
         paddingX={1}>
-        {logs.slice(Math.max(0, logs.length - logCount)).map(({ message, color }) => (
+        {lines.slice(Math.max(0, lines.length - logCount)).map(({ message, color }) => (
           <Text color={color}>{message}</Text>
         ))}
       </Box>

--- a/packages/snack-term/src/index.tsx
+++ b/packages/snack-term/src/index.tsx
@@ -24,7 +24,13 @@ function SnackTerminal() {
               width={Math.round(size.width / 2)}
               height={size.height - 1 - Math.round((size.height - 1) / 2)}
             />
-            <Text color="cyan">Press Ctrl+C to exit</Text>
+            <Text color="cyan">
+              Open{' '}
+              <Text bold underline>
+                snack.expo.test
+              </Text>{' '}
+              or press Ctrl+C to exit
+            </Text>
           </Box>
           <Terminal
             cwd="packages/snack-proxies"


### PR DESCRIPTION
Terminal app overflows past the bottom when logs wrap and occupy multiple lines. This PR also adds a link to `snack.expo.test` at the bottom to quickly open the Snack website.
