### PR TITLE
[ci] Runtime deployment github actions

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
+          expo-cache: true
           token: ${{ secrets.EXPO_PRODUCTION }}
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -1,0 +1,63 @@
+name: RuntimeProduction
+
+defaults:
+  run:
+    working-directory: runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'type "deploy" to confirm deploy to production (main branch only)'
+        required: false
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/runtime-production.yml
+      - runtime/**
+      - .eslint*
+      - .prettier*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 4.x
+          expo-token: ${{ secrets.EXPO_PRODUCTION }}
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc --noEmit
+      - run: yarn lint --max-warnings 0
+      # - run: yarn test --ci --maxWorkers 15%
+
+      - name: Deploy web-player
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: yarn deploy:web:prod
+
+      - name: Deploy native runtime
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: yarn deploy:prod
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Production
+          fields: message,commit,author,took

--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Deploy web-player
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:web:prod
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
 
       - name: Deploy native runtime
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'

--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: expo/expo-github-action@v5
+      - uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
-          expo-token: ${{ secrets.EXPO_PRODUCTION }}
+          token: ${{ secrets.EXPO_PRODUCTION }}
 
       - run: yarn install --frozen-lockfile
       - run: yarn tsc --noEmit

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: expo/expo-github-action@v5
+      - uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
-          expo-token: ${{ secrets.EXPO_STAGING }}
+          token: ${{ secrets.EXPO_STAGING }}
 
       - run: yarn install --frozen-lockfile
       - run: yarn tsc --noEmit

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: expo/expo-github-action@v6
         with:
           expo-version: 4.x
+          expo-cache: true
           token: ${{ secrets.EXPO_STAGING }}
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -1,0 +1,60 @@
+name: RuntimeStaging
+
+defaults:
+  run:
+    working-directory: runtime
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/runtime-staging.yml
+      - runtime/**
+      - .eslint*
+      - .prettier*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      EXPO_STAGING: 1
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 4.x
+          expo-token: ${{ secrets.EXPO_STAGING }}
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc --noEmit
+      - run: yarn lint --max-warnings 0
+      # - run: yarn test --ci --maxWorkers 15%
+
+      - name: Deploy web-player
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: yarn deploy:web:staging
+
+      - name: Deploy native runtime
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: yarn deploy:staging
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Staging
+          fields: message,commit,author,took

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -42,7 +42,10 @@ jobs:
 
       - name: Deploy web-player
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: yarn deploy:web:staging
+        run: yarn deploy:web:
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
 
       - name: Deploy native runtime
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ All contributors can [test package bundling](./snackager/README#test-package-bun
 
 ### Runtime
 
-By default, the latest deployed runtime from Staging is used. To starts the runtime in development, see  [Runtime development](runtime/README.md#development).
+By default, the latest runtime that was deployed to staging is used. To start the runtime in development, see  [Runtime development](runtime/README.md#development).
 
 ## ✅ Testing
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -28,7 +28,10 @@ This loads the runtime into Expo Go and displays another QR-code scanner. Now, u
 
 ## Deployment
 
-The runtime is not yet auto-deployed in CI. To manually deploy the runtime, see the [Deployment guide](./__internal__/DEPLOYING.md).
+The runtime is auto-deployed to Staging upon mergin to main. 
+To deploy to production, run the `deploy` dispatch trigger of the `RuntimeProduction` Github Action workflow.
+
+To manually deploy or learn more about deploying, see the [Deployment guide](./__internal__/DEPLOYING.md).
 
 
 ## Loading states


### PR DESCRIPTION
# Work in progress

# Why

This PR adds automatic deployment of the Snack runtime to the staging and production environment (web-player & native runtime). Previously this needed to be done by hand, which was cumbersome and time consuming.

# How

- Auto deploy to staging upon pushing to main
- Deploy to production by running the `deploy` workflow in `RuntimeProduction`
- Native runtime deploy has been verified
- Web-player deploy is Work in progress, requires S3 credentials config to work

# Test Plan

- [X] Verified deployment of the native runtime to staging
- [X] Verified slack notification on staging
- [ ] Verified web-player deployment to staging (FAIL: requires S3 credentials) 
- [ ] Verified deployment of the native runtime to production (should work, but not yet verified)
- [ ] Verified slack notification on staging (should work, but not yet verified)
- [ ] Verified web-player deployment to staging (FAIL: requires S3 credentials) 
