### PR TITLE
[sdk] Set default SDK to 42 and update changelog

### DIFF
--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### 🛠 Breaking changes
 
+- Remove support for SDK 38 ([#175](https://github.com/expo/snack/pull/175) by [@bycedric](https://github.com/bycedric))
+
 ### 🎉 New features
+
+- Add support for SDK 42 ([#174](https://github.com/expo/snack/pull/174) by [@IjzerenHein](https://github.com/IjzerenHein))
+- Allow checking for deprecated modules using `getDeprecatedModule` ([#172](https://github.com/expo/snack/pull/172) by [@IjzerenHein](https://github.com/IjzerenHein))
 
 ### 🐛 Bug fixes
 

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.41.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.42.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/packages/snack-sdk/src/defaultConfig.ts
+++ b/packages/snack-sdk/src/defaultConfig.ts
@@ -5,7 +5,7 @@ export const snackagerURL: string = 'https://snackager.expo.io';
 export const webPlayerURL: string =
   'https://snack-web-player.s3.us-west-1.amazonaws.com/v2/%%SDK_VERSION%%';
 
-export const sdkVersion: SDKVersion = '41.0.0';
+export const sdkVersion: SDKVersion = '42.0.0';
 
 export const SnackIdentityState: SnackState = {
   sdkVersion,

--- a/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
@@ -223,7 +223,7 @@ Array [
         },
         "description": "test2 @ Jan 1, 2020",
         "name": "test2",
-        "sdkVersion": "41.0.0",
+        "sdkVersion": "42.0.0",
       },
     },
     "headers": Object {
@@ -261,7 +261,7 @@ Array [
         },
         "description": "test3 @ Jan 1, 2020",
         "name": "test3",
-        "sdkVersion": "41.0.0",
+        "sdkVersion": "42.0.0",
       },
     },
     "headers": Object {
@@ -295,7 +295,7 @@ Array [
         },
         "description": "some-example @ Jan 1, 2020",
         "name": "some-example",
-        "sdkVersion": "41.0.0",
+        "sdkVersion": "42.0.0",
       },
     },
     "headers": Object {

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -116,7 +116,7 @@ class Main extends React.Component<Props, State> {
 
     let name = props.defaults.name;
     let description = DEFAULT_DESCRIPTION;
-    let sdkVersion: SDKVersion = DEFAULT_SDK_VERSION;
+    let sdkVersion = DEFAULT_SDK_VERSION;
     let code: SnackFiles | string = props.files;
     let dependencies =
       props.files === DEFAULT_CODE && !props.snack?.code ? DEFAULT_DEPENDENCIES : {};

--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -12,5 +12,5 @@ export const versions: Record<SDKVersion, boolean> = {
   '42.0.0': true,
 };
 
-export const DEFAULT_SDK_VERSION = '41.0.0';
-export const TEST_SDK_VERSION = '39.0.0';
+export const DEFAULT_SDK_VERSION: SDKVersion = '42.0.0';
+export const TEST_SDK_VERSION: SDKVersion = '39.0.0';


### PR DESCRIPTION
# Why

Sets the default Expo SDK for snack-sdk to 42.0.0, as well as updates the changelog and makes some type improvements to website. Once completed, the snack-sdk will be published to NPM with these changes.

# How

- Set default SDK in snack-sdk to 42.0.0
- Set default SDK in website to 42.0.0
- Update snack-sdk changelog
- Stricter types for SDK_VERSION constants in website
- Update snackager test snapshots

# Test Plan

- snack-sdk `yarn lint && yarn tsc`
- snack-sdk `yarn test`
- website `yarn lint && yarn tsc`
- website `yarn test`
- snackager `yarn test`