### PR TITLE
[ci] Fix deploy of runtime to production

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -47,19 +47,19 @@ jobs:
       # - run: yarn test --ci --maxWorkers 15%
 
       - name: Deploy web-player
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:web:prod
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
 
       - name: Deploy native runtime
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:prod
 
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
-        if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
+        if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
         with:


### PR DESCRIPTION
# Why

Fixes the `RuntimeProduction` Github Action, which does not execute the deploy steps when triggering the workflow_dispatch using `deploy`.

This is currently preventing SDK 43 from working on the Snack production environement.

![image](https://user-images.githubusercontent.com/6184593/137328628-6a69ec72-c9f2-4ffe-ac60-479738bd392a.png)

# How

- Remove criteria that to only execute the steps on a `push` (push had already been done)

# Test Plan

- :eyes: