### PR TITLE
[docs] Update to dev domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@
 </p>
 
 <p align="center">
-  <a href="https://snack.expo.io">Try Expo Snack at snack.expo.io</a>
+  <a href="https://snack.expo.dev">Try Expo Snack at snack.expo.dev</a>
 </p>
 
 Expo Snack is an open-source platform for running React Native apps in the browser. It dynamically bundles and compiles code and runs it in the Expo Client or in a web-player. Code can be saved as "Snacks" and easily shared with others. Snacks can also be embedded to show "live" previews as used by the [React Native documentation](https://reactnative.dev/docs/getting-started).
+
+> Snack has a new domain: snack.expo.dev!
+> [Read more about it here!](https://blog.expo.io/introducing-expo-dev-a70818bf336e)
 
 <!--
 > Requesting snacks in bug reports gives your users an easy, lightweight way to give you a minimal, complete, and verifiable example (https://stackoverflow.com/help/minimal-reproducible-example) and allows you to spend more time fixing real issues in your project rather than staring at copy pasted code or cloning someone's repository that may or may not demonstrate a real issue with your project.
@@ -38,10 +41,10 @@ Internal documentation
 
 - [`docs`](/docs) *Documentation and guides.*
 - [`packages`](/packages) *Shared packages.*
-  - [`snack-sdk`](/packages/snack-sdk) *Package for creating (custom) Snack experiences (used by [snack.expo.io](https://snack.expo.io)).*
+  - [`snack-sdk`](/packages/snack-sdk) *Package for creating (custom) Snack experiences (used by [snack.expo.dev](https://snack.expo.dev)).*
   - [`snack-sdk-legacy`](/packages/snack-sdk-legacy) *Legacy snack-sdk provided for completeness.*
   - [`snack-proxies`](/packages/snack-proxies) *Proxies for doing local development*
-- [`website`](/website) *The web-app for **https://snack.expo.io** and for **[embedded Snacks](https://snack.expo.io/embedded).***
+- [`website`](/website) *The web-app for **https://snack.expo.dev** and for **[embedded Snacks](https://snack.expo.dev/embedded).***
 - [`snackager`](/snackager) *The Snack package bundler at **https://snackager.expo.io**.*
 - [`runtime`](/runtime) *The Snack runtime app and web-player.*
 

--- a/docs/embedding-snacks.md
+++ b/docs/embedding-snacks.md
@@ -27,7 +27,7 @@ Snacks are a great way to show off what your library can do and let users explor
 </div>
 
 <!-- Load the embed.js script -->
-<script async src="https://snack.expo.io/embed.js"></script>
+<script async src="https://snack.expo.dev/embed.js"></script>
 ```
 
 The `embed.js` script scans the DOM and populates any elements containing a `data-snack-id` or `data-snack-code` attribute with an `<iframe>` displaying an embedded Snack. Attributes that start with `data-snack-` are converted to [Parameters](./url-query-parameters.md#parameters) and can be used to provide the contents of the Snack or override defaults.
@@ -51,7 +51,7 @@ The `embed.js` script scans the DOM and populates any elements containing a `dat
 ## Via link
 
 ```url
-https://snack.expo.io/?platform=android&name=Hello%20World&dependencies=react-navigation%40%5E4.0.10%2Creact-navigation-tabs%40%5E2.5.6%2Creact-navigation-stack%40%5E1.10.3%2Creact-navigation-drawer%40%5E2.3.3&sourceUrl=https%3A%2F%2Freactnavigation.org%2Fexamples%2F4.x%2Fhello-react-navigation.js
+https://snack.expo.dev/?platform=android&name=Hello%20World&dependencies=react-navigation%40%5E4.0.10%2Creact-navigation-tabs%40%5E2.5.6%2Creact-navigation-stack%40%5E1.10.3%2Creact-navigation-drawer%40%5E2.3.3&sourceUrl=https%3A%2F%2Freactnavigation.org%2Fexamples%2F4.x%2Fhello-react-navigation.js
 ```
 
 See [URLs and Parameters](./url-query-parameters.md#parameters) for all supported query arguments.

--- a/docs/expo-sdk-upgrade.md
+++ b/docs/expo-sdk-upgrade.md
@@ -89,14 +89,14 @@ The Expo documentation contains excellent examples for verifying Snack. The easi
 
 ### Checklist
 
-- Test snack.expo.io (with no id!)
+- Test snack.expo.dev (with no id!)
   - Open unsaved snack in app, make some changes, then hit save
-- Test existing snack.expo.io/ID (https://snack.expo.io/r1Xun_7eb)
+- Test existing snack.expo.dev/ID (https://snack.expo.dev/r1Xun_7eb)
   - Open that in the app, make some changes, save, and reload
-- Test existing permanent snack snack.expo.io/@username/project
+- Test existing permanent snack snack.expo.dev/@username/project
   - Open that in the app, make some changes, save, and reload
-- Open snack directly on phone without website open (https://expo.io/@snack/r1Xun_7eb)
-- Open permanent snack directly on phone without website open (https://expo.io/@username/project)
+- Open snack directly on phone without website open (https://expo.dev/@snack/r1Xun_7eb)
+- Open permanent snack directly on phone without website open (https://expo.dev/@username/project)
 - Open `website/snack-embed.html` to test embeds
 
 ## Pre-release snack-sdk

--- a/docs/hosts-ports.md
+++ b/docs/hosts-ports.md
@@ -4,11 +4,10 @@ The following hosts and ports are used by Snack.
 
 | Development | Staging | Production | Description |
 |---|---|---|---|
-| [localhost:3011](http://localhost:3011) ([snack.expo.test](http://snack.expo.test)) | [staging.snack.expo.dev](https://staging.snack.expo.dev) | [snack.expo.io](https://snack.expo.io) | Snack web-app located in `./website`. |
+| [localhost:3011](http://localhost:3011) ([snack.expo.test](http://snack.expo.test)) | [staging.snack.expo.dev](https://staging.snack.expo.dev) | [snack.expo.dev](https://snack.expo.dev) | Snack web-app located in `./website`. |
 | localhost:3012 (snackager.expo.test) | staging.snackager.expo.io | snackager.expo.io | Snackager bundler service. |
 | localhost:3000 | staging.exp.host | exp.host | The Expo API server. |
-| localhost:3001 | staging.expo.dev | expo.io | The Expo website. |
+| localhost:3001 | staging.expo.dev | expo.dev | The Expo website. |
 | localhost:3020 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo API server. Located in `./packages/snack-proxies`. |
 | localhost:3021 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo website. Located in `./packages/snack-proxies`. |
 | localhost:3022 | - | - | Proxy server that forwards and logs all requests to the local or staging Snackager service. Located in `./packages/snack-proxies`. |
-

--- a/docs/snack-sdk-api/README.md
+++ b/docs/snack-sdk-api/README.md
@@ -337,7 +337,7 @@ Name | Type | Description |
 `sdkVersion` | [SDKVersion](README.md#sdkversion) | Expo SDK version. |
 `sendBeaconCloseRequest?` | [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) | A close request that should be send using the browser `sendBeacon` API whenever the browser session is unloaded. This gives the Snack a last opportunity to gracefully close its connections so that the "Recently in Development" section in the Expo client no longer shows the Snack. |
 `unsaved` | boolean | Unsaved status of the Snack. Becomes `true` when the Snack code is changed and `false` whenever the Snack is saved. |
-`url` | string | Unique experience url which can be used to open the Expo client and connect to the Snack (e.g. "exp://expo.io/@snack/sdk.38.0.0-78173941"). |
+`url` | string | Unique experience url which can be used to open the Expo client and connect to the Snack (e.g. "exp://exp.host/@snack/sdk.38.0.0-78173941"). |
 `user?` | [SnackUser](README.md#snackuser) |  |
 `wantedDependencyVersions?` | [SnackDependencyVersions](README.md#snackdependencyversions) | Collection of packages and versions that are compatible with the selected SDK version. This is similar to using `expo install`, which ensures the latest compatible version is installed. |
 `webPreviewURL?` | undefined \| string | URL to use to when loading the web-preview in an iframe.  Web-preview is supported from SDK 40 and higher. To enable it, set the `webPreviewRef` to the contentWindow of the iframe.  |

--- a/docs/snack-sdk.md
+++ b/docs/snack-sdk.md
@@ -1,6 +1,6 @@
 # Snack SDK Documentation <!-- omit in toc -->
 
-The Expo Snack SDK. Use this to create a custom web interface for https://snack.expo.io/. 
+The Expo Snack SDK. Use this to create a custom web interface for https://snack.expo.dev/. 
 
 
 ## Index <!-- omit in toc -->
@@ -387,7 +387,7 @@ const snack = new Snack({
 });
 
 const { id, url } = await snack.saveAsync();
-console.log(url); // "exp://expo.io/@jsghakdshgs"
+console.log(url); // "exp://exp.host/@jsghakdshgs"
 ```
 
 To save the Snack to your user account, set the user in the constructor or using `setUser`.

--- a/docs/url-query-parameters.md
+++ b/docs/url-query-parameters.md
@@ -1,16 +1,19 @@
 # URLs and Parameters
 
-The main Snack website is hosted at [https://snack.expo.io](https://snack.expo.io) and can be loaded in embedded mode and with custom parameters.
+The main Snack website is hosted at [https://snack.expo.dev](https://snack.expo.dev) and can be loaded in embedded mode and with custom parameters.
+
+> Snack has been transitioned to the `.dev` domain! Any traffic to `snack.expo.io` is automatically
+> redirected to `snack.expo.dev`. [Read more about it here!](https://blog.expo.io/introducing-expo-dev-a70818bf336e)
 
 ## URLs
 
 | Path  | Description  |
 |---|---|
-| [https://snack.expo.io](https://snack.expo.io) | Default Snack website. |
-| [https://snack.expo.io/embedded](https://snack.expo.io/embedded) | Minimal embedded website. |
-| [https://snack.expo.io/{id}](https://snack.expo.io/mYtGTbIqv) | Loads a saved Snack. |
-| [https://snack.expo.io/embedded/{id}](https://snack.expo.io/embedded/mYtGTbIqv) | Loads a saved Snack using the minimal embedded website. |
-| [https://snack.expo.io/embed.js](https://snack.expo.io/embedded/mYtGTbIqv) | Loads the [Embed Script](./embedding-snacks.md) for including Snack embeds in your documentation. |
+| [https://snack.expo.dev](https://snack.expo.dev) | Default Snack website. |
+| [https://snack.expo.dev/embedded](https://snack.expo.dev/embedded) | Minimal embedded website. |
+| [https://snack.expo.dev/{id}](https://snack.expo.dev/mYtGTbIqv) | Loads a saved Snack. |
+| [https://snack.expo.dev/embedded/{id}](https://snack.expo.dev/embedded/mYtGTbIqv) | Loads a saved Snack using the minimal embedded website. |
+| [https://snack.expo.dev/embed.js](https://snack.expo.dev/embedded/mYtGTbIqv) | Loads the [Embed Script](./embedding-snacks.md) for including Snack embeds in your documentation. |
 
 ## Parameters
 
@@ -20,7 +23,7 @@ The main Snack website is hosted at [https://snack.expo.io](https://snack.expo.i
 | `description` | `&description=My%20Awesome%20Snack` | Description of the Snack. |
 | `dependencies` | `&dependencies=expo-image-picker,lodash%404` | Comma separated list of dependencies to include in the Snack. The dependency version is optional. When omitted the version that is compatible with the selected SDK version is used (similar to `expo install`). |
 | `files` | `&files=...` | Files that make up the Snack. This should be a URL encoded JSON object, see [Files](#Files). Causes the `code` parameter to be ignored when specified. |
-| `hideQueryParams` | `&hideQueryParams=true` |  Removes (hides) the query arguments from the browser address bar (defaults to `false`). You can use this argument to show a clean url to the user (e.g. `https://snack.expo.io`, instead of `https://snack.expo.io?name=foo&dependencies=...&theme=dark&sourceUrl=...`). |
+| `hideQueryParams` | `&hideQueryParams=true` |  Removes (hides) the query arguments from the browser address bar (defaults to `false`). You can use this argument to show a clean url to the user (e.g. `https://snack.expo.dev`, instead of `https://snack.expo.dev?name=foo&dependencies=...&theme=dark&sourceUrl=...`). |
 | `name` | `&name=My%20Demo` | Name of the Snack. Defaults to an auto-generated name. |
 | `platform`| `&platform=web` | The default platform to preview the Snack on. Defaults to `web` which will run as soon as your users see the Snack. Valid values: `ios`, `android`, `web`, `mydevice`. |
 | `preview`| `&preview=true` | Shows or hides preview pane. Defaults to `false` on embedded Snacks. Valid values: `true`, `false`. |
@@ -64,5 +67,5 @@ const files = {
 };
 
 // URL example
-const url = `https://snack.expo.io?files=${encodeURIComponent(JSON.stringify(files))}`;
+const url = `https://snack.expo.dev?files=${encodeURIComponent(JSON.stringify(files))}`;
 ```

--- a/packages/snack-sdk/README.md
+++ b/packages/snack-sdk/README.md
@@ -1,6 +1,6 @@
 # snack-sdk
 
-The Expo Snack SDK. Use this to create a custom web interface for https://snack.expo.io/. 
+The Expo Snack SDK. Use this to create a custom web interface for https://snack.expo.dev/. 
 
 ## 📚 Documentation
 

--- a/packages/snack-sdk/src/__mocks__/window.ts
+++ b/packages/snack-sdk/src/__mocks__/window.ts
@@ -43,7 +43,7 @@ let globalWindowMock: any;
 
 beforeEach(() => {
   globalWindowMock = new Window({
-    location: 'https://snack.expo.io',
+    location: 'https://snack.expo.dev',
   });
   Object.keys(globalWindowMock).forEach((key) => {
     // @ts-ignore
@@ -52,5 +52,5 @@ beforeEach(() => {
 });
 
 export function postMessage(message: any, origin?: string) {
-  globalWindowMock.postMessage(message, origin ?? 'https://snack.expo.io');
+  globalWindowMock.postMessage(message, origin ?? 'https://snack.expo.dev');
 }

--- a/runtime/src/BarCodeScannerView.native.tsx
+++ b/runtime/src/BarCodeScannerView.native.tsx
@@ -47,7 +47,7 @@ export default class BarCodeScannerView extends React.Component<Props, State> {
         <View style={styles.container}>
           <Text style={styles.initialURL}>{`Launch URL: ${initialURL}`}</Text>
           <Text style={styles.paragraph}>
-            Open up https://snack.expo.io and scan the QR code to get started!
+            Open up https://snack.expo.dev and scan the QR code to get started!
             {'\n'}
             {'\n'}
             Make sure to leave the web page open while you are running the project.

--- a/runtime/src/Messaging.web.tsx
+++ b/runtime/src/Messaging.web.tsx
@@ -27,8 +27,8 @@ const listeners: Listener[] = [];
  * - Origin is checked against a white-list of allowed origins.
  *
  * Scenarios:
- * [snack.expo.io] -> [https://s3.webplayer?origin=snack.expo.io] (allowed)
- * [snack.expo.io] -> [https://s3.webplayer?origin=expo.io] (allowed, but fails on postMessage & recv message check)
+ * [snack.expo.dev] -> [https://s3.webplayer?origin=snack.expo.dev] (allowed)
+ * [snack.expo.dev] -> [https://s3.webplayer?origin=expo.dev] (allowed, but fails on postMessage & recv message check)
  * [badsite.com] -> [https://s3.webplayer?origin=badsite.com] (disallowed)
  * [badsite.com] -> [https://s3.webplayer?origin=snack.expo.io] (allowed, but fails on postMessage & recv message check)
  */

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # website
 
-This is the web app for [snack.expo.io](https://snack.expo.io/) and for [embedded Snacks](https://snack.expo.io/embedded).
+This is the web app for [snack.expo.dev](https://snack.expo.dev/) and for [embedded Snacks](https://snack.expo.dev/embedded).
 
 ## Getting started
 

--- a/website/snack-embed.html
+++ b/website/snack-embed.html
@@ -17,9 +17,9 @@
 
 
     embedded named snack
-   <iframe src='http://snack.expo.io/embedded/@react-navigation/hello-react-navigation' frameborder='0' style='display: block;border:1px solid rgba(0,0,0,.16);border-radius:4px;height:500px; width:700px'></iframe>
+   <iframe src='http://snack.expo.dev/embedded/@react-navigation/hello-react-navigation' frameborder='0' style='display: block;border:1px solid rgba(0,0,0,.16);border-radius:4px;height:500px; width:700px'></iframe>
 
-    <iframe src='http://snack.expo.io/embedded/@react-navigation/hello-react-navigation' height='100%' width='100%' frameborder='0' style='display: block;border:1px solid rgba(0,0,0,.16);border-radius:4px;height:400px; width:600px'></iframe>
+    <iframe src='http://snack.expo.dev/embedded/@react-navigation/hello-react-navigation' height='100%' width='100%' frameborder='0' style='display: block;border:1px solid rgba(0,0,0,.16);border-radius:4px;height:400px; width:600px'></iframe>
 
     embed script ios
 <div data-snack-id="ry5fCdnnB" data-snack-supported-platforms="ios" data-snack-preview="true" style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.16);border-radius:4px;height:514px;width:70%"></div>

--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -2,7 +2,7 @@ import { SDKVersion } from 'snack-sdk';
 
 /**
  * Setting the value to `false` will hide the version from the version picker.
- * It can be selected by specifying `?sdkVersion=99.0.0` in the URL. Ex: http://snack.expo.io?sdkVersion=99.0.0
+ * It can be selected by specifying `?sdkVersion=99.0.0` in the URL. Ex: http://snack.expo.dev?sdkVersion=99.0.0
  * This is useful when deploying the website  with preliminary support for a new SDK version.
  */
 export const versions: Record<SDKVersion, boolean> = {


### PR DESCRIPTION
# Why

Updates the URLs in the documentation to refer to `.dev` when it comes to `expo.io` and `snack.expo.io`. This also adds a small sub-banner which informs the  users of the transition to the `.dev` domain.

![image](https://user-images.githubusercontent.com/6184593/126468333-f5628762-484e-4b67-9875-f1a5ad165ce9.png)

![image](https://user-images.githubusercontent.com/6184593/126468283-69344531-b273-4a8a-b2d0-d3a4da385ae8.png)

# How

- Update `expo.io` -> `expo.dev`
- Update `snack.expo.io` -> `snack.expo.dev`
- Fix several `exp://` urls which were still using `.io` (should have been `exp.host`)
- Add banners to inform users of change to `.dev`

# Test Plan

- :eyes:
- All tests pass