### PR TITLE
[snackager] Add motify org to forced reanimated plugin bundling

### DIFF
--- a/snackager/src/cache-busting.ts
+++ b/snackager/src/cache-busting.ts
@@ -13,6 +13,8 @@ const cacheBusting: { version: number; packages: { [name: string]: number } } = 
   packages: {
     'react-native-reanimated': 1,
     moti: 1,
+    '@motify/interactions': 1,
+    '@motify/skeleton': 1,
     '@draftbit/ui': 1,
     '@expo-google-fonts/.*': 2,
   },

--- a/snackager/src/utils/packageBundle.ts
+++ b/snackager/src/utils/packageBundle.ts
@@ -121,7 +121,7 @@ async function packageBundleUnsafe({
       // need to be converted.
       reanimatedPlugin:
         (pkg.name === 'react-native-reanimated' && pkg.version >= '2') ||
-        pkg.name === 'moti' ||
+        pkg.name === 'moti' || pkg.name.startsWith('@motify/') ||
         externals.includes('react-native-reanimated'),
     })
   );


### PR DESCRIPTION
# Why

All of the `moti` / `@motify/` libraries require the reanimated plugin.

# How

- Added the org to the bundler
- Added cache busting to rebuild the libraries

# Test Plan

- See if staging works with [this snack](https://snack.expo.dev/@beatgig/courageous-peach)
