### PR TITLE
[website] Update react-native-paper dependency

### DIFF
--- a/website/src/client/configs/defaults.tsx
+++ b/website/src/client/configs/defaults.tsx
@@ -109,10 +109,13 @@ Snack is Open Source. You can find the code on the [GitHub repo](https://github.
 
 export const DEFAULT_DEPENDENCIES: SnackDependencies = {
   'react-native-paper': {
-    version: '3.6.0',
+    version: '4.9.2',
     // The handle ensures that the dependency doesn't need to be resolved
     // on startup
-    handle: 'snackager-1/react-native-paper@3.6.0',
+    handle: 'snackager-1/react-native-paper@4.9.2',
+  },
+  '@expo/vector-icons': {
+    version: '*',
   },
   'expo-constants': {
     version: '*',


### PR DESCRIPTION
# Why

Updates default library `react-native-paper` in order to facilitate reproducing bugs in the latests changes in the project.

# How

Locally run the snack website and confirm the new dependencies version are applied.

# Test Plan

All the tests should pass.
