### PR TITLE
[ci] Run production runtime workflow for sdk branches

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -1,0 +1,69 @@
+name: RuntimeProduction
+
+defaults:
+  run:
+    working-directory: runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'type "deploy" to confirm deploy to production (main branch only)'
+        required: false
+  push:
+    branches:
+      - main
+      - 'sdk-**'
+    paths:
+      - .github/workflows/runtime-production.yml
+      - runtime/**
+      - .eslint*
+      - .prettier*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: expo/expo-github-action@v6
+        with:
+          expo-version: 4.x
+          expo-cache: true
+          token: ${{ secrets.EXPO_PRODUCTION }}
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn tsc --noEmit
+      - run: yarn lint --max-warnings 0
+      # - run: yarn test --ci --maxWorkers 15%
+
+      - name: Deploy web-player
+        if: github.event.inputs.deploy == 'deploy'
+        run: yarn deploy:web:prod
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
+
+      - name: Deploy native runtime
+        if: github.event.inputs.deploy == 'deploy'
+        run: yarn deploy:prod
+
+      - name: Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always() && github.event.inputs.deploy == 'deploy'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Production
+          fields: message,commit,author,ref


### PR DESCRIPTION
# Why

Follow up to #180 to add deployment to production through "deploy" trigger.

# How

- Add CI action for this branch

# Test Plan

After merging, the CI step should run but not deploy. Upon succesful run, the "deploy" trigger should be run to verify deployment of the SDK 41 branch to production