### PR TITLE
[website][debug] set proxy = true and add more log statements for redirect

### DIFF
--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -17,9 +17,13 @@ export function redirectToDevDomain(ctx: Context): boolean {
   console.log(`.DEV REDIRECT: ${ctx.protocol}://${ctx.hostname}`);
 
   console.log('.DEV REDIRECT: isDevDomainEnabled', isDevDomainEnabled());
+  console.log('.DEV REDIRECT: ctx', ctx);
   console.log('.DEV REDIRECT: ctx.protocol', ctx.protocol);
   console.log('.DEV REDIRECT: ctx.hostname', ctx.hostname);
+  console.log('.DEV REDIRECT: ctx.origin', ctx.origin);
   console.log('.DEV REDIRECT: ctx.req.url', ctx.req.url);
+  console.log('.DEV REDIRECT: ctx.req.headers', ctx.req.headers);
+  console.log('.DEV REDIRECT: ctx.req', ctx.req);
   console.log(
     '.DEV REDIRECT: process.env.LEGACY_SNACK_SERVER_URL',
     process.env.LEGACY_SNACK_SERVER_URL

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -43,6 +43,9 @@ if (require.main === module) {
 
 const app = new Koa();
 
+// trust incoming header fields from nginx
+app.proxy = true;
+
 app.on('error', (err, ctx: Koa.Context) => {
   // We get EPIPE and ECONNRESET errors if the client terminates the connection. Log these but
   // don't report them as errors.


### PR DESCRIPTION

# Why

After checking the logs and doing a quick search, my new theory is that the redirect code isn't working because we are serving Snack behind an nginx proxy, but we aren't trusting the headers sent from the proxy so we aren't able to find out the original request url. 

<img width="335" alt="Screen Shot 2021-06-25 at 11 41 24" src="https://user-images.githubusercontent.com/12488826/123450074-50b30c00-d5aa-11eb-834a-7ddc02dab932.png">

# How

- set `app.proxy = true` to enable proxy headers https://koajs.com/#settings
- added new logs to get more info about the request and its context
