### PR TITLE
[snackager] Update test snapshots

### DIFF
--- a/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
@@ -9,16 +9,16 @@ Object {
           "react",
           "react-native",
         ],
-        "size": 69283,
+        "size": 69327,
       },
     },
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 66895,
+        "size": 66939,
       },
     },
     "web": Object {
@@ -27,7 +27,7 @@ Object {
           "react",
           "react-native",
         ],
-        "size": 138143,
+        "size": 138218,
       },
     },
   },
@@ -101,16 +101,16 @@ Object {
       },
       "bundle.js": Object {
         "externals": Array [
+          "@react-native-community/masked-view",
+          "@react-navigation/native",
+          "AssetRegistry",
           "react",
           "react-native",
-          "@react-navigation/native",
-          "react-native-safe-area-context",
-          "AssetRegistry",
           "react-native-gesture-handler",
+          "react-native-safe-area-context",
           "react-native-screens",
-          "@react-native-community/masked-view",
         ],
-        "size": 100808,
+        "size": 100893,
       },
     },
     "ios": Object {
@@ -134,16 +134,16 @@ Object {
       },
       "bundle.js": Object {
         "externals": Array [
+          "@react-native-community/masked-view",
+          "@react-navigation/native",
+          "AssetRegistry",
           "react",
           "react-native",
-          "@react-navigation/native",
-          "react-native-safe-area-context",
           "react-native-gesture-handler",
-          "AssetRegistry",
+          "react-native-safe-area-context",
           "react-native-screens",
-          "@react-native-community/masked-view",
         ],
-        "size": 101787,
+        "size": 101872,
       },
     },
     "web": Object {
@@ -155,14 +155,14 @@ Object {
       },
       "bundle.js": Object {
         "externals": Array [
+          "@react-navigation/native",
+          "AssetRegistry",
           "react",
           "react-native",
-          "@react-navigation/native",
           "react-native-safe-area-context",
-          "AssetRegistry",
           "react-native-screens",
         ],
-        "size": 105768,
+        "size": 105853,
       },
     },
   },
@@ -208,11 +208,11 @@ Object {
         "externals": Array [
           "@react-navigation/native",
           "react",
-          "react-native-screens",
           "react-native",
+          "react-native-screens",
           "react-native/Libraries/ReactNative/AppContainer",
         ],
-        "size": 9284,
+        "size": 9328,
       },
     },
     "ios": Object {
@@ -220,11 +220,11 @@ Object {
         "externals": Array [
           "@react-navigation/native",
           "react",
-          "react-native-screens",
           "react-native",
+          "react-native-screens",
           "react-native/Libraries/ReactNative/AppContainer",
         ],
-        "size": 9280,
+        "size": 9324,
       },
     },
     "web": Object {
@@ -232,11 +232,11 @@ Object {
         "externals": Array [
           "@react-navigation/native",
           "react",
-          "react-native-screens",
           "react-native",
+          "react-native-screens",
           "react-native/Libraries/ReactNative/AppContainer",
         ],
-        "size": 9115,
+        "size": 9159,
       },
     },
   },
@@ -255,8 +255,8 @@ Object {
     "android": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
           "react-native/Libraries/BatchedBridge/BatchedBridge",
         ],
         "size": 12236,
@@ -265,8 +265,8 @@ Object {
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
         "size": 11901,
       },
@@ -295,19 +295,19 @@ Object {
     "android": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 46834,
+        "size": 46878,
       },
     },
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 46830,
+        "size": 46874,
       },
     },
     "web": Object {
@@ -316,7 +316,7 @@ Object {
           "react",
           "react-native",
         ],
-        "size": 118074,
+        "size": 118149,
       },
     },
   },
@@ -368,7 +368,7 @@ Object {
           "expo-constants",
           "react-native",
         ],
-        "size": 14413,
+        "size": 14476,
       },
     },
     "ios": Object {
@@ -379,7 +379,7 @@ Object {
           "expo-constants",
           "react-native",
         ],
-        "size": 14409,
+        "size": 14472,
       },
     },
     "web": Object {
@@ -390,7 +390,7 @@ Object {
           "expo-constants",
           "react-native",
         ],
-        "size": 14409,
+        "size": 14472,
       },
     },
   },
