### PR TITLE
[website] Fix initial editor height

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -69,6 +69,7 @@
     "react-dom": "^16.8.1",
     "react-helmet-async": "^0.2.0",
     "react-redux": "^6.0.0",
+    "react-resize-detector": "^6.7.4",
     "react-router-dom": "^4.4.0-beta.6",
     "react-simple-code-editor": "^0.11.0",
     "react-textarea-autosize": "^7.1.0",

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -651,7 +651,7 @@ class MonacoEditor extends React.Component<Props, State> {
     }
   };
 
-  _handleResize = debounce(() => this._editor?.layout(), 50, {
+  _handleResize = debounce((_width?: number, _height?: number) => this._editor?.layout(), 50, {
     leading: true,
     trailing: true,
   });

--- a/website/src/client/components/shared/ResizeDetector.tsx
+++ b/website/src/client/components/shared/ResizeDetector.tsx
@@ -1,45 +1,19 @@
 import { StyleSheet, css } from 'aphrodite';
 import * as React from 'react';
+import { useResizeDetector } from 'react-resize-detector';
 
 type Props = {
-  onResize: () => void;
+  onResize: (width?: number | undefined, height?: number | undefined) => void;
   children: React.ReactNode;
 };
 
-export default class ResizeDetector extends React.Component<Props> {
-  componentDidMount() {
-    const horiz = this._horizontal.current;
-    const verti = this._vertical.current;
-
-    horiz?.contentWindow?.addEventListener('resize', this._handleResize);
-
-    verti?.contentWindow?.addEventListener('resize', this._handleResize);
-  }
-
-  componentWillUnmount() {
-    const horiz = this._horizontal.current;
-    const verti = this._vertical.current;
-
-    horiz?.contentWindow?.removeEventListener('resize', this._handleResize);
-
-    verti?.contentWindow?.removeEventListener('resize', this._handleResize);
-  }
-
-  _handleResize = () => this.props.onResize();
-
-  _horizontal = React.createRef<HTMLIFrameElement>();
-  _vertical = React.createRef<HTMLIFrameElement>();
-
-  render() {
-    return (
-      <div className={css(styles.container)}>
-        {/* pointer-events: none is not working properly on EDGE, so we render 2 iframes to detect resize instead of one iframe covering the entire editor */}
-        <iframe ref={this._horizontal} className={css(styles.phantom, styles.horizontal)} />
-        <iframe ref={this._vertical} className={css(styles.phantom, styles.vertical)} />
-        {this.props.children}
-      </div>
-    );
-  }
+export default function ResizeDetector(props: Props) {
+  const { ref } = useResizeDetector({ onResize: props.onResize });
+  return (
+    <div ref={ref} className={css(styles.container)}>
+      {props.children}
+    </div>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -50,21 +24,5 @@ const styles = StyleSheet.create({
     minWidth: 0,
     minHeight: 0,
     position: 'relative',
-  },
-  phantom: {
-    display: 'block',
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    pointerEvents: 'none',
-    opacity: 0,
-  },
-  horizontal: {
-    height: 1,
-    width: '100%',
-  },
-  vertical: {
-    height: '100%',
-    width: 1,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,6 +2930,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/resize-observer-browser@^0.1.5":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz#d8e6c2f830e2650dc06fe74464472ff64b54a302"
+  integrity sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg==
+
 "@types/sanitize-html@^1.18.2":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.27.0.tgz#77702dc856f16efecc005014c1d2e45b1f2cbc56"
@@ -9422,6 +9427,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash@4.x, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.5.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -11459,6 +11469,16 @@ react-refresh@^0.4.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
   integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
 
+react-resize-detector@^6.7.4:
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-6.7.4.tgz#594cc026115af05484e8011157b5dc2137492680"
+  integrity sha512-wzvGmUdEDMhiUHVZGnl4kuyj/TEQhvbB5LyAGkbYXetwJ2O+u/zftmPvU+kxiO1h+d9aUqQBKcNLS7TvB3ytqA==
+  dependencies:
+    "@types/resize-observer-browser" "^0.1.5"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    resize-observer-polyfill "^1.5.1"
+
 react-router-dom@^4.4.0-beta.6:
   version "4.4.0-beta.8"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.4.0-beta.8.tgz#bc85cb4bdc9347f5fe270f3e4555cd5038ae7a9f"
@@ -11885,6 +11905,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Why

Fixes the initial Monaco editor height. This problem started appearing in Chrome recently and has also been appearing in Firefox. Reported by @EvanBacon 

![image](https://user-images.githubusercontent.com/6184593/127474499-a97e6ce2-417b-450d-9ab8-c9eca765727e.png)

# How

- Use `react-resize-detector` to detect size changes

# Test Plan

- Verified on Chrome 92 locally (mac)
- Verified on Firefox 90 locally (mac)
- Verified on Safari 14.1.2 locally (mac)
- Verified on Edge 92 locally (mac)