### PR TITLE
[ci] Add appetize workflow to check and deploy new simulator builds

### DIFF
--- a/.github/workflows/appetize.yml
+++ b/.github/workflows/appetize.yml
@@ -1,0 +1,162 @@
+name: Appetize
+
+on:
+  workflow_dispatch:
+    inputs:
+      appetizeQueue:
+        description: Appetize queue to use (main/embed/all)
+        default: main
+        required: true
+      sdkPlatform:
+        description: Platform to use (android/ios/all)
+        default: all
+        required: true
+      sdkVersion:
+        description: SDK version to resolve Expo Go version (e.g. 42.0.0)
+        required: false
+      deploy:
+        description: type "deploy" to update Appetize (without this it only checks the version)
+        required: false
+
+jobs:
+  android:
+    if: contains('all android', github.event.inputs.sdkPlatform)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Appetize (main) version
+        if: contains('all main', github.event.inputs.appetizeQueue)
+        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        run: |
+          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
+          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
+          rm -rf appetize.json
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_ANDROID }}
+      
+      - name: Resolve Appetize (embed) version
+        if: contains('all embed', github.event.inputs.appetizeQueue)
+        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        run: |
+          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
+          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
+          rm -rf appetize.json
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_ANDROID }}
+
+      - name: Resolve Android client
+        if: github.event.inputs.sdkVersion
+        id: android
+        run: |
+          curl --silent -o versions.json https://exp.host/--/api/v2/versions
+
+          VERSION=${{ github.event.inputs.sdkVersion }}
+          CLIENT_URL=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].androidClientUrl)
+          CLIENT_VERSION=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].androidClientVersion)
+          
+          if [ "${CLIENT_URL}" == "null" ]; then echo "No client url for SDK '$VERSION'"; exit 1; fi
+          if [ "${CLIENT_VERSION}" == "null" ]; then echo "No client version for SDK '$VERSION'"; exit 1; fi
+
+          echo "Resolved client $CLIENT_VERSION from SDK $VERSION"
+          echo "::set-output name=url::$CLIENT_URL"
+          echo "::set-output name=version::$CLIENT_VERSION"
+      
+      - name: Download Android client
+        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        run: curl -o exponent-android.apk ${{ steps.android.outputs.url }}
+
+      - name: Upload to Appetize (main)
+        if: contains('all main', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        # This step MUST NOT output anything, the endpoint returns the public and private app keys
+        run: |
+          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
+          rm -rf exponent-android.apk
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_ANDROID }}
+
+      - name: Upload to Appetize (embed)
+        if: contains('all embed', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        # This step MUST NOT output anything, the endpoint returns the public and private app keys
+        run: |
+          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
+          rm -rf exponent-android.apk
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_ANDROID }}
+  
+  ios:
+    if: contains('all ios', github.event.inputs.sdkPlatform)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Appetize (main) version
+        if: contains('all main', github.event.inputs.appetizeQueue)
+        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        run: |
+          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
+          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
+          rm -rf appetize.json
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_IOS }}
+      
+      - name: Resolve Appetize (embed) version
+        if: contains('all embed', github.event.inputs.appetizeQueue)
+        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        run: |
+          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
+          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
+          rm -rf appetize.json
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_IOS }}
+      
+      - name: Resolve iOS client
+        if: github.event.inputs.sdkVersion
+        id: ios
+        run: |
+          curl --silent -o versions.json https://exp.host/--/api/v2/versions
+
+          VERSION=${{ github.event.inputs.sdkVersion }}
+          CLIENT_URL=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].iosClientUrl)
+          CLIENT_VERSION=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].iosClientVersion)
+          
+          if [ "${CLIENT_URL}" == "null" ]; then echo "No client url for SDK '$VERSION'"; exit 1; fi
+          if [ "${CLIENT_VERSION}" == "null" ]; then echo "No client version for SDK '$VERSION'"; exit 1; fi
+
+          echo "Resolved client $CLIENT_VERSION from SDK $VERSION"
+          echo "::set-output name=url::$CLIENT_URL"
+          echo "::set-output name=version::$CLIENT_VERSION"
+
+      - name: Download iOS client
+        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        run: curl -o exponent-ios.tar.gz ${{ steps.ios.outputs.url }}
+
+      - name: Prepare iOS package
+        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        run: |
+          mkdir exponent-ios.app
+          tar -xf exponent-ios.tar.gz -C exponent-ios.app
+          zip -q -r exponent-ios.zip exponent-ios.app
+          rm -rf exponent-ios.app exponent-ios.tar.gz
+
+      - name: Upload to Appetize (main)
+        if: contains('all main', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        # This step MUST NOT output anything, the endpoint returns the public and private app keys
+        run: |
+          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
+          rm -rf exponent-ios.zip
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_IOS }}
+
+      - name: Upload to Appetize (embed)
+        if: contains('all embed', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+        # This step MUST NOT output anything, the endpoint returns the public and private app keys
+        run: |
+          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
+          rm -rf exponent-ios.zip
+        env:
+          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
+          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_IOS }}

