### PR TITLE
Update Ingress resources

### DIFF
--- a/snackager/k8s/base/ingress.yaml
+++ b/snackager/k8s/base/ingress.yaml
@@ -1,10 +1,8 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snackager
-  labels:
-    ssl: 'true'
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:

--- a/snackager/k8s/development/ingress-spec.yaml
+++ b/snackager/k8s/development/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snackager
@@ -8,6 +8,8 @@ spec:
       http:
         paths:
         - backend:
-            serviceName: snackager
-            servicePort: 80
+            service:
+              name: snackager
+              port:
+                number: 80
           path: /

--- a/snackager/k8s/production/ingress-spec.yaml
+++ b/snackager/k8s/production/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snackager
@@ -12,6 +12,8 @@ spec:
       http:
         paths:
         - backend:
-            serviceName: snackager
-            servicePort: 80
+            service:
+              name: snackager
+              port:
+                number: 80
           path: /

--- a/snackager/k8s/staging/ingress-spec.yaml
+++ b/snackager/k8s/staging/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snackager
@@ -12,6 +12,8 @@ spec:
       http:
         paths:
         - backend:
-            serviceName: snackager
-            servicePort: 80
+            service:
+              name: snackager
+              port:
+                number: 80
           path: /

--- a/website/deploy/base/ingress.yaml
+++ b/website/deploy/base/ingress.yaml
@@ -1,9 +1,7 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snack
-  labels:
-    ssl: "true"
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/website/deploy/development/ingress-spec.yaml
+++ b/website/deploy/development/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snack
@@ -8,6 +8,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: snack
-          servicePort: 80
+          service:
+            name: snack
+            port:
+              number: 80
         path: /

--- a/website/deploy/production/ingress-spec.yaml
+++ b/website/deploy/production/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snack
@@ -13,13 +13,17 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: snack
-          servicePort: 80
+          service:
+            name: snack
+            port:
+              number: 80
         path: /
   - host: snack.expo.dev
     http:
       paths:
       - backend:
-          serviceName: snack
-          servicePort: 80
+          service:
+            name: snack
+            port:
+              number: 80
         path: /

--- a/website/deploy/staging/ingress-spec.yaml
+++ b/website/deploy/staging/ingress-spec.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: snack
@@ -13,13 +13,17 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: snack
-          servicePort: 80
+          service:
+            name: snack
+            port:
+              number: 80
         path: /
   - host: staging.snack.expo.dev
     http:
       paths:
       - backend:
-          serviceName: snack
-          servicePort: 80
+          service:
+            name: snack
+            port:
+              number: 80
         path: /


### PR DESCRIPTION
- Specify ClusterIssuer
- Use networking.k8s.io/v1 format

# Why

The deprecated networking.k8s.io/v1beta kubernetes api group is removed in version 1.22.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
