### PR TITLE
[runtime] Allow web-player on sizze domain

### DIFF
--- a/runtime/src/Messaging.web.tsx
+++ b/runtime/src/Messaging.web.tsx
@@ -48,6 +48,8 @@ const allowedOrigins = [
   'https://jackdaw.codecademy.com',
   'https://staging.codecademy.com',
   'https://production.codecademy.com',
+  // Sizze
+  'https://dashboard.sizze.io',
 ];
 
 function isAllowedOrigin(origin: string): boolean {


### PR DESCRIPTION
# Why

To allow running the Snack web-player on the sizze.io domain.

@Tozare

# How

- Add `https://dashboard.sizze.io` to list of allowed domains

# Test Plan

- Unable to test, needs to be performed by sizze.io after deployment