### PR TITLE
[website] Sanitize theme name to light or dark only

### DIFF
--- a/website/src/client/components/EditorView.tsx
+++ b/website/src/client/components/EditorView.tsx
@@ -648,7 +648,7 @@ class EditorView extends React.Component<Props, State> {
                   onChangeSDKVersion={this.props.onChangeSDKVersion}
                   onShowModal={this._handleShowModal}
                   onPrettifyCode={this._prettier}
-                  theme={this.props.preferences.theme}
+                  theme={preferences.theme}
                 />
                 <DeviceInstructionsModal
                   visible={currentModal === 'device-instructions'}

--- a/website/src/client/components/Preferences/withThemeName.tsx
+++ b/website/src/client/components/Preferences/withThemeName.tsx
@@ -28,9 +28,10 @@ export default function withThemeName<P extends InjectedProps>(
 
       return (
         <PreferencesContext.Consumer>
-          {(props) => {
+          {(props: any) => {
+            const theme = sanitizeThemeName(props.preferences.theme);
             // @ts-ignore
-            return <Comp ref={__forwardedRef} theme={sanitizeThemeName(props.preferences.theme)} {...rest} />;
+            return <Comp ref={__forwardedRef} theme={theme} {...rest} />;
           }}
         </PreferencesContext.Consumer>
       );

--- a/website/src/client/components/Preferences/withThemeName.tsx
+++ b/website/src/client/components/Preferences/withThemeName.tsx
@@ -10,6 +10,10 @@ type InjectedProps = {
   theme: ThemeName;
 };
 
+function sanitizeThemeName(theme?: ThemeName | null): ThemeName {
+  return theme === 'dark' ? 'dark' : 'light';
+}
+
 // react-redux doesn't work with forwardRef: https://github.com/reduxjs/react-redux/issues/914
 // so this HOC always needs wrap a connect call, and a connect call cannot wrap this
 export default function withThemeName<P extends InjectedProps>(
@@ -26,7 +30,7 @@ export default function withThemeName<P extends InjectedProps>(
         <PreferencesContext.Consumer>
           {(props) => {
             // @ts-ignore
-            return <Comp ref={__forwardedRef} theme={props.preferences.theme} {...rest} />;
+            return <Comp ref={__forwardedRef} theme={sanitizeThemeName(props.preferences.theme)} {...rest} />;
           }}
         </PreferencesContext.Consumer>
       );


### PR DESCRIPTION
# Why

Without this, the syntax highlighting might be wrong when for null theme values.

# How

- Sanitized the theme name in the theme context provider
- Converts `ThemeName | null | undefined` to `ThemeName` (defaults to `light`).

# Test Plan

- See if staging works
