### PR TITLE
[website] Fix ResizeObserver loop

### DIFF
--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -650,10 +650,7 @@ class MonacoEditor extends React.Component<Props, State> {
     }
   };
 
-  _handleResize = (_width?: number, _height?: number) => {
-    console.log('onResize', _width, _height);
-    this._editor?.layout();
-  };
+  _handleResize = (_width?: number, _height?: number) => this._editor?.layout();
 
   _typingsWorker: Worker | undefined;
   _disposables: monaco.IDisposable[] = [];

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -1,6 +1,5 @@
 import { StyleSheet, css } from 'aphrodite';
 import classnames from 'classnames';
-import debounce from 'lodash/debounce';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.main';
 import { SimpleEditorModelResolverService } from 'monaco-editor/esm/vs/editor/standalone/browser/simpleServices';
 import { StaticServices } from 'monaco-editor/esm/vs/editor/standalone/browser/standaloneServices';
@@ -651,10 +650,10 @@ class MonacoEditor extends React.Component<Props, State> {
     }
   };
 
-  _handleResize = debounce((_width?: number, _height?: number) => this._editor?.layout(), 50, {
-    leading: true,
-    trailing: true,
-  });
+  _handleResize = (_width?: number, _height?: number) => {
+    console.log('onResize', _width, _height);
+    this._editor?.layout();
+  };
 
   _typingsWorker: Worker | undefined;
   _disposables: monaco.IDisposable[] = [];

--- a/website/src/client/components/shared/ResizeDetector.tsx
+++ b/website/src/client/components/shared/ResizeDetector.tsx
@@ -8,7 +8,15 @@ type Props = {
 };
 
 export default function ResizeDetector(props: Props) {
-  const { ref } = useResizeDetector({ onResize: props.onResize });
+  const { ref } = useResizeDetector({
+    onResize: props.onResize,
+    refreshMode: 'debounce',
+    refreshRate: 50,
+    refreshOptions: {
+      leading: true,
+      trailing: true,
+    },
+  });
   return (
     <div ref={ref} className={css(styles.container)}>
       {props.children}


### PR DESCRIPTION
# Why

Fixes `ResizeObserver loop limit exceeded` error reported in Sentry. Problem was introduced in PR #189.

![image](https://user-images.githubusercontent.com/6184593/128329507-52640069-5190-4166-98d5-18df0964d980.png)

More information: https://github.com/maslianok/react-resize-detector/issues/45

# How

- Use `debounce` mode for `useResizeDetector`

# Test Plan

- Verified resizing works as expected and does not produce any errors locally
- Was unable to reproduce the original error, so not able to verify it fixes the reported problem. As per described [here](https://github.com/maslianok/react-resize-detector/issues/45), assuming this fixes the reported error.
- All tests pass