### PR TITLE
[website] Remove file import JS limitation

### DIFF
--- a/website/src/client/components/Import/ImportFilesManager.tsx
+++ b/website/src/client/components/Import/ImportFilesManager.tsx
@@ -299,7 +299,6 @@ export default class ImportFilesManager extends React.PureComponent<Props, State
                   <input
                     multiple
                     type="file"
-                    accept=".js"
                     onChange={this._handleFilesChange}
                     className={css(styles.fileInput)}
                   />


### PR DESCRIPTION
# Why

Right now, users can only upload JS files through the "Import files" modal. I don't think we should limit it to JS only, as users should be able to upload images and maybe JSON/txt files too.

# How

Removed the `accept="js"` from the file import modal.

# Test Plan

- See if we can upload more types of files after this change, e.g. assets and code.
