### PR TITLE
 [website][debug] add debug code to figure out why .dev transition isn't working in staging

### DIFF
--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -3,24 +3,37 @@ import { Context } from 'koa';
 export function isDevDomainEnabled(): boolean {
   const DEPLOY_ENVIRONMENT = process.env.DEPLOY_ENVIRONMENT;
 
+  console.log('DEPLOY_ENVIRONMENT', DEPLOY_ENVIRONMENT);
+
   if (!DEPLOY_ENVIRONMENT) return false;
 
-  if (['development', 'staging'].includes(DEPLOY_ENVIRONMENT)) return true;
+  if (['staging'].includes(DEPLOY_ENVIRONMENT)) return true;
   if (['production'].includes(DEPLOY_ENVIRONMENT)) return false;
 
   return false;
 }
 
 export function redirectToDevDomain(ctx: Context): boolean {
+  console.log(`${ctx.protocol}://${ctx.hostname}`);
+
+  console.log('isDevDomainEnabled', isDevDomainEnabled());
+  console.log('ctx.protocol', ctx.protocol);
+  console.log('ctx.hostname', ctx.hostname);
+  console.log('ctx.req.url', ctx.req.url);
+  console.log('process.env.LEGACY_SNACK_SERVER_URL', process.env.LEGACY_SNACK_SERVER_URL);
+  console.log('process.env.SNACK_SERVER_URL', process.env.SNACK_SERVER_URL);
+
   // if the incoming request is from snack.expo.io, redirect to snack.expo.dev
   if (
     isDevDomainEnabled() &&
     `${ctx.protocol}://${ctx.hostname}` === process.env.LEGACY_SNACK_SERVER_URL &&
     process.env.SNACK_SERVER_URL
   ) {
+    console.log('is redirecting');
     ctx.redirect(`${process.env.SNACK_SERVER_URL}${ctx.req.url}`);
     return true;
   } else {
+    console.log('is not redirecting');
     return false;
   }
 }

--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -14,14 +14,17 @@ export function isDevDomainEnabled(): boolean {
 }
 
 export function redirectToDevDomain(ctx: Context): boolean {
-  console.log(`${ctx.protocol}://${ctx.hostname}`);
+  console.log(`.DEV REDIRECT: ${ctx.protocol}://${ctx.hostname}`);
 
-  console.log('isDevDomainEnabled', isDevDomainEnabled());
-  console.log('ctx.protocol', ctx.protocol);
-  console.log('ctx.hostname', ctx.hostname);
-  console.log('ctx.req.url', ctx.req.url);
-  console.log('process.env.LEGACY_SNACK_SERVER_URL', process.env.LEGACY_SNACK_SERVER_URL);
-  console.log('process.env.SNACK_SERVER_URL', process.env.SNACK_SERVER_URL);
+  console.log('.DEV REDIRECT: isDevDomainEnabled', isDevDomainEnabled());
+  console.log('.DEV REDIRECT: ctx.protocol', ctx.protocol);
+  console.log('.DEV REDIRECT: ctx.hostname', ctx.hostname);
+  console.log('.DEV REDIRECT: ctx.req.url', ctx.req.url);
+  console.log(
+    '.DEV REDIRECT: process.env.LEGACY_SNACK_SERVER_URL',
+    process.env.LEGACY_SNACK_SERVER_URL
+  );
+  console.log('.DEV REDIRECT: process.env.SNACK_SERVER_URL', process.env.SNACK_SERVER_URL);
 
   // if the incoming request is from snack.expo.io, redirect to snack.expo.dev
   if (
@@ -29,11 +32,11 @@ export function redirectToDevDomain(ctx: Context): boolean {
     `${ctx.protocol}://${ctx.hostname}` === process.env.LEGACY_SNACK_SERVER_URL &&
     process.env.SNACK_SERVER_URL
   ) {
-    console.log('is redirecting');
+    console.log('.DEV REDIRECT: is redirecting');
     ctx.redirect(`${process.env.SNACK_SERVER_URL}${ctx.req.url}`);
     return true;
   } else {
-    console.log('is not redirecting');
+    console.log('.DEV REDIRECT: is not redirecting');
     return false;
   }
 }

--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -3,7 +3,7 @@ import { Context } from 'koa';
 export function isDevDomainEnabled(): boolean {
   const DEPLOY_ENVIRONMENT = process.env.DEPLOY_ENVIRONMENT;
 
-  console.log('DEPLOY_ENVIRONMENT', DEPLOY_ENVIRONMENT);
+  console.log('.DEV REDIRECT: DEPLOY_ENVIRONMENT', DEPLOY_ENVIRONMENT);
 
   if (!DEPLOY_ENVIRONMENT) return false;
 

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -34,9 +34,9 @@ const createChannel = customAlphabet(
 );
 
 const render = async (ctx: Context) => {
-  console.log('render() started');
+  console.log('.DEV REDIRECT: render() started');
   if (redirectToDevDomain(ctx)) return;
-  console.log('render() continued after redirectToDevDomain()');
+  console.log('.DEV REDIRECT: render() continued after redirectToDevDomain()');
 
   const id = ctx.params
     ? ctx.params.id

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -34,7 +34,9 @@ const createChannel = customAlphabet(
 );
 
 const render = async (ctx: Context) => {
+  console.log('render() started');
   if (redirectToDevDomain(ctx)) return;
+  console.log('render() continued after redirectToDevDomain()');
 
   const id = ctx.params
     ? ctx.params.id


### PR DESCRIPTION
# Why

The snack.expo.io -> snack.expo.dev redirect isn't working as expected in staging, so I want to learn more about why since the code implementation seems simple.

# How

Added logging around env vars and execution flow (or the lack of execution).

## Test Plan

After this is deployed and merged in staging, I should be able to read the logs with `ks logs <snack-pod>` and/or `ks attach <snack-pod> -i`
