### PR TITLE
[website] store editor theme and mode in local storage

### DIFF
--- a/website/src/client/components/EditorView.tsx
+++ b/website/src/client/components/EditorView.tsx
@@ -319,15 +319,17 @@ class EditorView extends React.Component<Props, State> {
   _changeConnectionMethod = (deviceConnectionMethod: ConnectionMethod) =>
     this.props.setPreferences({ deviceConnectionMethod });
 
-  _toggleEditorMode = () =>
-    this.props.setPreferences({
-      editorMode: this.props.preferences.editorMode === 'vim' ? 'normal' : 'vim',
-    });
+  _toggleEditorMode = () => {
+    const editorMode = this.props.preferences.editorMode === 'vim' ? 'normal' : 'vim';
+    this.props.setPreferences({ editorMode });
+    localStorage.setItem('editorMode', editorMode);
+  };
 
-  _toggleTheme = () =>
-    this.props.setPreferences({
-      theme: this.props.preferences.theme === 'light' ? 'dark' : 'light',
-    });
+  _toggleTheme = () => {
+    const theme = this.props.preferences.theme === 'light' ? 'dark' : 'light';
+    this.props.setPreferences({ theme });
+    localStorage.setItem('theme', theme);
+  };
 
   _toggleMarkdownPreview = () =>
     this.setState((state) => ({ isMarkdownPreview: !state.isMarkdownPreview }));

--- a/website/src/client/components/Preferences/PreferencesProvider.tsx
+++ b/website/src/client/components/Preferences/PreferencesProvider.tsx
@@ -9,12 +9,13 @@ import type { PreferencesContextType } from './withPreferences';
 import type { ThemeName } from './withThemeName';
 
 export type PanelType = 'errors' | 'logs';
+export type EditorModeType = 'normal' | 'vim';
 
 export type PreferencesType = {
   deviceConnectionMethod: ConnectionMethod;
   devicePreviewPlatform: Platform;
   devicePreviewShown: boolean;
-  editorMode: 'normal' | 'vim';
+  editorMode: EditorModeType;
   fileTreeShown: boolean;
   panelsShown: boolean;
   panelType: PanelType;
@@ -60,6 +61,16 @@ class PreferencesProvider extends React.Component<Props, State> {
     const { cookies, queryParams } = this.props;
 
     let overrides: Partial<PreferencesType> = {};
+
+    try {
+      // Restore editor preferences from local storage
+      if (localStorage) {
+        overrides.editorMode = localStorage.getItem('editorMode') as EditorModeType;
+        overrides.theme = localStorage.getItem('theme') as ThemeName;
+      }
+    } catch (e) {
+      // Ignore error
+    }
 
     try {
       // Restore editor preferences from saved data


### PR DESCRIPTION
# Why

Currently, often first thing done when I open a new Snack is to change the theme to dark mode. 😅 

Since the editor preferences are non-crucial or sensitive data in any way we can use the browser local storage to store them to improve the users UX.

# How

This PR adds store and load code for the editor theme and mode.

I have placed this on top of all overrides for it has the less priority and will be overwritten by, for example, theme provided in query string.

Also to improve the readability a bit I have extracted the editor mode possible values to the separate type.

# Test Plan

The changes have been tested by running the website code on localhost.

# Preview

> No preferences in LS => Set/toggle preferences => Reload website

![Kapture 2021-12-09 at 16 24 09](https://user-images.githubusercontent.com/719641/145425119-3bc7742b-06b3-4e50-81ab-f8179c19075f.gif)
