### PR TITLE
update remaining relevant urls to expo.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
       value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
   - type: markdown
     attributes:
-      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.io/c/snack) instead.
+      value: If you leave out sections there is a high likelihood your issue will be closed. If you have a question, not a bug report, please post it on our [forums](https://forums.expo.dev/c/snack) instead.
   - type: textarea
     attributes:
       label: Summary
@@ -32,7 +32,7 @@ body:
   - type: textarea
     attributes:
       label: Reproducible demo or steps to reproduce from a blank project
-      description: 'This should include as little code as possible, do not simply link your entire project. Sharing a link to a [Snack](https://snack.expo.io/) is a GREAT way to provide a reproducible demo :) If a reproducible demo, or a complete list of steps from blank project to bug, are not provided, it is very likely your issue will be closed. Read [here more guidance](https://stackoverflow.com/help/mcve).'
+      description: 'This should include as little code as possible, do not simply link your entire project. Sharing a link to a [Snack](https://snack.expo.dev/) is a GREAT way to provide a reproducible demo :) If a reproducible demo, or a complete list of steps from blank project to bug, are not provided, it is very likely your issue will be closed. Read [here more guidance](https://stackoverflow.com/help/mcve).'
     validations:
       required: true
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Expo Community Support
-    url: https://forums.expo.io/c/snack
+    url: https://forums.expo.dev/c/snack
     about: Please ask and answer questions regarding Expo Snack here

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -3,7 +3,7 @@ description: 'You have a question about Expo Snack or want to discuss some aspec
 body:
   - type: markdown
     attributes:
-      value: If you have a question about Expo Snack or want to discuss about related aspects, please post it on our forums at https://forums.expo.io/c/snack.
+      value: If you have a question about Expo Snack or want to discuss about related aspects, please post it on our forums at https://forums.expo.dev/c/snack.
   - type: dropdown
     attributes:
       label: Do you understand that any discussions or questions opened as issues in the core Expo Snack repository will be closed?

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Expo Snack is an open-source platform for running React Native apps in the browser. It dynamically bundles and compiles code and runs it in the Expo Client or in a web-player. Code can be saved as "Snacks" and easily shared with others. Snacks can also be embedded to show "live" previews as used by the [React Native documentation](https://reactnative.dev/docs/getting-started).
 
 > Snack has a new domain: snack.expo.dev!
-> [Read more about it here!](https://blog.expo.io/introducing-expo-dev-a70818bf336e)
+> [Read more about it here!](https://blog.expo.dev/introducing-expo-dev-a70818bf336e)
 
 <!--
 > Requesting snacks in bug reports gives your users an easy, lightweight way to give you a minimal, complete, and verifiable example (https://stackoverflow.com/help/minimal-reproducible-example) and allows you to spend more time fixing real issues in your project rather than staring at copy pasted code or cloning someone's repository that may or may not demonstrate a real issue with your project.
@@ -53,7 +53,7 @@ Internal documentation
 ## ❓ Getting in touch
 
 - [Issues](https://github.com/expo/snack/issues)
-- [Expo forums](https://forums.expo.io/c/snack)
+- [Expo forums](https://forums.expo.dev/c/snack)
 
 ## 👏 Contributing
 

--- a/docs/url-query-parameters.md
+++ b/docs/url-query-parameters.md
@@ -3,7 +3,7 @@
 The main Snack website is hosted at [https://snack.expo.dev](https://snack.expo.dev) and can be loaded in embedded mode and with custom parameters.
 
 > Snack has been transitioned to the `.dev` domain! Any traffic to `snack.expo.io` is automatically
-> redirected to `snack.expo.dev`. [Read more about it here!](https://blog.expo.io/introducing-expo-dev-a70818bf336e)
+> redirected to `snack.expo.dev`. [Read more about it here!](https://blog.expo.dev/introducing-expo-dev-a70818bf336e)
 
 ## URLs
 

--- a/packages/snack-sdk-legacy/README.md
+++ b/packages/snack-sdk-legacy/README.md
@@ -119,7 +119,7 @@ is not available once you import `lodash` You will need to import 'lodash/zip' t
 let saveResult = await session.saveAsync();
 
 console.log(saveResult);
-// This will print: `{"id":"abc123","url":"https://expo.io/@snack/abc123"}`
+// This will print: `{"id":"abc123","url":"https://expo.dev/@snack/abc123"}`
 ```
 This will upload the current code to Expo's servers and return a url that points to that version of the code.
 

--- a/packages/snack-sdk-legacy/package.json
+++ b/packages/snack-sdk-legacy/package.json
@@ -27,7 +27,7 @@
     "flow-typed": "flow-typed install",
     "docs": "documentation readme --readme-file API.md --section \"Snack SDK API\" src/SnackSession.js"
   },
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
     "node": "12.18.4"

--- a/packages/snack-sdk-legacy/src/SnackSession.js
+++ b/packages/snack-sdk-legacy/src/SnackSession.js
@@ -574,7 +574,7 @@ export default class SnackSession {
         this.snackId = data.id;
         return {
           id: data.id,
-          url: `https://expo.io/${fullName}`,
+          url: `https://expo.dev/${fullName}`,
         };
       } else {
         throw new Error(

--- a/packages/snack-sdk-legacy/src/__tests__/SnackSession-test.js
+++ b/packages/snack-sdk-legacy/src/__tests__/SnackSession-test.js
@@ -435,7 +435,7 @@ describe('saveAsync', () => {
     const saveResult = await session.saveAsync();
     expect(saveResult).toEqual({
       id: 'abc123',
-      url: 'https://expo.io/@snack/abc123',
+      url: 'https://expo.dev/@snack/abc123',
     });
 
     const lastCall = fetchMock.lastCall('*');
@@ -463,7 +463,7 @@ describe('saveAsync', () => {
     const saveResult = await session.saveAsync();
     expect(saveResult).toEqual({
       id: 'abc123',
-      url: 'https://expo.io/@snack/abc123',
+      url: 'https://expo.dev/@snack/abc123',
     });
 
     const lastCall = fetchMock.lastCall('*');

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -23,7 +23,7 @@
     "doc": "yarn typedoc",
     "doc:ci": "yarn doc && node ./scripts/checkUncommittedDocChanges.js"
   },
-  "author": "Expo <support@expo.io>",
+  "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
     "node": "12.16.2"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,6 +1,6 @@
 # Snack Runtime
 
-The Snack runtime is an Expo App that loads and runs the Snack code from https://snack.expo.io or from any other app using the [snack-sdk](../packages/snack-sdk). The Snack runtime exists in two flavours:
+The Snack runtime is an Expo App that loads and runs the Snack code from https://snack.expo.dev or from any other app using the [snack-sdk](../packages/snack-sdk). The Snack runtime exists in two flavours:
 - A native runtime for Expo Go
 - A web-player for running Snacks in the browser
 

--- a/runtime/__internal__/DEPLOYING.md
+++ b/runtime/__internal__/DEPLOYING.md
@@ -18,5 +18,5 @@ No CI actions are configured for this yet, so it needs to be done manually.
 - Login: `expo login`
 - Deploy runtime: `yarn deploy:prod` (is used by the Expo client)
 - Deploy web player `yarn deploy:web:prod` (is used by Snack web preview)
-- Verify that the runtime works by opening an app from `snack.expo.io` on your Expo client.
-- Verify that the web-player works by using the web-preview on `snack.expo.io`.
+- Verify that the runtime works by opening an app from `snack.expo.dev` on your Expo client.
+- Verify that the web-player works by using the web-preview on `snack.expo.dev`.


### PR DESCRIPTION
Forums, blog, emails, and the main website are now on expo.dev, so our code should reflect that.