### PR TITLE
[snack-sdk][website][snackager][docs] track events by uuid

### DIFF
--- a/docs/snack-sdk-api/README.md
+++ b/docs/snack-sdk-api/README.md
@@ -253,12 +253,13 @@ ___
 
 ### SnackOptions
 
-Ƭ  **SnackOptions**: { apiURL?: undefined \| string ; channel?: undefined \| string ; codeChangesDelay?: undefined \| number ; createTransport?: undefined \| (options: SnackTransportOptions) => SnackTransport ; dependencies?: [SnackDependencies](README.md#snackdependencies) ; description?: undefined \| string ; deviceId?: undefined \| string ; disabled?: undefined \| false \| true ; files?: [SnackFiles](README.md#snackfiles) ; host?: undefined \| string ; id?: undefined \| string ; name?: undefined \| string ; online?: undefined \| false \| true ; previewTimeout?: undefined \| number ; reloadTimeout?: undefined \| number ; sdkVersion?: [SDKVersion](README.md#sdkversion) ; snackagerURL?: undefined \| string ; transports?: undefined \| { [id:string]: SnackTransport;  } ; user?: [SnackUser](README.md#snackuser) ; verbose?: undefined \| false \| true ; webPlayerURL?: undefined \| string ; webPreviewRef?: [SnackWindowRef](README.md#snackwindowref)  }
+Ƭ  **SnackOptions**: { accountSnackId?: undefined \| string ; apiURL?: undefined \| string ; channel?: undefined \| string ; codeChangesDelay?: undefined \| number ; createTransport?: undefined \| (options: SnackTransportOptions) => SnackTransport ; dependencies?: [SnackDependencies](README.md#snackdependencies) ; description?: undefined \| string ; deviceId?: undefined \| string ; disabled?: undefined \| false \| true ; files?: [SnackFiles](README.md#snackfiles) ; host?: undefined \| string ; id?: undefined \| string ; name?: undefined \| string ; online?: undefined \| false \| true ; previewTimeout?: undefined \| number ; reloadTimeout?: undefined \| number ; sdkVersion?: [SDKVersion](README.md#sdkversion) ; snackagerURL?: undefined \| string ; snackId?: undefined \| string ; transports?: undefined \| { [id:string]: SnackTransport;  } ; user?: [SnackUser](README.md#snackuser) ; verbose?: undefined \| false \| true ; webPlayerURL?: undefined \| string ; webPreviewRef?: [SnackWindowRef](README.md#snackwindowref)  }
 
 #### Type declaration:
 
 Name | Type |
 ------ | ------ |
+`accountSnackId?` | undefined \| string |
 `apiURL?` | undefined \| string |
 `channel?` | undefined \| string |
 `codeChangesDelay?` | undefined \| number |
@@ -276,6 +277,7 @@ Name | Type |
 `reloadTimeout?` | undefined \| number |
 `sdkVersion?` | [SDKVersion](README.md#sdkversion) |
 `snackagerURL?` | undefined \| string |
+`snackId?` | undefined \| string |
 `transports?` | undefined \| { [id:string]: SnackTransport;  } |
 `user?` | [SnackUser](README.md#snackuser) |
 `verbose?` | undefined \| false \| true |
@@ -314,12 +316,13 @@ ___
 
 ### SnackState
 
-Ƭ  **SnackState**: { channel: string ; connectedClients: [SnackConnectedClients](README.md#snackconnectedclients) ; dependencies: [SnackDependencies](README.md#snackdependencies) ; description: string ; deviceId?: undefined \| string ; disabled: boolean ; files: [SnackFiles](README.md#snackfiles) ; id?: undefined \| string ; missingDependencies: [SnackMissingDependencies](README.md#snackmissingdependencies) ; name: string ; online: boolean ; onlineName?: undefined \| string ; saveURL?: undefined \| string ; savedSDKVersion?: undefined \| string ; sdkVersion: [SDKVersion](README.md#sdkversion) ; sendBeaconCloseRequest?: [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) ; unsaved: boolean ; url: string ; user?: [SnackUser](README.md#snackuser) ; wantedDependencyVersions?: [SnackDependencyVersions](README.md#snackdependencyversions) ; webPreviewURL?: undefined \| string  }
+Ƭ  **SnackState**: { accountSnackId: undefined \|string ; channel: string ; connectedClients: [SnackConnectedClients](README.md#snackconnectedclients) ; dependencies: [SnackDependencies](README.md#snackdependencies) ; description: string ; deviceId?: undefined \| string ; disabled: boolean ; files: [SnackFiles](README.md#snackfiles) ; id?: undefined \| string ; missingDependencies: [SnackMissingDependencies](README.md#snackmissingdependencies) ; name: string ; online: boolean ; onlineName?: undefined \| string ; saveURL?: undefined \| string ; savedSDKVersion?: undefined \| string ; sdkVersion: [SDKVersion](README.md#sdkversion) ; sendBeaconCloseRequest?: [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) ; snackId: undefined \|string ; unsaved: boolean ; url: string ; user?: [SnackUser](README.md#snackuser) ; wantedDependencyVersions?: [SnackDependencyVersions](README.md#snackdependencyversions) ; webPreviewURL?: undefined \| string  }
 
 #### Type declaration:
 
 Name | Type | Description |
 ------ | ------ | ------ |
+`accountSnackId` | undefined \| string | Id of the saved Snack if it belongs to an account.
 `channel` | string | Communication channel ("pubnub") through which live updates are transferred. The communication channel is only used when the Snack is "online". |
 `connectedClients` | [SnackConnectedClients](README.md#snackconnectedclients) | Clients that are currently connected. |
 `dependencies` | [SnackDependencies](README.md#snackdependencies) | Packages that can be used in the code files. Packages that are pre-loaded by the sdk may be ommited, but it is recommended to add them anyway. |
@@ -327,7 +330,7 @@ Name | Type | Description |
 `deviceId?` | undefined \| string | Device-id of the Expo client. When set causes the Snack to be visible in the "Recently in Development" section of the Expo client with that device-id. The device-id is only used when the Snack is "online". |
 `disabled` | boolean | Disabled state. When the Snack is disabled it will not resolve any dependencies or upload any asset files. It also disables the ability to go online. |
 `files` | [SnackFiles](README.md#snackfiles) | Files that make up the content (code & assets) of the Snack. There should always be a file called "App.js" or "App.tsx" as the main entry point. |
-`id?` | undefined \| string | Id of the saved Snack. |
+`id?` | undefined \| string | Full name of the saved Snack. |
 `missingDependencies` | [SnackMissingDependencies](README.md#snackmissingdependencies) | Collection of dependencies that are missing but are required by one or more of the dependencies. |
 `name` | string | Optional name. The name is used when saving or downloading the Snack; and is used for the onlineName property. |
 `online` | boolean | When online is true, Expo clients can connect to the Snack and receive live updates when code or dependencies are changed. It also makes the Snack visible in the "Recently in Development" section of the Expo client. |
@@ -336,6 +339,7 @@ Name | Type | Description |
 `savedSDKVersion?` | undefined \| string | Last saved (non-draft) Expo SDK version. |
 `sdkVersion` | [SDKVersion](README.md#sdkversion) | Expo SDK version. |
 `sendBeaconCloseRequest?` | [SnackSendBeaconRequest](README.md#snacksendbeaconrequest) | A close request that should be send using the browser `sendBeacon` API whenever the browser session is unloaded. This gives the Snack a last opportunity to gracefully close its connections so that the "Recently in Development" section in the Expo client no longer shows the Snack. |
+`snackId` | undefined \| string | Id of this version of the saved Snack.
 `unsaved` | boolean | Unsaved status of the Snack. Becomes `true` when the Snack code is changed and `false` whenever the Snack is saved. |
 `url` | string | Unique experience url which can be used to open the Expo client and connect to the Snack (e.g. "exp://exp.host/@snack/sdk.38.0.0-78173941"). |
 `user?` | [SnackUser](README.md#snackuser) |  |

--- a/docs/snack-sdk-api/classes/snack.md
+++ b/docs/snack-sdk-api/classes/snack.md
@@ -174,7 +174,7 @@ ___
 
 ### saveAsync
 
-▸ **saveAsync**(`options?`: [SnackSaveOptions](../README.md#snacksaveoptions)): Promise\<{ hashId: undefined \| string ; id: string ; url: string = saveURL }>
+▸ **saveAsync**(`options?`: [SnackSaveOptions](../README.md#snacksaveoptions)): Promise\<{ hashId: undefined \| string ; id: string ; url: string = saveURL ; snackId: undefined \| string ; accountSnackId: undefined \| string ; }>
 
 Uploads the current code to Expo's servers and return a url that points to that version of the code.
 
@@ -184,7 +184,7 @@ Name | Type |
 ------ | ------ |
 `options?` | [SnackSaveOptions](../README.md#snacksaveoptions) |
 
-**Returns:** Promise\<{ hashId: undefined \| string ; id: string ; url: string = saveURL }>
+**Returns:** Promise\<{ hashId: undefined \| string ; id: string ; url: string = saveURL ; snackId: undefined \| string ; accountSnackId: undefined \| string ; }>
 
 ___
 

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -67,6 +67,7 @@ export type SnackOptions = {
   previewTimeout?: number;
   user?: SnackUser;
   id?: string;
+  uuid?: string;
   webPlayerURL?: string;
   webPreviewRef?: SnackWindowRef;
 };
@@ -161,6 +162,7 @@ export default class Snack {
         url: createURL(this.host, sdkVersion, channel, options.id),
         channel,
         deviceId: options.deviceId,
+        uuid: options.uuid,
       },
       SnackIdentityState
     );
@@ -377,6 +379,7 @@ export default class Snack {
       const id: string = data.id;
       const saveURL = createURL(this.host, sdkVersion, undefined, id);
       const hashId: string | undefined = data.hashId;
+      const uuid: string = data.uuid;
 
       this.setState((state) => ({
         id,
@@ -384,6 +387,7 @@ export default class Snack {
         unsaved: State.isUnsaved(state, prevState),
         savedSDKVersion:
           options?.isDraft && state.savedSDKVersion ? state.savedSDKVersion : sdkVersion,
+        uuid,
       }));
 
       previewPromise.then((connectedClients) => {

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -67,7 +67,8 @@ export type SnackOptions = {
   previewTimeout?: number;
   user?: SnackUser;
   id?: string;
-  uuid?: string;
+  snackId?: string;
+  accountSnackId?: string;
   webPlayerURL?: string;
   webPreviewRef?: SnackWindowRef;
 };
@@ -162,7 +163,8 @@ export default class Snack {
         url: createURL(this.host, sdkVersion, channel, options.id),
         channel,
         deviceId: options.deviceId,
-        uuid: options.uuid,
+        snackId: options.snackId,
+        accountSnackId: options.accountSnackId,
       },
       SnackIdentityState
     );
@@ -379,7 +381,8 @@ export default class Snack {
       const id: string = data.id;
       const saveURL = createURL(this.host, sdkVersion, undefined, id);
       const hashId: string | undefined = data.hashId;
-      const uuid: string = data.uuid;
+      const accountSnackId: string | undefined = data.accountSnackId;
+      const snackId: string | undefined = data.snackId;
 
       this.setState((state) => ({
         id,
@@ -387,7 +390,8 @@ export default class Snack {
         unsaved: State.isUnsaved(state, prevState),
         savedSDKVersion:
           options?.isDraft && state.savedSDKVersion ? state.savedSDKVersion : sdkVersion,
-        uuid,
+        accountSnackId,
+        snackId,
       }));
 
       previewPromise.then((connectedClients) => {
@@ -403,6 +407,8 @@ export default class Snack {
         id,
         url: saveURL,
         hashId,
+        accountSnackId,
+        snackId,
       };
     } catch (e) {
       this.logger?.error(e);

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -261,9 +261,14 @@ export type SnackState = {
   unsaved: boolean;
 
   /**
-   * Id of the saved Snack.
+   * Full name of the saved Snack.
    */
   id?: string;
+
+  /**
+   * uuid of the saved Snack.
+   */
+  uuid?: string;
 
   /**
    * URL of the saved Snack.

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -266,12 +266,12 @@ export type SnackState = {
   id?: string;
 
   /**
-   * Id of this version of the saved Snack.
+   * Id of this version of the saved Snack. Each Snack can have many different versions or revisions, each revision has its own snackId.
    */
   snackId?: string;
 
   /**
-   * Id of the saved Snack if it belongs to an account.
+   * Id of a Snack saved to an account. This id points to the latest version of a Snack revision and associated user.
    */
   accountSnackId?: string;
 

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -266,9 +266,14 @@ export type SnackState = {
   id?: string;
 
   /**
-   * uuid of the saved Snack.
+   * Id of this version of the saved Snack.
    */
-  uuid?: string;
+  snackId?: string;
+
+  /**
+   * Id of the saved Snack if it belongs to an account.
+   */
+  accountSnackId?: string;
 
   /**
    * URL of the saved Snack.

--- a/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
@@ -531,7 +531,7 @@ Object {
           "react-native-safe-area-context",
           "react-native-svg",
         ],
-        "size": 292736,
+        "size": 292692,
       },
     },
     "web": Object {

--- a/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/bundler.test.ts.snap
@@ -518,7 +518,7 @@ Object {
           "react-native-svg",
           "react-native/Libraries/BatchedBridge/BatchedBridge",
         ],
-        "size": 285810,
+        "size": 285622,
       },
     },
     "ios": Object {
@@ -531,7 +531,7 @@ Object {
           "react-native-safe-area-context",
           "react-native-svg",
         ],
-        "size": 293122,
+        "size": 292736,
       },
     },
     "web": Object {

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -187,7 +187,6 @@ class Main extends React.Component<Props, State> {
         ? props.match.params.id
         : undefined;
 
-    const uuid = props.snack?.id;
     const verbose = props.query.verbose === 'true';
     const isWorker = true;
     const sendCodeOnChangeEnabled = true;
@@ -224,7 +223,8 @@ class Main extends React.Component<Props, State> {
         typeof window !== 'undefined' && isLocalWebPreview
           ? `${window.location.origin}/web-player/%%SDK_VERSION%%`
           : nullthrows(process.env.SNACK_WEBPLAYER_URL) + '/v2/%%SDK_VERSION%%',
-      uuid,
+      snackId: props.snack?.id,
+      accountSnackId: props.snack?.accountSnackId,
     });
 
     const devicePreviewPlatformOptions = PlatformOptions.filter({
@@ -344,7 +344,8 @@ class Main extends React.Component<Props, State> {
     }
 
     Analytics.getInstance().setCommonData({
-      snackId: this.state.session.uuid,
+      accountSnackId: this.state.session.accountSnackId,
+      snackId: this.state.session.snackId ?? this.props.snack?.id,
       isEmbedded: !!this.props.isEmbedded,
       previewPane: this.state.devicePreviewShown ? this.state.devicePreviewPlatform : 'hidden',
     });
@@ -731,7 +732,17 @@ class Main extends React.Component<Props, State> {
         });
       }
 
+      Analytics.getInstance().updateCommonData({
+        snackId: saveResult.snackId ?? this.props.snack?.id,
+        accountSnackId: saveResult.accountSnackId,
+      });
+
       this.setState((state) => ({
+        session: {
+          ...state.session,
+          snackId: saveResult.snackId,
+          accountSnackId: saveResult.accountSnackId,
+        },
         isSavedOnce: true,
         saveHistory: excludeFromHistory
           ? state.saveHistory

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -187,6 +187,7 @@ class Main extends React.Component<Props, State> {
         ? props.match.params.id
         : undefined;
 
+    const uuid = props.snack?.id;
     const verbose = props.query.verbose === 'true';
     const isWorker = true;
     const sendCodeOnChangeEnabled = true;
@@ -223,6 +224,7 @@ class Main extends React.Component<Props, State> {
         typeof window !== 'undefined' && isLocalWebPreview
           ? `${window.location.origin}/web-player/%%SDK_VERSION%%`
           : nullthrows(process.env.SNACK_WEBPLAYER_URL) + '/v2/%%SDK_VERSION%%',
+      uuid,
     });
 
     const devicePreviewPlatformOptions = PlatformOptions.filter({
@@ -342,7 +344,7 @@ class Main extends React.Component<Props, State> {
     }
 
     Analytics.getInstance().setCommonData({
-      snackId: this.state.session.id,
+      snackId: this.state.session.uuid,
       isEmbedded: !!this.props.isEmbedded,
       previewPane: this.state.devicePreviewShown ? this.state.devicePreviewPlatform : 'hidden',
     });

--- a/website/src/client/types.tsx
+++ b/website/src/client/types.tsx
@@ -44,6 +44,7 @@ export type SavedSnack = {
   dependencies?: SnackDependencies;
   history?: SaveHistory;
   isDraft?: boolean;
+  accountSnackId?: string;
 };
 
 export type SnackDefaults = {

--- a/website/src/client/utils/Analytics.tsx
+++ b/website/src/client/utils/Analytics.tsx
@@ -1,6 +1,7 @@
 import type { AmplitudeClient } from 'amplitude-js';
 
 type AnalyticsCommonData = {
+  accountSnackId?: string;
   snackId?: string;
   isEmbedded?: boolean;
   previewPane?: 'hidden' | 'mydevice' | 'ios' | 'android' | 'web';


### PR DESCRIPTION
# Why

We'd like to anonymize events by removing mentions of account name or username to hit GDPR specs. This converts snack tracking id to uuid.

# How

needs to be landed after this [PR](https://github.com/expo/universe/pull/8727) for `www` to have `/snack/save` return `uuid`.

Grabbed the UUID from the saved snack response and populated the analytics id with it.

# Test Plan

Ran some test events locally to confirm the id had updated.