--- a/.github/workflows/appetize.yml
+++ b/.github/workflows/appetize.yml
@@ -19,144 +19,157 @@ on:
         required: false
 
 jobs:
+  prepare:
+    name: Preparing deploy
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.result }}
+    steps:
+      - name: 📋 Download SDK information
+        run: curl --silent -o versions.json https://exp.host/--/api/v2/versions
+      - name: 🔍 Resolve SDK versions
+        uses: actions/github-script@v4
+        if: github.event.inputs.sdkVersion
+        id: sdk
+        with:
+          script: |
+            const { sdkVersions } = require('./versions.json')
+            const version = '${{ github.event.inputs.sdkVersion }}'
+            const sdk = sdkVersions[version];
+
+            if (!sdk) throw new Error(`Could not find SDK "${version}"`)
+
+            core.info(`Resolved client versions for SDK "${version}"`)
+            core.info(`  - Android: ${sdk.androidClientVersion}`)
+            core.info(`  - iOS: ${sdk.iosClientVersion}`)
+
+            for (const key of ['androidClientVersion', 'androidClientUrl', 'iosClientUrl', 'iosClientVersion']) {
+              core.setOutput(key, sdk && sdk[key] ? sdk[key] : '')
+            }
+      - name: 👷‍♀️ Prepare tasks
+        uses: actions/github-script@v4
+        id: matrix
+        with:
+          script: |
+            const allQueues = ['main', 'embed']
+            const queue = '${{ github.event.inputs.appetizeQueue }}'
+
+            return {
+              include: allQueues
+                .filter(name => queue === 'all' || queue === name)
+                .map(name => ({
+                  appetize: name.toUpperCase(),
+                  androidUrl: '${{ steps.sdk.outputs.androidClientUrl }}',
+                  androidVersion: '${{ steps.sdk.outputs.androidClientVersion }}',
+                  iosUrl: '${{ steps.sdk.outputs.iosClientUrl }}',
+                  iosVersion: '${{ steps.sdk.outputs.iosClientVersion }}',
+                }))
+            }
+
   android:
     if: contains('all android', github.event.inputs.sdkPlatform)
+    needs: prepare
+    name: Deploy Android on ${{ matrix.appetize }}
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - name: Resolve Appetize (main) version
-        if: contains('all main', github.event.inputs.appetizeQueue)
+      - name: 📋 Download Appetize information
         # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
-        run: |
-          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
-          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
-          rm -rf appetize.json
+        run: curl --silent --fail -o appetize.json https://$TOKEN@api.appetize.io/v1/apps/$APP > /dev/null
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_ANDROID }}
+          TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
+          APP: ${{ secrets[format('APPETIZE_{0}_ANDROID', matrix.appetize)] }}
+
+      - name: 🔍 Resolve Appetize version
+        uses: actions/github-script@v4
+        id: appetize
+        with:
+          script: |
+            const { appVersionName } = require('./appetize.json') || {};
+            if (!appVersionName) throw new Error('Invalid Appetize response')
+            core.setOutput('oldVersion', appVersionName)
+
+      - name: 📱 Download Android client (${{ matrix.androidVersion }})
+        if: github.event.inputs.deploy == 'deploy'
+        run: curl -o exponent-android.apk ${{ matrix.androidUrl }}
       
-      - name: Resolve Appetize (embed) version
-        if: contains('all embed', github.event.inputs.appetizeQueue)
-        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
-        run: |
-          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
-          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
-          rm -rf appetize.json
-        env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_ANDROID }}
-
-      - name: Resolve Android client
-        if: github.event.inputs.sdkVersion
-        id: android
-        run: |
-          curl --silent -o versions.json https://exp.host/--/api/v2/versions
-
-          VERSION=${{ github.event.inputs.sdkVersion }}
-          CLIENT_URL=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].androidClientUrl)
-          CLIENT_VERSION=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].androidClientVersion)
-          
-          if [ "${CLIENT_URL}" == "null" ]; then echo "No client url for SDK '$VERSION'"; exit 1; fi
-          if [ "${CLIENT_VERSION}" == "null" ]; then echo "No client version for SDK '$VERSION'"; exit 1; fi
-
-          echo "Resolved client $CLIENT_VERSION from SDK $VERSION"
-          echo "::set-output name=url::$CLIENT_URL"
-          echo "::set-output name=version::$CLIENT_VERSION"
-      
-      - name: Download Android client
-        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
-        run: curl -o exponent-android.apk ${{ steps.android.outputs.url }}
-
-      - name: Upload to Appetize (main)
-        if: contains('all main', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+      - name: 🚀 Upload to Appetize
+        if: github.event.inputs.deploy == 'deploy'
         # This step MUST NOT output anything, the endpoint returns the public and private app keys
         run: |
-          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
-          rm -rf exponent-android.apk
+          curl --silent --fail --http1.1 https://$TOKEN@api.appetize.io/v1/apps/$APP -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
+          rm -rf exponent-android.apk appetize.json
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_ANDROID }}
+          TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
+          APP: ${{ secrets[format('APPETIZE_{0}_ANDROID', matrix.appetize)] }}
 
-      - name: Upload to Appetize (embed)
-        if: contains('all embed', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
-        # This step MUST NOT output anything, the endpoint returns the public and private app keys
-        run: |
-          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
-          rm -rf exponent-android.apk
+      - name: 📢 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: always() && github.event.inputs.deploy == 'deploy'
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_ANDROID }}
-  
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Android (${{ steps.appetize.outputs.oldVersion }} -> ${{ matrix.androidVersion }}) on ${{ matrix.appetize }} 
+          fields: author
+
   ios:
     if: contains('all ios', github.event.inputs.sdkPlatform)
+    needs: prepare
+    name: Deploy iOS on ${{ matrix.appetize }}
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
-      - name: Resolve Appetize (main) version
-        if: contains('all main', github.event.inputs.appetizeQueue)
+      - name: 📋 Download Appetize information
         # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
-        run: |
-          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
-          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
-          rm -rf appetize.json
+        run: curl --silent --fail -o appetize.json https://$TOKEN@api.appetize.io/v1/apps/$APP > /dev/null
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_IOS }}
+          TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
+          APP: ${{ secrets[format('APPETIZE_{0}_IOS', matrix.appetize)] }}
+
+      - name: 🔍 Resolve Appetize version
+        uses: actions/github-script@v4
+        id: appetize
+        with:
+          script: |
+            const { appVersionName } = require('./appetize.json') || {};
+            if (!appVersionName) throw new Error('Invalid Appetize response')
+            core.setOutput('oldVersion', appVersionName)
       
-      - name: Resolve Appetize (embed) version
-        if: contains('all embed', github.event.inputs.appetizeQueue)
-        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
-        run: |
-          curl --silent -o appetize.json https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP > /dev/null
-          echo "Appetize is running $(cat appetize.json | jq .appVersionName)"
-          rm -rf appetize.json
-        env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_IOS }}
-      
-      - name: Resolve iOS client
-        if: github.event.inputs.sdkVersion
-        id: ios
-        run: |
-          curl --silent -o versions.json https://exp.host/--/api/v2/versions
+      - name: 📱 Download iOS client (${{ matrix.iosVersion }})
+        if: github.event.inputs.deploy == 'deploy'
+        run: curl -o exponent-ios.tar.gz ${{ matrix.iosUrl }}
 
-          VERSION=${{ github.event.inputs.sdkVersion }}
-          CLIENT_URL=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].iosClientUrl)
-          CLIENT_VERSION=$(cat versions.json | jq .sdkVersions[\"$VERSION\"].iosClientVersion)
-          
-          if [ "${CLIENT_URL}" == "null" ]; then echo "No client url for SDK '$VERSION'"; exit 1; fi
-          if [ "${CLIENT_VERSION}" == "null" ]; then echo "No client version for SDK '$VERSION'"; exit 1; fi
-
-          echo "Resolved client $CLIENT_VERSION from SDK $VERSION"
-          echo "::set-output name=url::$CLIENT_URL"
-          echo "::set-output name=version::$CLIENT_VERSION"
-
-      - name: Download iOS client
-        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
-        run: curl -o exponent-ios.tar.gz ${{ steps.ios.outputs.url }}
-
-      - name: Prepare iOS package
-        if: github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+      - name: 📦 Prepare iOS package
+        if: github.event.inputs.deploy == 'deploy'
         run: |
           mkdir exponent-ios.app
           tar -xf exponent-ios.tar.gz -C exponent-ios.app
           zip -q -r exponent-ios.zip exponent-ios.app
           rm -rf exponent-ios.app exponent-ios.tar.gz
 
-      - name: Upload to Appetize (main)
-        if: contains('all main', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
+      - name: 🚀 Upload to Appetize
+        if: github.event.inputs.deploy == 'deploy'
         # This step MUST NOT output anything, the endpoint returns the public and private app keys
         run: |
-          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
-          rm -rf exponent-ios.zip
+          curl --silent --fail --http1.1 https://$TOKEN@api.appetize.io/v1/apps/$APP -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
+          rm -rf exponent-ios.zip appetize.json
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_MAIN_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_MAIN_IOS }}
+          TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
+          APP: ${{ secrets[format('APPETIZE_{0}_IOS', matrix.appetize)] }}
 
-      - name: Upload to Appetize (embed)
-        if: contains('all embed', github.event.inputs.appetizeQueue) && github.event.inputs.deploy == 'deploy' && github.event.inputs.sdkVersion
-        # This step MUST NOT output anything, the endpoint returns the public and private app keys
-        run: |
-          curl --silent --http1.1 https://$APPETIZE_TOKEN@api.appetize.io/v1/apps/$APPETIZE_APP -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
-          rm -rf exponent-ios.zip
+      - name: 📢 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: always() && github.event.inputs.deploy == 'deploy'
         env:
-          APPETIZE_TOKEN: ${{ secrets.APPETIZE_EMBED_TOKEN }}
-          APPETIZE_APP: ${{ secrets.APPETIZE_EMBED_IOS }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy iOS (${{ steps.appetize.outputs.oldVersion }} -> ${{ matrix.androidVersion }}) on ${{ matrix.appetize }} 
+          fields: author


### PR DESCRIPTION
# Why

We have almost all of the Snack development workflow in Github, except for Appetize. It's a manual step that requires some attention. This should fix that by adding a check & deploy workflow for Appetize.

# How

The workflow contains a couple of steps, with small differences for Android and iOS:

1. Resolve the current version on Appetize (main, embedded, or both queues)
2. Resolve the client version it _should have_ from SDK version
3. Download the client for the specified version
4. Prepare the client for Appetize (iOS only)
5. Upload the client to Appetize (main, embedded, or both queues)

With the inputs, we have a "double failsafe" to prevent undesired deployments. You both have to specify the exact SDK version to use, and you have to confirm with "deploy".

- When omitting both `deploy` and `sdkVersion`, only step 1 is executed.
- When omitting `deploy` but defining `sdkVersion`, steps 1 and 2 are executed.
- When defining both `deploy` and `sdkVersion`, all steps are executed.

# Required Environment variables

> ~~I haven't set these up yet!~~ Done, all set up! Thanks @tcdavis 

- `APPETIZE_MAIN_TOKEN` - account token for Appetize **main** queue
- `APPETIZE_MAIN_ANDROID` - public key for Appetize **main** Android app
- `APPETIZE_MAIN_IOS` - public key for Appetize **main** iOS app
- `APPETIZE_EMBED_TOKEN` - account token for Appetize **embed** queue
- `APPETIZE_EMBED_ANDROID` - public key for Appetize **embed** Android app
- `APPETIZE_EMBED_IOS` - public key for Appetize **embed** iOS app

# Test Plan

I created this workflow in my own repository, connected to my own Appetize instance. You [can see my test runs here](https://github.com/byCedric/snack-appetize-workflow). (_note, only `main` queue is set up_)
