### PR TITLE
[website] remove .dev redirect debug statements

### DIFF
--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -3,8 +3,6 @@ import { Context } from 'koa';
 export function isDevDomainEnabled(): boolean {
   const DEPLOY_ENVIRONMENT = process.env.DEPLOY_ENVIRONMENT;
 
-  console.log('.DEV REDIRECT: DEPLOY_ENVIRONMENT', DEPLOY_ENVIRONMENT);
-
   if (!DEPLOY_ENVIRONMENT) return false;
 
   if (['staging'].includes(DEPLOY_ENVIRONMENT)) return true;
@@ -14,33 +12,15 @@ export function isDevDomainEnabled(): boolean {
 }
 
 export function redirectToDevDomain(ctx: Context): boolean {
-  console.log(`.DEV REDIRECT: ${ctx.protocol}://${ctx.hostname}`);
-
-  console.log('.DEV REDIRECT: isDevDomainEnabled', isDevDomainEnabled());
-  console.log('.DEV REDIRECT: ctx', ctx);
-  console.log('.DEV REDIRECT: ctx.protocol', ctx.protocol);
-  console.log('.DEV REDIRECT: ctx.hostname', ctx.hostname);
-  console.log('.DEV REDIRECT: ctx.origin', ctx.origin);
-  console.log('.DEV REDIRECT: ctx.req.url', ctx.req.url);
-  console.log('.DEV REDIRECT: ctx.req.headers', ctx.req.headers);
-  console.log('.DEV REDIRECT: ctx.req', ctx.req);
-  console.log(
-    '.DEV REDIRECT: process.env.LEGACY_SNACK_SERVER_URL',
-    process.env.LEGACY_SNACK_SERVER_URL
-  );
-  console.log('.DEV REDIRECT: process.env.SNACK_SERVER_URL', process.env.SNACK_SERVER_URL);
-
   // if the incoming request is from snack.expo.io, redirect to snack.expo.dev
   if (
     isDevDomainEnabled() &&
     `${ctx.protocol}://${ctx.hostname}` === process.env.LEGACY_SNACK_SERVER_URL &&
     process.env.SNACK_SERVER_URL
   ) {
-    console.log('.DEV REDIRECT: is redirecting');
     ctx.redirect(`${process.env.SNACK_SERVER_URL}${ctx.req.url}`);
     return true;
   } else {
-    console.log('.DEV REDIRECT: is not redirecting');
     return false;
   }
 }

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -34,9 +34,7 @@ const createChannel = customAlphabet(
 );
 
 const render = async (ctx: Context) => {
-  console.log('.DEV REDIRECT: render() started');
   if (redirectToDevDomain(ctx)) return;
-  console.log('.DEV REDIRECT: render() continued after redirectToDevDomain()');
 
   const id = ctx.params
     ? ctx.params.id


### PR DESCRIPTION
# Why

With the help of logging, I figured out that `app.proxy = true` was the key to getting the redirect code working, so the debug statements I added have now served their purpose and now should be removed.

# How

Removed all `console.log('.DEV Redirect...` statements.
