### PR TITLE
chore: show embedded preview for horizontal ipad devices

### DIFF
--- a/website/src/client/components/DevicePreview/DevicePreview.tsx
+++ b/website/src/client/components/DevicePreview/DevicePreview.tsx
@@ -54,8 +54,9 @@ class DevicePreview extends React.PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    this.mql = window.matchMedia(VISIBILITY_MEDIA_QUERY);
-    this.mql = window.matchMedia(VISIBILITY_MEDIA_QUERY_EMBEDDED);
+    this.mql = window.matchMedia(
+      this.props.isEmbedded ? VISIBILITY_MEDIA_QUERY_EMBEDDED : VISIBILITY_MEDIA_QUERY
+    );
     this.mql.addListener(this.handleMediaQuery);
     this.handleMediaQuery(this.mql);
   }

--- a/website/src/client/components/DevicePreview/DevicePreview.tsx
+++ b/website/src/client/components/DevicePreview/DevicePreview.tsx
@@ -45,6 +45,7 @@ type State = {
 };
 
 const VISIBILITY_MEDIA_QUERY = `(min-width: ${constants.preview.minWidth}px)`;
+const VISIBILITY_MEDIA_QUERY_EMBEDDED = `(min-width: ${constants.preview.embeddedMinWidth}px)`;
 
 class DevicePreview extends React.PureComponent<Props, State> {
   state: State = {
@@ -54,6 +55,7 @@ class DevicePreview extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     this.mql = window.matchMedia(VISIBILITY_MEDIA_QUERY);
+    this.mql = window.matchMedia(VISIBILITY_MEDIA_QUERY_EMBEDDED);
     this.mql.addListener(this.handleMediaQuery);
     this.handleMediaQuery(this.mql);
   }
@@ -145,7 +147,9 @@ class DevicePreview extends React.PureComponent<Props, State> {
       theme,
     } = this.props;
     return (
-      <div className={classnames(css(styles.container), className)} style={{ width }}>
+      <div
+        className={classnames(css(isEmbedded ? styles.embedded : styles.container), className)}
+        style={{ width }}>
         {isEmbedded ? null : (
           <div className={css(styles.header)}>
             <ToggleButtons
@@ -220,6 +224,17 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
 
     [`@media ${VISIBILITY_MEDIA_QUERY}`]: {
+      display: 'flex',
+    },
+  },
+  embedded: {
+    position: 'relative',
+    maxWidth: '50%',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    display: 'none',
+    flexDirection: 'column',
+    [`@media ${VISIBILITY_MEDIA_QUERY_EMBEDDED}`]: {
       display: 'flex',
     },
   },

--- a/website/src/client/configs/constants.tsx
+++ b/website/src/client/configs/constants.tsx
@@ -18,6 +18,7 @@ export default {
     },
   },
   preview: {
-    minWidth: 600,
+    minWidth: 700,
+    embeddedMinWidth: 600,
   },
 };

--- a/website/src/client/configs/constants.tsx
+++ b/website/src/client/configs/constants.tsx
@@ -18,6 +18,6 @@ export default {
     },
   },
   preview: {
-    minWidth: 700,
+    minWidth: 600,
   },
 };


### PR DESCRIPTION
# Why

this PR update `min-width` according issue for react native docs 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

i test the resolution for `iPad Air 4th generation`  horizontally real device width for this device is `674px`,   
after run website example i change `min-width: 600` horizontally and vertically

Before: 
![Screen Shot 2021-08-12 at 14 00 15](https://user-images.githubusercontent.com/36824170/129256059-eea6ce97-bad4-4ee0-bef2-7ea45a32a2fc.png)

After:
![Screen Shot 2021-08-12 at 13 33 33](https://user-images.githubusercontent.com/36824170/129256797-2077a7ab-ca87-40ef-ad7a-9adb5ecae4fc.png)


