### PR TITLE
[website] Allow Sentry to init on server when undefined

### DIFF
--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -29,7 +29,7 @@ if (require.main === module) {
     require('source-map-support').install();
   }
 
-  if (process.env.NODE_ENV === 'production' || process.env.SNACK_SENTRY_DSN) {
+  if (process.env.NODE_ENV === 'production' && process.env.SNACK_SENTRY_DSN) {
     Raven.config(nullthrows(process.env.SNACK_SENTRY_DSN), {
       release:
         process.env.NODE_ENV === 'production' ? nullthrows(process.env.APP_VERSION) : undefined,


### PR DESCRIPTION
# Why

Right now, having no Sentry credentials available crashes the server. This should allow Sentry to be non-initialized.

# How

Check if Sentry DSN is defined before init the library.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

Deploy to staging and see if it works.