@@ -412,42 +412,42 @@ Object {
     "android": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
-          "react",
           "@expo/vector-icons",
-          "react-native-safe-area-context",
           "expo-av",
-          "react-native/Libraries/BatchedBridge/BatchedBridge",
+          "react",
+          "react-native",
+          "react-native-safe-area-context",
           "react-native-svg",
+          "react-native/Libraries/BatchedBridge/BatchedBridge",
         ],
-        "size": 294734,
+        "size": 307461,
       },
     },
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
-          "react",
-          "react-native-safe-area-context",
           "@expo/vector-icons",
           "expo-av",
+          "react",
+          "react-native",
+          "react-native-safe-area-context",
           "react-native-svg",
         ],
-        "size": 292431,
+        "size": 314823,
       },
     },
     "web": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react",
-          "react-native",
-          "react-dom",
           "@expo/vector-icons",
-          "react-native-safe-area-context",
           "expo-av",
+          "react",
+          "react-dom",
+          "react-native",
+          "react-native-safe-area-context",
           "react-native-svg",
         ],
-        "size": 652485,
+        "size": 662874,
       },
     },
   },
@@ -484,15 +484,15 @@ Object {
       },
       "bundle.js": Object {
         "externals": Array [
+          "@react-navigation/native",
+          "AssetRegistry",
           "react",
           "react-native",
-          "@react-navigation/native",
-          "react-native-screens",
           "react-native-gesture-handler",
-          "AssetRegistry",
           "react-native-gesture-handler/DrawerLayout",
+          "react-native-screens",
         ],
-        "size": 221207,
+        "size": 221282,
       },
     },
   },
@@ -520,10 +520,10 @@ Object {
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 9063,
+        "size": 9119,
       },
     },
     "web": Object {
@@ -555,7 +555,7 @@ Object {
           "react-native",
           "react-native/Libraries/Utilities/dismissKeyboard",
         ],
-        "size": 8187,
+        "size": 8231,
       },
     },
     "ios": Object {
@@ -565,7 +565,7 @@ Object {
           "react-native",
           "react-native/Libraries/Utilities/dismissKeyboard",
         ],
-        "size": 8183,
+        "size": 8227,
       },
     },
     "web": Object {
@@ -575,7 +575,7 @@ Object {
           "react-native",
           "react-native/Libraries/Utilities/dismissKeyboard",
         ],
-        "size": 8183,
+        "size": 8227,
       },
     },
   },
@@ -594,28 +594,28 @@ Object {
     "android": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 19030,
+        "size": 19074,
       },
     },
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 19026,
+        "size": 19070,
       },
     },
     "web": Object {
       "bundle.js": Object {
         "externals": Array [
-          "react-native",
           "react",
+          "react-native",
         ],
-        "size": 19026,
+        "size": 19070,
       },
     },
   },
@@ -631,21 +631,21 @@ Object {
     "android": Object {
       "bundle.js": Object {
         "externals": Array [
+          "@unimodules/core",
           "react",
           "react-native",
-          "@unimodules/core",
         ],
-        "size": 8091,
+        "size": 8135,
       },
     },
     "ios": Object {
       "bundle.js": Object {
         "externals": Array [
+          "@unimodules/core",
           "react",
           "react-native",
-          "@unimodules/core",
         ],
-        "size": 7471,
+        "size": 7515,
       },
     },
     "web": Object {
@@ -654,7 +654,7 @@ Object {
           "react",
           "react-native",
         ],
-        "size": 14946,
+        "size": 15002,
       },
     },
   },

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/@draftbit/ui@40.34.4.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/@draftbit/ui@40.34.4.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
-  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -22,27 +22,30 @@
     "@date-io/core" "^1.3.13"
 
 "@draftbit/core@^40.34.4":
