### PR TITLE
[website] Do not log dependency errors to Sentry

### DIFF
--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -596,16 +596,6 @@ class Main extends React.Component<Props, State> {
       },
       () => this._saveDraftIfNeeded(true)
     );
-
-    // Record any dependency errors
-    if (state.dependencies !== prevState.dependencies) {
-      for (const name in state.dependencies) {
-        const dep = state.dependencies[name];
-        if (dep.error && dep.error !== prevState.dependencies[name]?.error) {
-          Raven.captureMessage(dep.error.message);
-        }
-      }
-    }
   };
 
   _reloadSnack = () => this._snack.reloadConnectedClients();


### PR DESCRIPTION
# Why

Only programming, or maybe service errors should be logged to Sentry. This removes the explicit sentry logging of dependency errors in the Snack web app.

This removes logging of the `Failed to resolve dependency` and `Invalid dependency` errors that happens because of invalid user input. These are not programming or service errors, but misconfigurations.

```
Failed to resolve dependency 'expo-constant@~11.0.1' (Package 'expo-constant' not found in the registry)
Failed to resolve dependency 'react-native-elements@42.0.0' (Version '42.0.0' for package 'react-native-elements' not found)
Invalid dependency 'expo-constants' (version '~11.0.1-' is not a valid semver)
Invalid dependency '@@blaexpo-constants' (name can only contain URL-friendly characters)
```

In rare cases, it may happen that Snackager cannot bundle a package. These would be useful to know, however these are already recorded in Snackager to Sentry.

# How

- Remove explicit dependency error logging in Snack website

# Test Plan

- All tests pass
- Confirmed that Snackager records bundling errors to Sentry