### PR TITLE
[website] Import files/repo improvements

### DIFF
--- a/website/src/client/components/Import/ImportRepoModal.tsx
+++ b/website/src/client/components/Import/ImportRepoModal.tsx
@@ -20,6 +20,7 @@ type Props = {
 
 type State = {
   status: 'idle' | 'importing' | 'error';
+  error?: string;
   advanced: boolean;
   url: string;
   repo: string;
@@ -103,6 +104,7 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
 
     if (didFail) {
       this.setState({
+        error: snackId,
         status: 'error',
       });
       Analytics.getInstance().logEvent('IMPORT_COMPLETED', { reason: 'error' }, 'importStart');
@@ -133,7 +135,7 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { status, url, repo, path, branch, advanced } = this.state;
+    const { status, error, url, repo, path, branch, advanced } = this.state;
     const isImporting = status === 'importing';
     const isError = status === 'error';
 
@@ -148,9 +150,10 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
         <form onSubmit={this._handleImportRepoClick}>
           <p className={!isError ? css(styles.paragraph) : css(styles.errorParagraph)}>
             {!isError
-              ? 'Import an Expo project from a Git repository.'
+              ? 'Import an Expo project from a Public Git repository.'
               : 'An error occurred during import. This could be because the data provided was invalid, or because the repository referenced is not a properly formatted Expo project.'}
           </p>
+          {isError && <p className={css(styles.errorParagraph)}>{error}</p>}
           {advanced ? (
             <>
               <h4 className={css(styles.subtitle)}>Repository URL</h4>

--- a/website/src/client/utils/convertDataTransferItemsToFiles.tsx
+++ b/website/src/client/utils/convertDataTransferItemsToFiles.tsx
@@ -38,6 +38,8 @@ const blacklist = [
   /^yarn-error\.log$/, // yarn error log
   /^yarn\.lock$/, // yarn package metadata
   /^__tests__$/, // jest tests
+  /^__integration-tests__$/, // jest tests
+  /^__mocks__$/, // jest tests
   /~$/, // hidden and backup files
 ];
 

--- a/website/src/client/utils/fileUtilities.tsx
+++ b/website/src/client/utils/fileUtilities.tsx
@@ -59,6 +59,14 @@ export function isJson(name: string): boolean {
   return name.endsWith('.json');
 }
 
+export function isMarkdown(name: string): boolean {
+  return name.endsWith('.md');
+}
+
+export function isAsset(name: string): boolean {
+  return !(isScript(name) || isJson(name) || isMarkdown(name));
+}
+
 export function isJS(name: string): boolean {
   return name.endsWith('.js');
 }


### PR DESCRIPTION
# Why

This PR makes several improvements to importing files and repositories.

Replaces #154

### Before

![image](https://user-images.githubusercontent.com/6184593/121535361-60efb680-ca02-11eb-8de8-a476392b1d9d.png)

![image](https://user-images.githubusercontent.com/6184593/121535387-69e08800-ca02-11eb-9ce3-8c7a1c27b302.png)

### After

![image](https://user-images.githubusercontent.com/6184593/121535210-3bfb4380-ca02-11eb-980e-ebe613dd13bf.png)

![image](https://user-images.githubusercontent.com/6184593/121535259-4a495f80-ca02-11eb-92a5-bde02d2d617f.png)

# How

- Indicate that only Public git repo's are supported
- Display error-code from Snackager when git import fails
- Show size for file when importing through drag & drop
- Layout improvements to import files modal

# Test Plan

- Drag & drop a file onto Snack and confirm size is shown
- Drag & drop `.json` file and confirm it was imported as a code file (and not an asset)
- Import invalid Git repo and confirm error is shown (`https://github.com/ide/love-languages/tree/main/app`)