### PR TITLE
[snack] Migrate staging urls to .dev

### DIFF
--- a/docs/expo-sdk-upgrade.md
+++ b/docs/expo-sdk-upgrade.md
@@ -156,4 +156,4 @@ Appetize.io is used for running the Expo Go app in the cloud, in your browser. W
 4. Upload to Appetize Embedded Queue (Use credentials from 1password - Appetize Embedded Queue)
   - Android is at https://appetize.io/manage/private_cg1109cch61mzkhyq7cx67qprg
   - iOS is at https://appetize.io/manage/private_wpak1hhfkbv8czpx4k48gz5664
-5. Check that they are working! (Android emulator will only work from staging.snack.expo.io, not through ngrok)
+5. Check that they are working! (Android emulator will only work from staging.snack.expo.dev, not through ngrok)

--- a/docs/hosts-ports.md
+++ b/docs/hosts-ports.md
@@ -4,10 +4,10 @@ The following hosts and ports are used by Snack.
 
 | Development | Staging | Production | Description |
 |---|---|---|---|
-| [localhost:3011](http://localhost:3011) ([snack.expo.test](http://snack.expo.test)) | [staging.snack.expo.io](https://staging.snack.expo.io) | [snack.expo.io](https://snack.expo.io) | Snack web-app located in `./website`. |
+| [localhost:3011](http://localhost:3011) ([snack.expo.test](http://snack.expo.test)) | [staging.snack.expo.dev](https://staging.snack.expo.dev) | [snack.expo.io](https://snack.expo.io) | Snack web-app located in `./website`. |
 | localhost:3012 (snackager.expo.test) | staging.snackager.expo.io | snackager.expo.io | Snackager bundler service. |
 | localhost:3000 | staging.exp.host | exp.host | The Expo API server. |
-| localhost:3001 | staging.expo.io | expo.io | The Expo website. |
+| localhost:3001 | staging.expo.dev | expo.io | The Expo website. |
 | localhost:3020 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo API server. Located in `./packages/snack-proxies`. |
 | localhost:3021 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo website. Located in `./packages/snack-proxies`. |
 | localhost:3022 | - | - | Proxy server that forwards and logs all requests to the local or staging Snackager service. Located in `./packages/snack-proxies`. |

--- a/packages/snack-proxies/src/index.ts
+++ b/packages/snack-proxies/src/index.ts
@@ -13,7 +13,7 @@ Promise.all([
     name: 'expo-website',
     port: 3021,
     localURL: 'http://localhost:3001',
-    stagingURL: 'https://staging.expo.io',
+    stagingURL: 'https://staging.expo.dev',
   }),
   createProxy({
     name: 'snackager',

--- a/runtime/__internal__/DEPLOYING.md
+++ b/runtime/__internal__/DEPLOYING.md
@@ -8,8 +8,8 @@ No CI actions are configured for this yet, so it needs to be done manually.
 - Login to staging: `EXPO_STAGING=1 expo login`
 - Deploy runtime: `yarn deploy:staging` (used by the Expo client)
 - Deploy web player: `yarn deploy:web:staging` (used by Snack web preview)
-- Verify that the runtime works by opening an app from `staging.snack.expo.io` on your Expo client.
-- Verify that the web-player works by using the web-preview on `staging.snack.expo.io`.
+- Verify that the runtime works by opening an app from `staging.snack.expo.dev` on your Expo client.
+- Verify that the web-player works by using the web-preview on `staging.snack.expo.dev`.
 
 ## Production
 

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -2,6 +2,7 @@ import './polyfill';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AppLoading from 'expo-app-loading';
+import Constants from 'expo-constants';
 import { activateKeepAwake } from 'expo-keep-awake';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
@@ -22,7 +23,8 @@ import { captureRef as takeSnapshotAsync } from './NativeModules/ViewShot';
 import * as Profiling from './Profiling';
 import UpdateIndicator from './UpdateIndicator';
 
-const expoApiUrl = 'https://expo.io';
+const API_SERVER_URL_STAGING = 'https://staging.exp.host';
+const API_SERVER_URL_PROD = 'https://exp.host';
 
 type State = {
   initialLoad: boolean;
@@ -293,7 +295,11 @@ export default class App extends React.Component<object, State> {
   };
 
   _uploadPreviewToS3 = async (asset: string, height: number, width: number) => {
-    const url = `${expoApiUrl}/--/api/v2/snack/uploadPreview`;
+    const url = `${
+      Constants.manifest.extra?.cloudEnv !== 'production'
+        ? API_SERVER_URL_STAGING
+        : API_SERVER_URL_PROD
+    }/--/api/v2/snack/uploadPreview`;
     const body = JSON.stringify({ asset, height, width });
     try {
       Logger.info('Uploading preview...', 'width', width, 'height', height);

--- a/website/deploy/staging/snack.env
+++ b/website/deploy/staging/snack.env
@@ -1,7 +1,7 @@
-SERVER_URL=https://staging.expo.io
+SERVER_URL=https://staging.expo.dev
 API_SERVER_URL=https://staging.exp.host
 SENTRY_ENVIRONMENT=staging
-SNACK_SERVER_URL=https://staging.snack.expo.io
+SNACK_SERVER_URL=https://staging.snack.expo.dev
 IMPORT_SERVER_URL=https://staging.snackager.expo.io
 DEPLOY_ENVIRONMENT=staging
 SNACK_WEBPLAYER_URL=https://snack-web-player-staging.s3.us-west-1.amazonaws.com

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -4,25 +4,25 @@ metadata:
   name: snack
 build:
   artifacts:
-  - image: gcr.io/exponentjs/snack
-    sync:
-      manual:
-      - src: src/**/*
-        dest: /snack/app
-    docker:
-      dockerfile: website/Dockerfile
-      buildArgs:
-        node_version: 12.18.4
-        SERVER_URL: https://staging.expo.io
-        API_SERVER_URL: https://staging.exp.host
-        APP_VERSION: staging-{{.GITHUB_SHA}}
-        DEPLOY_ENVIRONMENT: staging
-        IMPORT_SERVER_URL: https://staging.snackager.expo.io
-        SNACK_SERVER_URL: https://staging.snack.expo.io
-        SNACK_SEGMENT_KEY: dxul6twMnfpyguF8w4W2qUpFnhxEUSV6
-        SNACK_AMPLITUDE_KEY: 512bcbce69eae77fee77be53ec230088
-        SNACK_WEBPLAYER_URL: https://snack-web-player-staging.s3.us-west-1.amazonaws.com
-        SNACK_WEBPLAYER_CDN: https://d1qt8af2b3kxj0.cloudfront.net
+    - image: gcr.io/exponentjs/snack
+      sync:
+        manual:
+          - src: src/**/*
+            dest: /snack/app
+      docker:
+        dockerfile: website/Dockerfile
+        buildArgs:
+          node_version: 12.18.4
+          SERVER_URL: https://staging.expo.dev
+          API_SERVER_URL: https://staging.exp.host
+          APP_VERSION: staging-{{.GITHUB_SHA}}
+          DEPLOY_ENVIRONMENT: staging
+          IMPORT_SERVER_URL: https://staging.snackager.expo.io
+          SNACK_SERVER_URL: https://staging.snack.expo.dev
+          SNACK_SEGMENT_KEY: dxul6twMnfpyguF8w4W2qUpFnhxEUSV6
+          SNACK_AMPLITUDE_KEY: 512bcbce69eae77fee77be53ec230088
+          SNACK_WEBPLAYER_URL: https://snack-web-player-staging.s3.us-west-1.amazonaws.com
+          SNACK_WEBPLAYER_CDN: https://d1qt8af2b3kxj0.cloudfront.net
   tagPolicy:
     sha256: {}
   local:
@@ -30,62 +30,62 @@ build:
 deploy:
   kustomize:
     paths:
-    - website/deploy/staging
+      - website/deploy/staging
 profiles:
-- name: prod
-  build:
-    artifacts:
-    - image: gcr.io/exponentjs/snack
-      docker:
-        dockerfile: website/Dockerfile
-        buildArgs:
-          node_version: 12.18.4
-          SERVER_URL: https://expo.io
-          API_SERVER_URL: https://exp.host
-          APP_VERSION: production-{{.GITHUB_SHA}}
-          DEPLOY_ENVIRONMENT: production
-          IMPORT_SERVER_URL: https://snackager.expo.io
-          SNACK_SERVER_URL: https://snack.expo.io
-          SNACK_SEGMENT_KEY: Ha0swpI6s2CVEMxK84cEmKmUVmBa1USu
-          SNACK_AMPLITUDE_KEY: e91121c19a5bdcccd852cd032dc911fe
-          SNACK_WEBPLAYER_URL: https://snack-web-player.s3.us-west-1.amazonaws.com
-          SNACK_WEBPLAYER_CDN: https://dwmszb351h4q.cloudfront.net
-  deploy:
-    kustomize:
-      paths:
-      - website/deploy/production
-  activation:
-  - env: ENVIRONMENT=production
-- name: main
-  build:
-    local:
-      push: true
-  activation:
-  - env: GITHUB_REF=refs/heads/main
-- name: local
-  deploy:
-    kustomize:
-      paths:
-      - website/deploy/development
-    statusCheckDeadlineSeconds: 10
-    kubeContext: minikube
-  patches:
-  - op: replace
-    path: /build/artifacts/0/docker/buildArgs/APP_VERSION
-    value: development
-  - op: replace
-    path: /build/artifacts/0/docker/buildArgs/DEPLOY_ENVIRONMENT
-    value: local
-  - op: replace
-    path: /build/artifacts/0/docker/buildArgs/SNACK_SEGMENT_KEY
-    value: ""
-  activation:
-  - command: dev
-  - command: debug
-- name: development
-  patches:
-  - op: add
-    path: /build/artifacts/0/docker/target
-    value: dev
-  activation:
-  - command: dev
+  - name: prod
+    build:
+      artifacts:
+        - image: gcr.io/exponentjs/snack
+          docker:
+            dockerfile: website/Dockerfile
+            buildArgs:
+              node_version: 12.18.4
+              SERVER_URL: https://expo.io
+              API_SERVER_URL: https://exp.host
+              APP_VERSION: production-{{.GITHUB_SHA}}
+              DEPLOY_ENVIRONMENT: production
+              IMPORT_SERVER_URL: https://snackager.expo.io
+              SNACK_SERVER_URL: https://snack.expo.io
+              SNACK_SEGMENT_KEY: Ha0swpI6s2CVEMxK84cEmKmUVmBa1USu
+              SNACK_AMPLITUDE_KEY: e91121c19a5bdcccd852cd032dc911fe
+              SNACK_WEBPLAYER_URL: https://snack-web-player.s3.us-west-1.amazonaws.com
+              SNACK_WEBPLAYER_CDN: https://dwmszb351h4q.cloudfront.net
+    deploy:
+      kustomize:
+        paths:
+          - website/deploy/production
+    activation:
+      - env: ENVIRONMENT=production
+  - name: main
+    build:
+      local:
+        push: true
+    activation:
+      - env: GITHUB_REF=refs/heads/main
+  - name: local
+    deploy:
+      kustomize:
+        paths:
+          - website/deploy/development
+      statusCheckDeadlineSeconds: 10
+      kubeContext: minikube
+    patches:
+      - op: replace
+        path: /build/artifacts/0/docker/buildArgs/APP_VERSION
+        value: development
+      - op: replace
+        path: /build/artifacts/0/docker/buildArgs/DEPLOY_ENVIRONMENT
+        value: local
+      - op: replace
+        path: /build/artifacts/0/docker/buildArgs/SNACK_SEGMENT_KEY
+        value: ''
+    activation:
+      - command: dev
+      - command: debug
+  - name: development
+    patches:
+      - op: add
+        path: /build/artifacts/0/docker/target
+        value: dev
+    activation:
+      - command: dev

--- a/website/snack-embed.html
+++ b/website/snack-embed.html
@@ -3,7 +3,7 @@
   <head>
   </head>
   <body>
-    <form action="https://staging.snack.expo.io" method="POST" target="_blank">
+    <form action="https://staging.snack.expo.dev" method="POST" target="_blank">
       <input type="hidden" name="platform" value="ios"/>
       <input type="hidden" name="name" value={'Example'} />
       <input type="hidden" name="dependencies" value="lodash@*" />

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -334,7 +334,7 @@ class Main extends React.Component<Props, State> {
       Analytics.getInstance().verbose = true;
     }
 
-    if (window.location.host.includes('expo.io')) {
+    if (window.location.host.includes('expo.io') || window.location.host.includes('expo.dev')) {
       Raven.config('https://6501f7d527764d85b045b0ce31927c75@sentry.io/191351').install();
       const build_date = new Date(process.env.BUILD_TIMESTAMP ?? 0).toUTCString();
       Raven.setTagsContext({ build_date });


### PR DESCRIPTION
# Why

Migrates all staging URLs (with exception of Snackager) to `.dev`. instead of `.io`. This PR serves as a test to verify all Snack services work correctly on `.dev` prior to migrating production to `.dev`.

# How

- Update all staging URLs to `.dev`
- Fix runtime preview uploads which always uploaded to production and never to staging
- Snackager URLs are unchanged

# Test Plan

- Verified locally on `expo.test`. Attempted login and confirmed local login works correctly and no longer redirects.
- All tests pass
- Verified runtime `uploadPreview` now uses the correct staging URL and succeeds

![image](https://user-images.githubusercontent.com/6184593/119791353-0cfab300-bed5-11eb-9ee1-4745492be38e.png)
