### PR TITLE
[runtime] Remove installationId

### DIFF
--- a/runtime/src/Analytics.tsx
+++ b/runtime/src/Analytics.tsx
@@ -10,10 +10,16 @@ Amplitude.initializeAsync(AMPLITUDE_KEY);
 
 let loggedReceivedFirstCode = false;
 
-export const receivedCode = ({ message: { metadata } }: { message: { metadata: object } }) => {
+export const receivedCode = ({
+  message: { metadata },
+  deviceId,
+}: {
+  message: { metadata: object };
+  deviceId: string;
+}) => {
   if (!loggedReceivedFirstCode) {
     Amplitude.logEventWithPropertiesAsync('RECEIVED_FIRST_CODE', {
-      phoneId: Constants.installationId,
+      phoneId: deviceId,
       phoneName: Constants.deviceName,
       ...metadata,
     });

--- a/runtime/src/Console.tsx
+++ b/runtime/src/Console.tsx
@@ -7,9 +7,6 @@ const ignoredWarnings = [
   // TODO: These should probably be removed
   'Require cycle',
   'Following APIs have moved',
-
-  // TODO(cedric): Move away from Constants.installationId
-  'Constants.installationId has been deprecated',
 ];
 
 LogBox.ignoreLogs(ignoredWarnings);

--- a/runtime/src/Messaging.tsx
+++ b/runtime/src/Messaging.tsx
@@ -9,27 +9,32 @@ import * as Logger from './Logger';
 const PRESENCE_TIMEOUT = 600;
 const HEARTBEAT_INTERVAL = 60;
 
-const pubnub = new PubNub({
-  publishKey: 'pub-c-2a7fd67b-333d-40db-ad2d-3255f8835f70',
-  subscribeKey: 'sub-c-0b655000-d784-11e6-b950-02ee2ddab7fe',
-  uuid: JSON.stringify({
-    id: Constants.installationId,
-    name: Constants.deviceName,
-    platform: Platform.OS,
-  }),
-  ssl: true,
-  presenceTimeout: PRESENCE_TIMEOUT,
-  heartbeatInterval: HEARTBEAT_INTERVAL,
-});
+let pubnub: PubNub;
 
 // Device metadata that is sent with every message from us
 const device = {
-  id: Constants.installationId,
+  id: '', // async, populated in init
   name: Constants.deviceName,
   platform: Platform.OS,
 };
 
 let currentChannel: string | null = null;
+
+export const init = (deviceId: string) => {
+  pubnub = new PubNub({
+    publishKey: 'pub-c-2a7fd67b-333d-40db-ad2d-3255f8835f70',
+    subscribeKey: 'sub-c-0b655000-d784-11e6-b950-02ee2ddab7fe',
+    uuid: JSON.stringify({
+      id: deviceId,
+      name: Constants.deviceName,
+      platform: Platform.OS,
+    }),
+    ssl: true,
+    presenceTimeout: PRESENCE_TIMEOUT,
+    heartbeatInterval: HEARTBEAT_INTERVAL,
+  });
+  device.id = deviceId;
+};
 
 // End existing PubNub subscription, if any
 export const unsubscribe = () => {

--- a/runtime/src/Messaging.web.tsx
+++ b/runtime/src/Messaging.web.tsx
@@ -6,7 +6,7 @@ import * as Logger from './Logger';
 type Listener = (payload: { message: any }) => void;
 
 const device = {
-  id: Constants.installationId,
+  id: '', // async, populated in init
   name: Constants.deviceName,
   platform: Platform.OS,
 };
@@ -76,6 +76,10 @@ const onMessage = (event: MessageEvent) => {
   } catch (e) {
     Logger.comm_error('Failed to parse message', event.data);
   }
+};
+
+export const init = (deviceId: string) => {
+  device.id = deviceId;
 };
 
 export const unsubscribe = () => {

--- a/runtime/src/NativeModules/getDeviceIdAsync.tsx
+++ b/runtime/src/NativeModules/getDeviceIdAsync.tsx
@@ -1,0 +1,13 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Random from 'expo-random';
+
+export default async function getDeviceIdAsync() {
+  const value = await AsyncStorage.getItem('SnackDeviceId');
+  if (value) return value;
+  const byteArray = await Random.getRandomBytesAsync(16);
+  const hexString = [...new Uint8Array(byteArray.buffer)]
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+  await AsyncStorage.setItem('SnackDeviceId', hexString);
+  return hexString;
+}

--- a/runtime/src/NativeModules/getDeviceIdAsync.web.tsx
+++ b/runtime/src/NativeModules/getDeviceIdAsync.web.tsx
@@ -1,0 +1,12 @@
+import * as Random from 'expo-random';
+
+export default async function getDeviceIdAsync() {
+  const value = localStorage.getItem('SnackDeviceId');
+  if (value) return value;
+  const byteArray = await Random.getRandomBytesAsync(16);
+  const hexString = [...new Uint8Array(byteArray.buffer)]
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+  localStorage.setItem('SnackDeviceId', hexString);
+  return hexString;
+}


### PR DESCRIPTION
# Why

Removes the deprecated `Constants.installationId` and replaces it with a persisted randomly generated Id.

# How

- Use expo-random to generate a one time random id (hex 32 chars) and store in async/local-storage
- Remove `installationId` usage and warning

# Test Plan

- Loaded Snack runtime into Expo Go (iOS) and logged device-id to console
- Confirmed that the device-id remains the same after reloading the Snack runtime (by shaking and reloading)
- Loaded Snack web-player into the Snack website (using the localhost option)
- Confirmed that the device-id remains the same when refreshing the web-player