### PR TITLE
[website] Show warnings for deprecated packages

### DIFF
--- a/packages/snack-sdk/src/__tests__/sdkversion-test.ts
+++ b/packages/snack-sdk/src/__tests__/sdkversion-test.ts
@@ -6,6 +6,7 @@ import Snack, {
   isModulePreloaded,
   getPreloadedModules,
   isFeatureSupported,
+  getDeprecatedModule,
 } from './snack-sdk';
 
 describe('sdkVersion', () => {
@@ -144,5 +145,16 @@ describe('isFeatureSupported', () => {
   });
   it('throws for invalid version', () => {
     expect(() => isFeatureSupported('TYPESCRIPT', 'foo')).toThrowError();
+  });
+});
+
+describe('getDeprecatedModule', () => {
+  it('returns undefined for non deprecated modules', () => {
+    expect(getDeprecatedModule('expo-constants', '41.0.0')).toBe(undefined);
+  });
+  it('returns description for deprecated modules', () => {
+    expect(getDeprecatedModule('@react-native-community/async-storage', '41.0.0')).toBe(
+      'Async Storage has moved to new organization: https://github.com/react-native-async-storage/async-storage'
+    );
   });
 });

--- a/packages/snack-sdk/src/index.ts
+++ b/packages/snack-sdk/src/index.ts
@@ -12,6 +12,7 @@ import {
   getSupportedSDKVersions,
   isFeatureSupported,
   standardizeDependencies,
+  getDeprecatedModule,
 } from './sdk';
 
 export * from './transports';
@@ -24,6 +25,7 @@ export {
   getSupportedSDKVersions,
   isFeatureSupported,
   standardizeDependencies,
+  getDeprecatedModule,
   defaultConfig,
   Snack,
 };

--- a/packages/snack-sdk/src/sdk.ts
+++ b/packages/snack-sdk/src/sdk.ts
@@ -44,6 +44,15 @@ export function validateSDKVersion(sdkVersion: SDKVersion): SDKVersion {
 }
 
 /**
+ * Checks whether the module is deprecated for the given sdk-version and returns
+ * the alternative module or error description instead. If the module is not deprecated
+ * `undefined` is returned.
+ */
+export function getDeprecatedModule(name: string, sdkVersion: SDKVersion): string | undefined {
+  return sdks[sdkVersion]?.deprecatedModules?.[name];
+}
+
+/**
  * Returns the list of supported SDK versions.
  */
 export function getSupportedSDKVersions(): SDKVersion[] {

--- a/packages/snack-sdk/src/sdks/index.ts
+++ b/packages/snack-sdk/src/sdks/index.ts
@@ -165,6 +165,12 @@ const sdks: { [version: string]: SDKSpec } = {
       // Common packages that are included for easy of use
       'prop-types': '*',
     },
+    deprecatedModules: {
+      '@react-native-community/async-storage':
+        'Async Storage has moved to new organization: https://github.com/react-native-async-storage/async-storage',
+      'expo-permissions':
+        'Use permissions getters and requesters in specific modules instead, such as MediaLibrary.getPermissionsAsync() and MediaLibrary.requestPermissionsAsync().',
+    },
   },
 };
 

--- a/packages/snack-sdk/src/sdks/types.ts
+++ b/packages/snack-sdk/src/sdks/types.ts
@@ -28,6 +28,13 @@ export type SDKSpec = {
   bundledModules: {
     [name: string]: '*';
   };
+
+  // Modules that have been deprecated. The value represents a valid
+  // a description providing a solution or explanation (eg.
+  // "expo-permissions": "Use permissions getters and requesters in specific modules instead...""
+  deprecatedModules?: {
+    [name: string]: string;
+  };
 };
 
 /**


### PR DESCRIPTION
# Why

Show warnings for deprecated packages such as `expo-permissions` and `@react-native-community/async-storage`. These warnings help with upgrading Snacks to new latest SDK versions, for instance to SDK 41 and SDK 42.

![image](https://user-images.githubusercontent.com/6184593/124143501-7731e500-da8b-11eb-89df-faac2b21464e.png)


# How

- Allow defining deprecated packages on a per SDK basis
- Add `getDeprecatedModule` to `snack-sdk`
- Add unit tests for `snack-sdk`
- Show warning in website when a deprecated package is used (see screenshot in #why)

# Test Plan

- All tests pass
- Verified the warnings pop-up when the deprecated dependencies are added to `package.json`