-  version "40.34.5"
-  resolved "https://registry.yarnpkg.com/@draftbit/core/-/core-40.34.5.tgz#6289bf2a03151985c9308121cc5327b9e6e13c58"
-  integrity sha512-caqY5IlTv/KE6UVSeWrGoe+4Z/5ziZZkzsCWvnn3NK0D4nKZuCNUqahD2kYaFTaTGqb/ubh7LBWRxunIsLPrRA==
+  version "40.36.7"
+  resolved "https://registry.yarnpkg.com/@draftbit/core/-/core-40.36.7.tgz#f055238506f290ce982f8f736daeb5dc7ca92ce1"
+  integrity sha512-/1d5b9HT/mbjCjGBqGlk8FG+/edDSOALTm8c0rF4d6y/1dEJDxr29lcmc9LTI2Wo8sxlBIa7osvY8MhcJycucg==
   dependencies:
     "@date-io/date-fns" "^1.3.13"
     "@draftbit/react-theme-provider" "^2.1.1"
-    "@draftbit/types" "^40.33.7"
+    "@draftbit/types" "^40.36.7"
     "@material-ui/core" "^4.11.0"
     "@material-ui/pickers" "^3.2.10"
     "@react-native-community/slider" "^4.0.0-rc.3"
     color "^3.1.2"
     date-fns "^2.16.1"
     dateformat "^3.0.3"
+    lodash.isnumber "^3.0.3"
+    lodash.tonumber "^4.0.3"
+    react-native-modal-datetime-picker "^10.0.0"
     react-native-typography "^1.4.1"
 
 "@draftbit/native@^40.34.0":
-  version "40.34.0"
-  resolved "https://registry.yarnpkg.com/@draftbit/native/-/native-40.34.0.tgz#1fc503110ec512020338448fa2062090d91d312e"
-  integrity sha512-jJumqV1+kPONPUPy3stEON5ujFJHKT/iB3MUV+fcG3Crfytv5OHHw/8P89TdM4ZeVJMV1tXW0w8ANh38ktqTiA==
+  version "40.36.7"
+  resolved "https://registry.yarnpkg.com/@draftbit/native/-/native-40.36.7.tgz#4b9f2e5d77428a3463e7ee3fe3eff1d9f0b740b6"
+  integrity sha512-d+mqqiZwCPY9w27qRBCMDLFeP353ESO27HA8gbtnEeL+gjXw8MZMDsCTXbbCM0c8EyGSraybc6e7s17ilD2bbw==
   dependencies:
-    "@draftbit/types" "^40.33.7"
+    "@draftbit/types" "^40.36.7"
     "@expo/vector-icons" "^12.0.2"
     "@react-native-community/slider" "^4.0.0-rc.3"
     expo-av "^8.7.0"
@@ -56,10 +59,10 @@
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
 
-"@draftbit/types@^40.33.7":
-  version "40.33.7"
-  resolved "https://registry.yarnpkg.com/@draftbit/types/-/types-40.33.7.tgz#9883bd272c64410712b7852314652c89684ca731"
-  integrity sha512-K4oGJUnPWk55PP1ywhe34NWr0DR1alwLh0PtvvqQMnXCmahjogJVFCUOrb71lr4v/msoqR4yV2VnddR8G2F50g==
+"@draftbit/types@^40.36.7":
+  version "40.36.7"
+  resolved "https://registry.yarnpkg.com/@draftbit/types/-/types-40.36.7.tgz#42dd7966208ecdbc348f53c17ee3ffbc6587d34f"
+  integrity sha512-9hnJ/9FjW8r2W/qs7uS2zzA/4m3mNEOtKcDaCM4QyTfUYQxk4S7+xvw307QkzQ7xus07u9vPltuL8p2JkxcrKw==
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -174,9 +177,9 @@
     "@types/react" "*"
 
 "@types/react@*":
-  version "17.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.8.tgz#fe76e3ba0fbb5602704110fd1e3035cf394778e3"
-  integrity sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.11.tgz#67fcd0ddbf5a0b083a0f94e926c7d63f3b836451"
+  integrity sha512-yFRQbD+whVonItSk7ZzP/L+gPTJVBkL/7shLEF+i9GC/1cV3JmUxEQz6+9ylhUpWSDuqo1N9qEvqS6vTj4USUA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -251,9 +254,9 @@ csstype@^3.0.2:
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
 date-fns@^2.16.1:
-  version "2.21.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.3.tgz#8f5f6889d7a96bbcc1f0ea50239b397a83357f9b"
-  integrity sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
 dateformat@^3.0.3:
   version "3.0.3"
