### PR TITLE
[website] Fix misspelling of "spontaneous"

### DIFF
--- a/website/src/client/utils/projectNames.tsx
+++ b/website/src/client/utils/projectNames.tsx
@@ -41,7 +41,7 @@ const emotions = [
   'smiling',
   'grounded',
   'trusting',
-  'sponaneous',
+  'spontaneous',
   'healthy',
   'laughing',
   'graceful',


### PR DESCRIPTION
# Why

`spontaneous` is misspelt in `emotions` array.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
