### PR TITLE
[website] enable snack.expo.dev for everyone

### DIFF
--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -5,8 +5,7 @@ export function isDevDomainEnabled(): boolean {
 
   if (!DEPLOY_ENVIRONMENT) return false;
 
-  if (['staging'].includes(DEPLOY_ENVIRONMENT)) return true;
-  if (['production'].includes(DEPLOY_ENVIRONMENT)) return false;
+  if (['staging', 'production'].includes(DEPLOY_ENVIRONMENT)) return true;
 
   return false;
 }


### PR DESCRIPTION
# Why

Today is Expo.dev day! We're starting with the main website (expo.dev) and Snack.

