### PR TITLE
feat(import-repo-modal): note private repos cause errors

### DIFF
--- a/website/src/client/components/Import/ImportRepoModal.tsx
+++ b/website/src/client/components/Import/ImportRepoModal.tsx
@@ -149,7 +149,7 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
           <p className={!isError ? css(styles.paragraph) : css(styles.errorParagraph)}>
             {!isError
               ? 'Import an Expo project from a Git repository.'
-              : 'An error occurred during import. This could be because the data provided was invalid, or because the repository referenced is not a properly formatted Expo project.'}
+              : 'An error occurred during import. This could be because the data provided was invalid, because the provided repository is private, or because the provided repository is not a properly formatted Expo project.'}
           </p>
           {advanced ? (
             <>


### PR DESCRIPTION
# Why
I attempted importing a private Github repo and got an error message that was not related to the repo's visibility.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How
Updated the error copy
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Repro:
1. Make an expo project
2. Place that expo project in a private github repo
3. Attempt to import that private github repo

We should probably aim to have more verbose errors in the future, but I think this is an improvement in the near-term.
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
