### PR TITLE
[snackager] Add unimplemented view as external for react native picker

### DIFF
--- a/runtime/src/aliases/index.tsx
+++ b/runtime/src/aliases/index.tsx
@@ -13,6 +13,7 @@ const aliases: { [key: string]: any } = {
   'react-native/Libraries/ReactNative/AppContainer': require('react-native/Libraries/ReactNative/AppContainer'),
   'react-native/Libraries/Utilities/dismissKeyboard': require('react-native/Libraries/Utilities/dismissKeyboard'), // for @react-native-community/viewpager
   'react-native/Libraries/Renderer/shims/ReactNative': require('react-native/Libraries/Renderer/shims/ReactNative'), // for react-native-reanimated
+  'react-native/Libraries/Components/UnimplementedViews/UnimplementedView': require('react-native/Libraries/Components/UnimplementedViews/UnimplementedView'), // for @react-native-picker/picker@1.9.11
 };
 
 export default aliases;

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -25,6 +25,7 @@ const CORE_EXTERNALS = [
   'react-native/Libraries/ReactNative/AppContainer', // Used by react-native-screens
   'react-native/Libraries/Utilities/dismissKeyboard', // used by @react-native-community/viewpager@4.2.0
   'react-native/Libraries/Renderer/shims/ReactNative', // Used by moti
+  'react-native/Libraries/Components/UnimplementedViews/UnimplementedView', // Used by @react-native-picker@1.9.11
   // TODO: decide whether to treat prop-types as an external or not
   // previously it was always installed as a dependency and not treated as an external.
   // This however caused packages to be slightly larger than needed to be.

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -25,7 +25,7 @@ const CORE_EXTERNALS = [
   'react-native/Libraries/ReactNative/AppContainer', // Used by react-native-screens
   'react-native/Libraries/Utilities/dismissKeyboard', // used by @react-native-community/viewpager@4.2.0
   'react-native/Libraries/Renderer/shims/ReactNative', // Used by moti
-  'react-native/Libraries/Components/UnimplementedViews/UnimplementedView', // Used by @react-native-picker@1.9.11
+  'react-native/Libraries/Components/UnimplementedViews/UnimplementedView', // Used by @react-native-picker/picker@1.9.11
   // TODO: decide whether to treat prop-types as an external or not
   // previously it was always installed as a dependency and not treated as an external.
   // This however caused packages to be slightly larger than needed to be.


### PR DESCRIPTION
# Why

`@react-native-picker@1.9.11` manually imports [`react-native/Libraries/Components/UnimplementedViews/UnimplementedView`](https://github.com/react-native-picker/picker/blob/master/js/PickerAndroid.js#L11) in some places. This causes Snackager to actually load the unimplemented view from react-native itself. 

Eventually, it will end up with a weird set of dependencies that it thinks it needs to install. Because these aren't available in the registry, this will fail.
> "dependencies":{"React":"*","StyleSheet":"*","View":"*"},"time":"2021-07-01T12:12:38.554Z","v":0,"pkg":{"name":"@react-native-picker/picker","version":"1.9.11"},"msg":"@react-native-picker/picker@1.9.11 installing dependencies: React@*, StyleSheet@*, View@*"}
([see logs](https://github.com/expo/snack/files/6747966/test.txt))

# How

Explicitly mark the unimplemented view as external, and add it to the runtime as an alias. After doing that, the bundle is created properly.

# Test Plan

See [if this snack](https://snack.expo.io/@peterpme/supportive-churros) works as expected.
