### PR TITLE
[snack-sdk] Fix connected-clients not having id, name and platform

### DIFF
--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix connected-clients not having id, name, platform and transport fields ([#212](https://github.com/expo/snack/pull/212) by [@IjzerenHein](https://github.com/IjzerenHein))
+
 ## 3.5.0 — 2021-07-09
 
 ### 🛠 Breaking changes

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -1179,6 +1179,11 @@ export default class Snack {
     connectedClientId: string,
     message: ProtocolIncomingMessage
   ) {
+    // Ignore messages from clients that are not setup yet or have disconnected
+    if (!this.state.connectedClients[connectedClientId]) {
+      return;
+    }
+
     switch (message.type) {
       case 'CONSOLE':
         this.onConsoleMessageReceived(connectedClientId, message);

--- a/packages/snack-sdk/src/__tests__/connections-test.ts
+++ b/packages/snack-sdk/src/__tests__/connections-test.ts
@@ -1,5 +1,6 @@
 import '../__mocks__/fetch';
 import PubNub from '../__mocks__/pubnub';
+import { ProtocolErrorMessage } from '../transports/Protocol';
 import Snack from './snack-sdk';
 
 describe('connectedClients', () => {
@@ -68,5 +69,22 @@ describe('connectedClients', () => {
     expect(snack.getState().connectedClients[connectedClients[0]].status).toBe('reloading');
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(Object.keys(snack.getState().connectedClients)).toHaveLength(0);
+  });
+
+  it('ignores messages (errors/logs) for clients who have not advertised their presence', async () => {
+    const snack = new Snack({
+      online: true,
+    });
+    const pubnub = PubNub.instances[0];
+
+    const errorMessage: ProtocolErrorMessage = {
+      type: 'ERROR',
+      error: '{"message": "something went wrong"}',
+      device: PubNub.devices.ios,
+    };
+    pubnub.sendMessage(errorMessage);
+
+    const connectedClients = Object.keys(snack.getState().connectedClients);
+    expect(connectedClients).toHaveLength(0);
   });
 });


### PR DESCRIPTION
# Why

Fixes the `connectedClients` dictionary which sometimes contained entries without a device id, name, platform and transport field.

![image](https://user-images.githubusercontent.com/6184593/133586394-4779ee0c-4e9d-4251-bbbc-b1c756e0f6b4.png)

This happened because in some cases the error and log messages from the connected client were received before the presence was advertised over PubNub. This in turn caused errors on the Snack website when for instance loading a Snack which contained an error, and using the Expo Go client to connect to it.

![image](https://user-images.githubusercontent.com/6184593/133587410-c14b5644-0014-408e-a641-c39a5197bc0c.png)

Fixes #208

# How

- Ignore protocol messages from connected-clients if received before the `connect` presence event (and also after a client advertises that it left)
- Add unit test to verify that no connected clients are created upon receiving error/log messages

# Test Plan

- All tests pass
- New unit test passes
- Verified that the new unit test failed without the modification

![image](https://user-images.githubusercontent.com/6184593/133586978-6c86b64b-14e1-4419-9fcd-d3d75a853f71.png)

