### PR TITLE
[snackager] Use secure cloudfront url for snackager

### DIFF
--- a/snackager/k8s/staging/snackager.env
+++ b/snackager/k8s/staging/snackager.env
@@ -1,4 +1,4 @@
-CLOUDFRONT_URL=http://ductmb1crhe2d.cloudfront.net
+CLOUDFRONT_URL=https://ductmb1crhe2d.cloudfront.net
 IMPORTS_S3_BUCKET=snack-git-imports-staging
 S3_BUCKET=snackager-artifacts-staging
 API_SERVER_URL=https://staging.exp.host

--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -14,10 +14,14 @@ const cacheBusting: { version: number; packages: { [name: string]: number } } = 
     'react-native-reanimated': 1,
     moti: 1,
     '@draftbit/ui': 1,
+    '@expo-google-fonts/.*': 1,
   },
 };
 
 export default function getCachePrefix(name: string): string {
-  const packageVersion = cacheBusting.packages[name];
+  const match = Object.keys(cacheBusting.packages).find((spec) =>
+    new RegExp(`^${spec}$`).test(name)
+  );
+  const packageVersion = match ? cacheBusting.packages[match] : undefined;
   return `${cacheBusting.version}${packageVersion ? `-${packageVersion}` : ''}`;
 }

--- a/snackager/src/utils/__tests__/getCachePrefix.test.ts
+++ b/snackager/src/utils/__tests__/getCachePrefix.test.ts
@@ -1,0 +1,13 @@
+import getCachePrefix from '../../cache-busting';
+
+it('returns only global cache prefix for unlisted package', () => {
+  expect(getCachePrefix('some-unlisted-package')).toMatch(/^\d$/); // "1"
+});
+
+it('returns valid cache prefix for listed package', () => {
+  expect(getCachePrefix('react-native-reanimated')).toMatch(/^\d-\d$/); // "1-1"
+});
+
+it('returns valid cache prefix for listed package with wildcard', () => {
+  expect(getCachePrefix('@expo-google-fonts/inter')).toMatch(/^\d-\d$/); // "1-1"
+});


### PR DESCRIPTION
# Why

Font resources from the `expo-google-fonts` package aren't loaded atm. This is due to mixed resources (HTTP vs HTTPS). This is a test to enable it on staging only.

# How

Updated the k8s staging envvars.

# Test Plan

See if this [snack loads properly](https://snack.expo.io/@peterpme/rebellious-orange) on staging.