### PR TITLE
[website] link to Dashboard Snacks list instead of public one

### DIFF
--- a/website/src/client/components/UserMenu.tsx
+++ b/website/src/client/components/UserMenu.tsx
@@ -75,7 +75,7 @@ class UserMenu extends React.Component<Props, State> {
               ? [
                   {
                     label: 'My Snacks',
-                    handler: () => window.open(`${websiteURL}/@${viewer.username}/snacks`),
+                    handler: () => window.open(`${websiteURL}/snacks`),
                   },
                   {
                     label: 'Account Settings',


### PR DESCRIPTION
# Why

CC: @jonsamp 

Currently, when users logs in, in the menu appear link to "My Snacks", which currently redirects user to the public profile including Snacks tab. This might cause some confusion for the users.

# How

Let's switch the URL to the Snack list located in Dashboard. User need to be logged in, to see the link in the first place, so switching to the protected view should not results in any issues.

# Test Plan

The change has been tested by running the Snack website locally.