### PR TITLE
[website] bump rudder sdk

### DIFF
--- a/website/src/server/components/RudderStackDocumentComponent.tsx
+++ b/website/src/server/components/RudderStackDocumentComponent.tsx
@@ -24,7 +24,7 @@ export default class RudderStackDocumentComponent extends React.Component<Props>
     rudderStackDataPlaneURL: string
   ): string {
     return `
-!function(){var e=window.rudderanalytics=window.rudderanalytics||[];e.methods=["load","page","track","identify","alias","group","ready","reset","getAnonymousId","setAnonymousId"],e.factory=function(t){return function(){var r=Array.prototype.slice.call(arguments);return r.unshift(t),e.push(r),e}};for(var t=0;t<e.methods.length;t++){var r=e.methods[t];e[r]=e.factory(r)}e.loadJS=function(e,t){var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.rudderlabs.com/v1/rudder-analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)},e.loadJS(),
+!function(){var e=window.rudderanalytics=window.rudderanalytics||[];e.methods=["load","page","track","identify","alias","group","ready","reset","getAnonymousId","setAnonymousId"],e.factory=function(t){return function(){var r=Array.prototype.slice.call(arguments);return r.unshift(t),e.push(r),e}};for(var t=0;t<e.methods.length;t++){var r=e.methods[t];e[r]=e.factory(r)}e.loadJS=function(e,t){var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.rudderlabs.com/v1.1/rudder-analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)},e.loadJS(),
 e.load('${rudderStackWriteKey}','${rudderStackDataPlaneURL}');
 e.page();
 e.identify({


### PR DESCRIPTION
# Why

Rudderstack is [deprecating](https://rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-javascript-sdk/) v1 in favor of v1.1 (it is also 2/3 smaller in size)

# How

Bumped the version # in the initializer snippet.

# Test Plan

Plan to run in staging to confirm events make it to the backend
