### PR TITLE
[snackager] Fix react-dom not externalized in web-bundles

### DIFF
--- a/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
@@ -420,7 +420,7 @@ Object {
           "react-native/Libraries/BatchedBridge/BatchedBridge",
           "react-native-svg",
         ],
-        "size": 294732,
+        "size": 294734,
       },
     },
     "ios": Object {
@@ -441,12 +441,13 @@ Object {
         "externals": Array [
           "react",
           "react-native",
+          "react-dom",
           "@expo/vector-icons",
           "react-native-safe-area-context",
           "expo-av",
           "react-native-svg",
         ],
-        "size": 776828,
+        "size": 652485,
       },
     },
   },

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -10,6 +10,7 @@ const CORE_EXTERNALS = [
   'react-native',
   'react-native-web',
   'react-native-windows',
+  'react-dom',
   'expo',
   '@unimodules/core',
   '@unimodules/react-native-adapter',

--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -13,7 +13,7 @@ const cacheBusting: { version: number; packages: { [name: string]: number } } = 
   packages: {
     'react-native-reanimated': 1,
     moti: 1,
-    '@drafbit/ui': 1,
+    '@draftbit/ui': 1,
   },
 };
 


### PR DESCRIPTION
# Why

Fixes web-bundles that use `react-dom` directly such as `@material-ui` (and indirectly `@drafbit/ui`). In these cases `react-dom` was falsly included **inside** the bundle which conflicted with `react-dom` which was already included in the Snack runtime using `react-native-web`. This PR resolves the problem in Snackager by ensuring that `react-dom` is always externalized.

**After the fix**

![image](https://user-images.githubusercontent.com/6184593/122756699-0e7e8780-d297-11eb-8148-a55e15b53823.png)

# How

- Always externalize `react-dom`
- Invalidate cache for `@draftbit/ui`
- Update tests

# Test Plan

- Bump cache-bust number for `@drafbit/ui`
- `yarn start`
- Open `http://snack.expo.test/` and import Snack from production: https://snack.expo.io/@peterpme/(draftbit)-onboarding---kid-info
- Load web-preview and click on date (see screenshot in #why)
- Run `yarn test` to verify all tests succeed