### PR TITLE
[website] fix Algolia search results UI

### DIFF
--- a/website/src/client/components/Search/SearchBar.tsx
+++ b/website/src/client/components/Search/SearchBar.tsx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: c('border'),
     ':focus': {
-      borderColor: c('selected'),
+      borderColor: c('primary'),
     },
   },
   icon: {

--- a/website/src/client/components/Search/algolia.css
+++ b/website/src/client/components/Search/algolia.css
@@ -63,7 +63,7 @@
   .ds-suggestion.ds-cursor
   .algolia-docsearch-suggestion:not(.suggestion-layout-simple)
   .algolia-docsearch-suggestion--content {
-  background-color: rgba(69, 142, 225, 0.05);
+  background-color: rgba(69, 71, 213, 0.07);
 }
 .algolia-autocomplete .ds-dropdown-menu [class^='ds-dataset-'] {
   position: relative;
@@ -82,11 +82,12 @@
   background: var(--color-content);
   color: var(--color-text);
   overflow: hidden;
+  display: inherit;
 }
 .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
   color: var(--color-primary);
-  background: rgba(143, 187, 237, 0.1);
-  padding: 0.1em 0.05em;
+  background: rgb(69, 71, 213, 0.12);
+  padding: 0 0.05em;
 }
 .algolia-autocomplete
   .algolia-docsearch-suggestion--category-header
@@ -102,7 +103,7 @@
 .algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
   padding: 0 0 1px;
   background: inherit;
-  box-shadow: inset 0 -2px 0 0 rgba(69, 142, 225, 0.8);
+  box-shadow: inset 0 -2px 0 0 rgba(69, 71, 213, 0.8);
   color: var(--color-text);
 }
 .algolia-autocomplete .algolia-docsearch-suggestion--content {
@@ -120,7 +121,7 @@
   top: 0;
   height: 100%;
   width: 1px;
-  background: #ddd;
+  background: var(--color-border);
   left: -1px;
 }
 .algolia-autocomplete .algolia-docsearch-suggestion--category-header {

--- a/website/src/client/components/Search/algolia.css
+++ b/website/src/client/components/Search/algolia.css
@@ -87,7 +87,7 @@
 .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
   color: var(--color-primary);
   background: rgb(69, 71, 213, 0.12);
-  padding: 0 0.05em;
+  padding: 0.1em 0.05em;
 }
 .algolia-autocomplete
   .algolia-docsearch-suggestion--category-header


### PR DESCRIPTION
# Why

I have spotted that Algolia search results layout looks a bit off (too much spacing). This might be the result of Snack CSS overwrites, but AFAIK a few weeks ago it was still looking fine. 🤷‍♂️ 
 
# How

This PR fixes the Algolia search results UI, switches to violet as highlight color and also tweaks few colors in the dark mode.

# Test Plan

I have tested the changes running the Snack website locally.

# Preview

## Before

<img align="left" width="380" alt="Screenshot 2021-09-16 at 21 05 03" src="https://user-images.githubusercontent.com/719641/133671172-7aff2b47-7585-4904-a257-1176f475f510.png">
<img width="380" alt="Screenshot 2021-09-16 at 21 05 14" src="https://user-images.githubusercontent.com/719641/133671158-4a73e9c2-82ed-4559-9b3f-b98b504b42ae.png">

## After

<img align="left" width="380" alt="Screenshot 2021-09-16 at 21 25 07" src="https://user-images.githubusercontent.com/719641/133673174-e5fe1378-1884-45bd-9446-01f32092e1f0.png">
<img width="380" alt="Screenshot 2021-09-16 at 21 04 17" src="https://user-images.githubusercontent.com/719641/133671207-85bdcf3b-168a-4104-aac0-c4316ee17da7.png">

