### PR TITLE
[website] Show errors instead of warnings when dependencies are missing

### DIFF
--- a/website/src/client/utils/dependencies.tsx
+++ b/website/src/client/utils/dependencies.tsx
@@ -153,7 +153,7 @@ export function getDependencyAnnotations(
       annotations.push({
         message: `'${name}@${version}' is not the recommended version for SDK ${sdkVersion}.`,
         location: getPackageJsonLocation(name, lines, false),
-        severity: isModulePreloaded(name, sdkVersion) ? 2 : 3,
+        severity: isModulePreloaded(name, sdkVersion, true) ? 2 : 3,
         source: 'Dependencies',
         action: getDependencyAction(name, version, dependencies, sdkVersion),
       });
@@ -167,7 +167,11 @@ export function getDependencyAnnotations(
         ','
       )}' requires peer-dependency '${name}'.`,
       location: getPackageJsonLocation(missingDependencies[name].dependents[0], lines, false),
-      severity: isModulePreloaded(name, sdkVersion) ? 2 : 4,
+      severity: isModulePreloaded(name, sdkVersion, true)
+        ? 2
+        : isModulePreloaded(name, sdkVersion)
+        ? 3
+        : 4,
       source: 'Dependencies',
       action: getDependencyAction(
         name,
@@ -190,7 +194,7 @@ export function getDependencyAnnotations(
           annotations.push({
             message: `'${name}' is not defined in dependencies.`,
             location: fileDep.location,
-            severity: isPreloaded ? 2 : 4,
+            severity: isPreloaded ? 3 : 4,
             source: 'Dependencies',
             action: getDependencyAction(name, fileDep.version ?? '*', dependencies, sdkVersion),
           });


### PR DESCRIPTION
# Why

Make Snack more deliberate and stricter by showing errors when dependencies are missing, instead of just warnings. This ensures that the Snack lists all dependencies, even those that are pre-loaded by the Snack runtime. This contributes to learning how to use Expo correctly and ensures that the project will run when exporting it to a `.zip` file, as well as providing better compatibility with future SDKs.

### before

![image](https://user-images.githubusercontent.com/6184593/124147549-160c1080-da8f-11eb-83bc-fb04b162d379.png)

### after

![image](https://user-images.githubusercontent.com/6184593/124147429-f8d74200-da8e-11eb-97b3-6a5c17a6905d.png)

# How

- Return severity `3` (error) instead of `2` (warning) for annotations regarding preloaded modules

# Test Plan

- See screenshots
- All tests pass


