### PR TITLE
[runtime] Remove expo-permissions usage

### DIFF
--- a/runtime/src/BarCodeScannerView.native.tsx
+++ b/runtime/src/BarCodeScannerView.native.tsx
@@ -1,6 +1,5 @@
 import { BarCodeScanner, BarCodeScannedCallback } from 'expo-barcode-scanner';
 import Constants from 'expo-constants';
-import * as Permissions from 'expo-permissions';
 import * as React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 
@@ -27,7 +26,7 @@ export default class BarCodeScannerView extends React.Component<Props, State> {
   }
 
   _openCameraAsync = async () => {
-    const { status } = await Permissions.askAsync('camera');
+    const { status } = await BarCodeScanner.requestPermissionsAsync();
 
     this.setState({
       waitingForPermission: false,

--- a/runtime/src/aliases/common.tsx
+++ b/runtime/src/aliases/common.tsx
@@ -18,7 +18,7 @@ const aliases: { [key: string]: any } = {
   // Packages that are used internally by the runtime
   'expo-constants': require('expo-constants'),
   'expo-file-system': require('expo-file-system'),
-  'expo-permissions': require('expo-permissions'),
+  'expo-permissions': require('expo-permissions'), // TODO, remove this for SDK 42
   'expo-updates': require('expo-updates'),
   '@react-native-async-storage/async-storage': require('@react-native-async-storage/async-storage'),
 


### PR DESCRIPTION
# Why

Remove usage of deprecated `expo-permissons` API.

# How

- Replace expo-permissions by new requestPermissions API in barcode-scanner
- Add note that `expo-permissions` should be removed entirely in SDK 42

# Test Plan

- `yarn lint && yarn tsc`
- `yarn start`
- Uninstalled Expo Go on iPhone
- Installed Expo Go and loaded Snack runtime using qr-code
- Watched Expo Go present the camera permissions prompt
