### PR TITLE
[website] do not dismiss modal on content overselect

### DIFF
--- a/website/src/client/components/shared/Modal.tsx
+++ b/website/src/client/components/shared/Modal.tsx
@@ -75,7 +75,7 @@ export default class Modal extends React.PureComponent<Props, State> {
           !this.state.initial && styles.initial,
           this.props.visible ? styles.visible : styles.hidden
         )}
-        onClick={this._handleDismiss}>
+        onMouseDown={this._handleDismiss}>
         <div ref={this._content} className={css(styles.content)}>
           {this.state.rendered ? this.props.children : null}
         </div>


### PR DESCRIPTION
# Why

Currently, when user overselect the input or other content inside Modal, it automatically closes, which could be a bit annoying.

This is because the click started inside the modal ends outside of it, and click ends on the Modal overlay.

![Kapture 2021-09-17 at 15 16 20](https://user-images.githubusercontent.com/719641/133788878-d35c6e32-349a-4dd7-8d71-e5e1fc53760c.gif)

# How

To prevent this behaviour I have swapped the `onClick` listener to `onMouseDown` for the modal overlay component. 

# Test Plan

The change has been tested running the Snack website locally.

# Preview

![Kapture 2021-09-17 at 15 09 51](https://user-images.githubusercontent.com/719641/133787985-02ddc316-e3c9-42fe-80e6-e04fb8c4b50a.gif)