### PR TITLE
[ci] Remove pull request triggers on staging deployments

### DIFF
--- a/.github/workflows/snackager-staging.yml
+++ b/.github/workflows/snackager-staging.yml
@@ -14,15 +14,6 @@ on:
       - .eslint*
       - .prettier*
       - yarn.lock
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/workflows/snackager-staging.yml
-      - snackager/**
-      - packages/snack-sdk/**
-      - .eslint*
-      - .prettier*
-      - yarn.lock
 
 jobs:
   build:

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -14,14 +14,6 @@ on:
       - .eslint*
       - .prettier*
       - yarn.lock
-  pull_request:
-    paths:
-      - .github/workflows/website-staging.yml
-      - website/**
-      - packages/snack-sdk/**
-      - .eslint*
-      - .prettier*
-      - yarn.lock
 
 jobs:
   build:


### PR DESCRIPTION
# Why

This prevents PRs from forks to trigger a staging deployment workflow and failing in the process due to missing git secrets.

# How

- Removed `pull_request` trigger from workflows

# Test Plan

- Open a PR from a fork 😄 