### PR TITLE
[runtime] Add missing expo-random as dependency

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -36,6 +36,7 @@
     "expo-file-system": "~13.0.1",
     "expo-font": "~10.0.1",
     "expo-keep-awake": "~10.0.0",
+    "expo-random": "~12.0.0",
     "expo-status-bar": "~1.1.0",
     "expo-updates": "~0.10.3",
     "path": "^0.12.7",

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -5605,6 +5605,13 @@ expo-random@*:
   dependencies:
     base64-js "^1.3.0"
 
+expo-random@~12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/expo-random/-/expo-random-12.0.0.tgz#c5da0830a7618012da076a05c79abe9623731cd0"
+  integrity sha512-E71atdA3aZT/EdcmUSE1mAQ+tp1F7/UPuoUsw5wYTbpkrRSsWU2ZjaWLGqtNaV0cXU5MDGm0zl235Gjo8mOOkA==
+  dependencies:
+    base64-js "^1.3.0"
+
 expo-splash-screen@~0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-0.13.1.tgz#169e5cbd3ddbc964878623387e1edea98b0b95a7"


### PR DESCRIPTION
# Why

See #225

# How

See #225

# Test Plan

See #225