@@ -418,6 +421,11 @@ lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
@@ -447,6 +455,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
+
+lodash.tonumber@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz#0b96b31b35672793eb7f5a63ee791f1b9e9025d9"
+  integrity sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk=
 
 lodash@^4.17.15:
   version "4.17.21"
@@ -494,23 +507,30 @@ react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-native-modal-datetime-picker@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-10.0.0.tgz#1a424c0ed277ab76621542af4efa4f357ed2a740"
+  integrity sha512-uKi1K3nUWJ1UWssLsDt8s7KpfFFlZ0MaP91wf3rFG07woscVu70m1Db0f1v6s3YY01UW+q+8ZD+Y2Hp3o+UCvQ==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-native-typography@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-native-typography/-/react-native-typography-1.4.1.tgz#2d05cb5935a2f7fdb6b43bbde93d60f1324578e3"
   integrity sha512-dc9Zfs4jUdq4ygx4/KwO6jKTERBu6cRrfPJGntw/pA+D6BMjlWfMNuhZ/69vf4Zpsnt9s4AGe+Z/V1QFYaCXAA==
 
 react-native-webview@^11.6.2:
-  version "11.6.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.6.2.tgz#e19b3325d6777caee29d04eb2edf9b70f0b29915"
-  integrity sha512-7e5ltLBgqt1mX0gdTTS2nFPIjfS6y300wqJ4rLWqU71lDO+8ZeayfsF5qo83qxo2Go74CtLnSeWae4pdGwUqYw==
+  version "11.6.4"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.6.4.tgz#bd2d072ea0157b3fcb10961b5d1866470b22c3c3"
+  integrity sha512-ahW9KL/iBooDRdQwBgPEWOl5Awjwvmo5FtV83WzbgUpQxDJ+ZRzZDpbmwcjLtd6R67yWg6dk1inqKQTrmkWiXQ==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
 react-transition-group@^4.0.0, react-transition-group@^4.4.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
-  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-native-community/datetimepicker@3.0.3.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-native-community/datetimepicker@3.0.3.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-native-community/viewpager@4.2.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-native-community/viewpager@4.2.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-navigation/stack@5.9.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/@react-navigation/stack@5.9.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -27,9 +27,9 @@ color-name@^1.0.0:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
-  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
+  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/expo-google-app-auth@8.1.3.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/expo-google-app-auth@8.1.3.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/expo-linear-gradient@8.2.1.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/expo-linear-gradient@8.2.1.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/firestorter@2.0.1.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/firestorter@2.0.1.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/moti@0.10.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/moti@0.10.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
-  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-gesture-handler/DrawerLayout@1.6.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-gesture-handler/DrawerLayout@1.6.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -50,9 +50,9 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -144,9 +144,9 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 glob@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -173,9 +173,9 @@ iconv-lite@^0.4.4:
     safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
+  integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
   dependencies:
     minimatch "^3.0.4"
 
@@ -311,9 +311,9 @@ nopt@^4.0.1:
     osenv "^0.1.4"
 
 npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
+  integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
   dependencies:
     npm-normalize-package-bin "^1.0.1"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-gesture-handler@1.6.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-gesture-handler@1.6.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -50,9 +50,9 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -144,9 +144,9 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 glob@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -173,9 +173,9 @@ iconv-lite@^0.4.4:
     safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"
+  integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
   dependencies:
     minimatch "^3.0.4"
 
@@ -311,9 +311,9 @@ nopt@^4.0.1:
     osenv "^0.1.4"
 
 npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
+  integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
   dependencies:
     npm-normalize-package-bin "^1.0.1"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-reanimated@2.0.0-alpha.6.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-reanimated@2.0.0-alpha.6.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@babel/helper-plugin-utils@^7.12.13":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
-  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
 "@babel/plugin-transform-object-assign@^7.10.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.12.13.tgz#d9b9200a69e03403a813e44a933ad9f4bddfd050"
