### PR TITLE
[snackager] Fix incorrect webpack 4 config for webpack 5

### DIFF
--- a/snackager/src/bundler/makeConfig.ts
+++ b/snackager/src/bundler/makeConfig.ts
@@ -52,8 +52,10 @@ export default ({
       }),
     ],
     module: {
+      parser: {
+        javascript: { requireEnsure: false },
+      },
       rules: [
-        { parser: { requireEnsure: false } },
         {
           test: /\.mjs/,
           resolve: { fullySpecified: false },


### PR DESCRIPTION
# Why

It seems that `aws-amplify@4.2.0` triggered an incorrect `require.ensure` configuration in Webpack. Previously was throwing this error:

```
Error: Module not found: ValidationError: Invalid parser object. Json Modules Plugin has been initialized using a parser object that does not match the API schema.
 - parser has an unknown property 'requireEnsure'. These properties are valid:
   object { parse? }
Module not found: ValidationError: Invalid parser object. Json Modules Plugin has been initialized using a parser object that does not match the API schema.
 - parser has an unknown property 'requireEnsure'. These properties are valid:
   object { parse? }
Module not found: ValidationError: Invalid parser object. Json Modules Plugin has been initialized using a parser object that does not match the API schema.
 - parser has an unknown property 'requireEnsure'. These properties are valid:
   object { parse? }
...
```

With this change, from [the Webpack 5 docs](https://webpack.js.org/configuration/module/#moduleparser), it should be set properly.

There are more things going on with this library that I'm not happy about, e.g.:

```
aws-amplify@4.2.0 Dependency found on \"@react-native-async-storage/async-storage\" that is required for bundling, but its version is not defined in package.json. Using \"*\" instead.

aws-amplify@4.2.0 Dependency found on \"@react-native-community/netinfo\" that is required for bundling, but its version is not defined in package.json. Using \"*\" instead.
```

# How

- `$ yarn bundle aws-amplify@4.2.0`
- Check logs

# Test Plan

I don't like to add `aws-amplify` as test case in our E2E tests, it's amazingly big and will take a couple of minutes before finishing. Maybe it's good to have as a manual test case when we edit Webpack config.
