### PR TITLE
[ci] Run staging runtime workflow for sdk branches

### DIFF
--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -1,0 +1,64 @@
+name: RuntimeStaging
+
+defaults:
+  run:
+    working-directory: runtime
+
+on:
+  push:
+    branches:
+      - main
+      - 'sdk-**'
+    paths:
+      - .github/workflows/runtime-staging.yml
+      - runtime/**
+      - .eslint*
+      - .prettier*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      EXPO_STAGING: 1
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: expo/expo-github-action@v6
+        with:
+          expo-version: 4.x
+          expo-cache: true
+          token: ${{ secrets.EXPO_STAGING }}
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc --noEmit
+      - run: yarn lint --max-warnings 0
+      # - run: yarn test --ci --maxWorkers 15%
+
+      - name: Deploy web-player
+        run: yarn deploy:web:staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
+
+      - name: Deploy native runtime
+        run: yarn deploy:staging
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Staging
+          fields: message,commit,author,ref

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -6,7 +6,6 @@ defaults:
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - .github/workflows/runtime.yml
       - runtime/**


### PR DESCRIPTION
# Why

Run CI runtime workflow for `sdk-*` branches, to allow deployment of the webplayer and native runtime through the `deploy` workflow trigger.

# How

- Run generic `Runtime` workflow on any pull-request (instead of only PRs for main)
- Updated staging workflow to deploy when pushing to `main` or `sdk-*` branches
- No production deployment changes have yet been made in this PR. This will be done after in a new PR after verification of this PR.

# Test Plan

- [X] Confirmed the `Runtime` workflow ran for this PR
- To test auto-deployment to staging will need to be merged. This should cause the webplayer and native runtime (for SDK 41) to be deployed to staging