-  integrity sha512-4QxDMc0lAOkIBSfCrnSGbAJ+4epDBF2XXwcLXuBcG1xl9u7LrktNVD4+LwhL47XuKVPQ7R25e/WdcV+h97HyZA==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.14.5.tgz#62537d54b6d85de04f4df48bfdba2eebff17b760"
+  integrity sha512-lvhjk4UN9xJJYB1mI5KC0/o1D5EcJXdbhVe+4fSk08D6ZN+iuAIs7LJC+71h8av9Ew4+uRq9452v9R93SFmQlQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -58,9 +58,9 @@ fbjs@^1.0.0:
     ua-parser-js "^0.7.18"
 
 iconv-lite@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
-  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -130,9 +130,9 @@ string-hash-64@^1.0.3:
   integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
 
 ua-parser-js@^0.7.18:
-  version "0.7.24"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
-  integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 whatwg-fetch@>=0.10.0:
   version "3.6.2"

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-reanimated@2.0.0-rc.3.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-reanimated@2.0.0-rc.3.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@babel/helper-plugin-utils@^7.12.13":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
-  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
 "@babel/plugin-transform-object-assign@^7.10.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.12.13.tgz#d9b9200a69e03403a813e44a933ad9f4bddfd050"
-  integrity sha512-4QxDMc0lAOkIBSfCrnSGbAJ+4epDBF2XXwcLXuBcG1xl9u7LrktNVD4+LwhL47XuKVPQ7R25e/WdcV+h97HyZA==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.14.5.tgz#62537d54b6d85de04f4df48bfdba2eebff17b760"
+  integrity sha512-lvhjk4UN9xJJYB1mI5KC0/o1D5EcJXdbhVe+4fSk08D6ZN+iuAIs7LJC+71h8av9Ew4+uRq9452v9R93SFmQlQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -27,9 +27,9 @@ asap@~2.0.3:
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 cross-fetch@^3.0.4:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
-  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
   dependencies:
     node-fetch "2.6.1"
 
@@ -96,6 +96,6 @@ string-hash-64@^1.0.3:
   integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
 
 ua-parser-js@^0.7.18:
-  version "0.7.24"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
-  integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-responsive-grid@0.32.4.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-responsive-grid@0.32.4.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-screens/native-stack@2.11.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-screens/native-stack@2.11.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-web/src/modules/normalizeColor@0.14.4.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-web/src/modules/normalizeColor@0.14.4.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -79,9 +79,9 @@ hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
 iconv-lite@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
-  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -187,9 +187,9 @@ setimmediate@^1.0.5:
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 ua-parser-js@^0.7.18:
-  version "0.7.24"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
-  integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+  version "0.7.28"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
+  integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
 whatwg-fetch@>=0.10.0:
   version "3.6.2"

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-webview@10.9.1.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-native-webview@10.9.1.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-navigation@3.13.0.lock
+++ b/snackager/src/__integration-tests__/__snapshots__/lockfiles/react-navigation@3.13.0.lock
@@ -3,9 +3,9 @@
 
 
 "@babel/runtime@*":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
   dependencies:
     regenerator-runtime "^0.13.4"
 

--- a/snackager/src/utils/getBundleInfo.ts
+++ b/snackager/src/utils/getBundleInfo.ts
@@ -1,3 +1,5 @@
+import uniq from 'lodash/uniq';
+
 export type BundleInfo = {
   size: number;
   externals?: string[];
@@ -14,7 +16,9 @@ export default function getBundleInfo(
   }
   const code: string = buffer.toString();
   return {
-    externals: Array.from(code.matchAll(/require\("([^"]+)"\)/g)).map((match) => match[1]),
+    externals: uniq(
+      Array.from(code.matchAll(/require\("([^"]+)"\)/g)).map((match) => match[1])
+    ).sort(),
     size: code.length,
     ...(includeCode ? { code } : {}),
   };


### PR DESCRIPTION
# Why

Refreshes the `.lock` files which causes the latest `@babel/runtime` to be used. This causes the tests to closer represent the current reality when bundling. This PR also sorts the reported externals to prevent future test-cases from failing when the generated bundle is slightly different (causing a different import ordering).

# How

- Delete and regenerate `.lock` files so they use the latest `@babel/runtime`
- Sort reported externals

# Test Plan

- `yarn test`
- `yarn lint`
- Verified that the externals are unchanged
- Verified that the output size is within expected limits