### PR TITLE
[website] Use purple for links in Markdown preview

### DIFF
--- a/website/src/client/components/Markdown/markdown.css
+++ b/website/src/client/components/Markdown/markdown.css
@@ -21,6 +21,7 @@
 .markdown-body a {
   background-color: transparent;
   text-decoration: none;
+  color: var(--color-primary)
 }
 
 .markdown-body a:hover {

--- a/website/src/client/components/Markdown/markdown.css
+++ b/website/src/client/components/Markdown/markdown.css
@@ -21,7 +21,7 @@
 .markdown-body a {
   background-color: transparent;
   text-decoration: none;
-  color: var(--color-primary)
+  color: var(--color-primary);
 }
 
 .markdown-body a:hover {


### PR DESCRIPTION
# Why

Currently links in Markdown preview are rendered using default blue color.

<img width="594" alt="Screenshot 2021-09-17 at 16 07 54" src="https://user-images.githubusercontent.com/719641/133796812-511dea98-076f-416b-9e5c-8589d6b44889.png">

Let's switch this to Expo purple to make those fit the website palette a bit better. 🙂 

# How

Set color of links directly in `markdown.css` overwrites.

# Test Plan

The change has been tested running Snack website locally.

# Preview

<img width="594" alt="Screenshot 2021-09-17 at 16 07 46" src="https://user-images.githubusercontent.com/719641/133797069-72d8a3f1-0120-42ef-979f-dcb0f8fa6480.png">

