### PR TITLE
[snackager] Fix @expo-google-fonts/xxx not working on production

### DIFF
--- a/snackager/k8s/production/snackager.env
+++ b/snackager/k8s/production/snackager.env
@@ -1,4 +1,4 @@
-CLOUDFRONT_URL=http://d37p21p3n8r8ug.cloudfront.net
+CLOUDFRONT_URL=https://d37p21p3n8r8ug.cloudfront.net
 IMPORTS_S3_BUCKET=snack-git-imports
 S3_BUCKET=snackager-artifacts
 API_SERVER_URL=https://exp.host

--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -14,7 +14,7 @@ const cacheBusting: { version: number; packages: { [name: string]: number } } = 
     'react-native-reanimated': 1,
     moti: 1,
     '@draftbit/ui': 1,
-    '@expo-google-fonts/.*': 1,
+    '@expo-google-fonts/.*': 2,
   },
 };
 


### PR DESCRIPTION
# Why

Follow up to #170 and fixes `@expo-google-fonts/xxx` on production.

# How

- Update cloudfront url to `https`
- Bust cache for `@expo-google-fonts/` as Snackager was re-run on production, causing bundles with the old `http://` url to generated

# Test Plan

:eyes: