### PR TITLE
[ci] Add continuous tests for Appetize and website versions

### DIFF
--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: website
         run: yarn install --ignore-scripts --frozen-lockfile
 
-      # This command might fail on other dependencies, we just want to peak in the configs
+      # This command might fail on other dependencies, we just want to peek in the configs
       - name: 👷‍♀️ Build sdk config
         working-directory: website
         continue-on-error: true

--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -75,7 +75,7 @@ jobs:
           node-version: 16.x
           
       - name: 📋 Download Appetize information
-        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        # Redirect output because the endpoint returns the public and private app keys
         run: curl --silent --fail -o appetize.json https://$TOKEN@api.appetize.io/v1/apps/$APP > /dev/null
         env:
           TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}

--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -3,6 +3,7 @@ name: AppetizeValidation
 on:
   workflow_dispatch:
   schedule:
+    # daily at 14:00h UTC
     - cron: 0 14 * * *
 
 jobs:

--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -1,0 +1,131 @@
+name: AppetizeValidation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 14 * * *
+
+jobs:
+  website:
+    name: Resolve website config
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.config.outputs.result }}
+    steps:
+      - name: 👀 Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: 🚀 Use Node 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: 🔍 Find yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=path::$(yarn cache dir)"
+      
+      - name: ♻️ Restore yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.path }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 🧶 Install dependencies
+        working-directory: website
+        run: yarn install --ignore-scripts --frozen-lockfile
+
+      # This command might fail on other dependencies, we just want to peak in the configs
+      - name: 👷‍♀️ Build sdk config
+        working-directory: website
+        continue-on-error: true
+        run: yarn tsc src/client/configs/sdk.tsx > /dev/null
+
+      - name: 🕵️ Resolve sdk config
+        uses: actions/github-script@v4
+        id: config
+        with:
+          script: |
+            const config = require('./website/src/client/configs/sdk')
+            const versions = Object.keys(config.versions)
+            
+            core.info(`Resolved suppored website SDKs`)
+            for (const version of versions) {
+              core.info(`  - ${version} ${version === config.DEFAULT_SDK_VERSION ? '(default)' : ''}`)
+            }
+
+            return { versions, default: config.DEFAULT_SDK_VERSION }
+
+  appetize:
+    needs: website
+    name: Validate ${{ matrix.platform }} on ${{ matrix.appetize }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Use capitalized names for envvars
+        appetize: ['MAIN', 'EMBED']
+        platform: ['ANDROID', 'IOS']
+    steps:
+      - name: 🚀 Use Node 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          
+      - name: 📋 Download Appetize information
+        # This step MUST only output `appVersionName`, the endpoint returns the public and private app keys
+        run: curl --silent --fail -o appetize.json https://$TOKEN@api.appetize.io/v1/apps/$APP > /dev/null
+        env:
+          TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
+          APP: ${{ secrets[format('APPETIZE_{0}_{1}', matrix.appetize, matrix.platform)] }}
+    
+      - name: 📋 Download SDK information
+        run: curl --silent -o versions.json https://exp.host/--/api/v2/versions
+
+      - name: 🧶 Install semver
+        run: yarn add semver
+      
+      - name: Validate version
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const semver = require('semver')
+            const { appVersionName: appetizeVersion } = require('./appetize.json')
+            const { sdkVersions } = require('./versions.json')
+            const platform = '${{ matrix.platform }}'.toLowerCase()
+            const appetize = '${{ matrix.appetize }}'.toLowerCase()
+            
+            const website = JSON.parse('${{ needs.website.outputs.config }}')
+            const websiteSdk = sdkVersions[website.default]
+            const websiteVersion = (websiteSdk || {})[`${platform}ClientVersion`]
+
+            if (!websiteSdk) throw new Error(`Could not find default SDK "${website.default}"`)
+            if (!websiteVersion) throw new Error(`Could not find default ${platform} version for SDK "${website.default}"`)
+
+            const versionDiff = semver.diff(appetizeVersion, websiteVersion)
+            const appetizeIsNewer = semver.gt(appetizeVersion, websiteVersion)
+
+            const appetizeInfo = `Appetize (${appetize}) build for ${platform} (${appetizeVersion})`
+            const errorInfo = `${appetizeInfo} is outdated, website default is SDK ${website.default} (${websiteVersion})`
+
+            if (versionDiff === null) {
+              core.info(`${appetizeInfo} is up to date for SDK ${website.default}!`)
+            } else if (appetizeIsNewer) {
+              core.warning(`${appetizeInfo} is running a newer version, found SDK ${website.default} (${websiteVersion})`)
+            } else if (versionDiff === 'patch') {
+              core.warning(errorInfo)
+            } else {
+              throw new Error(errorInfo)
+            }
+
+      - name: 📢 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Validate Appetize ${{ matrix.platform }} on ${{ matrix.appetize }}
+          fields: author

--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -51,7 +51,7 @@ jobs:
             const config = require('./website/src/client/configs/sdk')
             const versions = Object.keys(config.versions)
             
-            core.info(`Resolved suppored website SDKs`)
+            core.info(`Resolved supported website SDKs`)
             for (const version of versions) {
               core.info(`  - ${version} ${version === config.DEFAULT_SDK_VERSION ? '(default)' : ''}`)
             }


### PR DESCRIPTION
# Why

> Only merge this after #194, it uses the same envvars.

This is a follow-up and related to #194. Instead of deploying Appetize builds, this workflow continuously checks the appetizer versions. We can change the interval, but this would be our trigger (from slack) to start fixing stuff. 

# How

This workflow is doing a couple of things:

- Resolve the configured version from `website/src/client/configs/sdks.tsx`
- Resolve the SDK versions from the versions api
- Check the Appetize version (per platform and per queue)
- Validate the default website version native build with the one on Appetize

There are a few outcomes, here are they:

State | Outcome | Message | Example
--- | --- | --- | ---
Appetize uses same version from default SDK | info | `Appetize (main) build for android (2.21.5) is up to date for SDK 42.0.0!` | [link](https://github.com/byCedric/snack/actions/runs/1125032557)
Appetize uses a newer version compared to default SDK | warn | `Appetize (embed) build for android (3.0.0) is running a newer version, found SDK 42.0.0 (2.21.5)` | [link](https://github.com/byCedric/snack/actions/runs/1125030663)
Appetize uses an older (patch) version compared to default SDK | warn | `Appetize (embed) build for android (2.21.4) is outdated, website default is SDK 42.0.0 (2.21.5)` | [link](https://github.com/byCedric/snack/actions/runs/1125039419)
Appetize uses an older (>=minor) version compared to default SDK | error | `Appetize (embed) build for android (2.19.6) is outdated, website default is SDK 42.0.0 (2.21.5)` | [link](https://github.com/byCedric/snack/actions/runs/1125024705)

> We could change the outcome types, e.g. make the outdated patch version fail as well. I did this because usually, this shouldn't break everything.

# Caveats

The way we resolve website config version is kind of dirty. I only compiled that version to avoid having to build the SDK etc (improved performance). Although this compiles fine, `tsc` will still error out. Kinda hard to fix that, or we have to build the whole project.

# Test Plan

- Run the workflow 😄 
