### PR TITLE
[website] make snack.expo.dev redirect permanent

### DIFF
--- a/website/src/client/utils/getWebsiteURL.ts
+++ b/website/src/client/utils/getWebsiteURL.ts
@@ -1,9 +1,7 @@
-import { isDevDomainEnabled } from '../../expo-dev-migration';
-
 export function getWebsiteURL() {
-  return isDevDomainEnabled() ? process.env.SERVER_URL : process.env.LEGACY_SERVER_URL;
+  return process.env.SERVER_URL;
 }
 
 export function getSnackWebsiteURL() {
-  return isDevDomainEnabled() ? process.env.SNACK_SERVER_URL : process.env.LEGACY_SNACK_SERVER_URL;
+  return process.env.SNACK_SERVER_URL;
 }

--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -1,19 +1,8 @@
 import { Context } from 'koa';
 
-export function isDevDomainEnabled(): boolean {
-  const DEPLOY_ENVIRONMENT = process.env.DEPLOY_ENVIRONMENT;
-
-  if (!DEPLOY_ENVIRONMENT) return false;
-
-  if (['staging', 'production'].includes(DEPLOY_ENVIRONMENT)) return true;
-
-  return false;
-}
-
 export function redirectToDevDomain(ctx: Context): boolean {
   // if the incoming request is from snack.expo.io, redirect to snack.expo.dev
   if (
-    isDevDomainEnabled() &&
     `${ctx.protocol}://${ctx.hostname}` === process.env.LEGACY_SNACK_SERVER_URL &&
     process.env.SNACK_SERVER_URL
   ) {

--- a/website/src/expo-dev-migration/index.ts
+++ b/website/src/expo-dev-migration/index.ts
@@ -17,22 +17,7 @@ export function redirectToDevDomain(ctx: Context): boolean {
     `${ctx.protocol}://${ctx.hostname}` === process.env.LEGACY_SNACK_SERVER_URL &&
     process.env.SNACK_SERVER_URL
   ) {
-    ctx.redirect(`${process.env.SNACK_SERVER_URL}${ctx.req.url}`);
-    return true;
-  } else {
-    return false;
-  }
-}
-
-// in the case that we need to rollback the domain redirect,
-// run this function in place of redirectToDevDomain
-export function redirectToIoDomain(ctx: Context): boolean {
-  // if the incoming request is from snack.expo.dev, redirect to snack.expo.io
-  if (
-    isDevDomainEnabled() &&
-    `${ctx.protocol}://${ctx.hostname}` === process.env.SNACK_SERVER_URL &&
-    process.env.LEGACY_SNACK_SERVER_URL
-  ) {
+    ctx.status = 308;
     ctx.redirect(`${process.env.SNACK_SERVER_URL}${ctx.req.url}`);
     return true;
   } else {


### PR DESCRIPTION
# Why

The main website and Snack have been migrated for a while now, we so should make this redirect permanent to signal which is the main website for SEO purposes.

# How

Changed response status to 308 and removed reversal code.

