### PR TITLE
[ci] Run runtime CI workflows for sdk-* branches

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -11,7 +11,9 @@ on:
         description: 'type "deploy" to confirm deploy to production (main branch only)'
         required: false
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-**'
     paths:
       - .github/workflows/runtime-production.yml
       - runtime/**
@@ -45,23 +47,23 @@ jobs:
       # - run: yarn test --ci --maxWorkers 15%
 
       - name: Deploy web-player
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        if: github.event.inputs.deploy == 'deploy'
         run: yarn deploy:web:prod
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
 
       - name: Deploy native runtime
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        if: github.event.inputs.deploy == 'deploy'
         run: yarn deploy:prod
 
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
-        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        if: always() && github.event.inputs.deploy == 'deploy'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:
           channel: '#snack'
           status: ${{ job.status }}
           author_name: Deploy Runtime to Production
-          fields: message,commit,author,took
+          fields: message,commit,author,ref

--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -47,19 +47,19 @@ jobs:
       # - run: yarn test --ci --maxWorkers 15%
 
       - name: Deploy web-player
-        if: github.event.inputs.deploy == 'deploy'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:web:prod
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
 
       - name: Deploy native runtime
-        if: github.event.inputs.deploy == 'deploy'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:prod
 
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
-        if: always() && github.event.inputs.deploy == 'deploy'
+        if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:

--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: 'type "deploy" to confirm deploy to production (main branch only)'
+        description: 'type "deploy" to confirm deploy to production (main or sdk-* branches only)'
         required: false
   push:
     branches:

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -6,7 +6,9 @@ defaults:
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-**'
     paths:
       - .github/workflows/runtime-staging.yml
       - runtime/**
@@ -42,23 +44,21 @@ jobs:
       # - run: yarn test --ci --maxWorkers 15%
 
       - name: Deploy web-player
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: yarn deploy:web:staging
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
 
       - name: Deploy native runtime
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         run: yarn deploy:staging
 
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
-        if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:
           channel: '#snack'
           status: ${{ job.status }}
           author_name: Deploy Runtime to Staging
-          fields: message,commit,author,took
+          fields: message,commit,author,ref

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -44,17 +44,19 @@ jobs:
       # - run: yarn test --ci --maxWorkers 15%
 
       - name: Deploy web-player
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         run: yarn deploy:web:staging
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
 
       - name: Deploy native runtime
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         run: yarn deploy:staging
 
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
-        if: always()
+        if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -6,7 +6,6 @@ defaults:
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - .github/workflows/runtime.yml
       - runtime/**


### PR DESCRIPTION
# Why

This PR updates the runtime CI actions to allow deployment to staging & production from `sdk-*` branches. The changes for this PR were tested on the `sdk-41` branch through #180 and #181. This PR ports them to the main branch so the changes will apply for future sdk versions as well.

# How

- Run generic Runtime workflow on any pull-request (instead of only PRs for `main`)
- Updated staging workflow to deploy when pushing to main or sdk-* branches
- Updated production workflow to deploy when pushing to main or sdk-* branches

# Test Plan

- Tested through PR #180 and #181
- Action that confirms the generic `Runtime` action runs on branches other than `main` 
  -https://github.com/expo/snack/actions/runs/1014691626
- Action that confirms succesful deployment of Runtime 41 to staging:
  - https://github.com/expo/snack/actions/runs/1014708028
- Actions that confirm succesful deployment of Runtime 41 to production:
  - https://github.com/expo/snack/actions/runs/1014748387
  - https://github.com/expo/snack/actions/runs/1014765302 