### PR TITLE
[k8s] deploy snack on expo.dev

### DIFF
--- a/website/deploy/production/ingress-spec.yaml
+++ b/website/deploy/production/ingress-spec.yaml
@@ -6,9 +6,17 @@ spec:
   tls:
   - hosts:
     - snack.expo.io
+    - snack.expo.dev
     secretName: snack-tls
   rules:
   - host: snack.expo.io
+    http:
+      paths:
+      - backend:
+          serviceName: snack
+          servicePort: 80
+        path: /
+  - host: snack.expo.dev
     http:
       paths:
       - backend:

--- a/website/deploy/staging/ingress-spec.yaml
+++ b/website/deploy/staging/ingress-spec.yaml
@@ -6,9 +6,17 @@ spec:
   tls:
   - hosts:
     - staging.snack.expo.io
+    - staging.snack.expo.dev
     secretName: snack-tls
   rules:
   - host: staging.snack.expo.io
+    http:
+      paths:
+      - backend:
+          serviceName: snack
+          servicePort: 80
+        path: /
+  - host: staging.snack.expo.dev
     http:
       paths:
       - backend:


### PR DESCRIPTION
# Why

We want to deploy Snack on snack.expo.dev so that it can share cookies with users logged in on expo.dev

# How

- added new host entries to staging and production ingress config.
- [ ] deploy to staging to test if these changes are working appropriately (I'm not sure of how to do this, guidance would be really appreciated)

# Test Plan

After this change, snack.expo.dev should work and render the snack UI
