### PR TITLE
[website] Change settings link text to match main website

### DIFF
--- a/website/src/client/components/UserMenu.tsx
+++ b/website/src/client/components/UserMenu.tsx
@@ -78,7 +78,7 @@ class UserMenu extends React.Component<Props, State> {
                     handler: () => window.open(`${websiteURL}/@${viewer.username}/snacks`),
                   },
                   {
-                    label: 'Account Settings',
+                    label: 'User Settings',
                     handler: () => window.open(`${websiteURL}/settings`),
                   },
                   ...(legacyLogout ? [{ label: 'Log out', handler: legacyLogout }] : []),


### PR DESCRIPTION
# Why

The main expo.dev website now calls these settings "User Settings" and refers to them as such in the similar dropdown on the website:

<img width="432" alt="Screen Shot 2022-01-20 at 12 17 00 PM" src="https://user-images.githubusercontent.com/189568/150415465-3a37c083-4427-4f46-9aa6-fa28e3b6da62.png">


# How

Grep, change text.

# Test Plan

Inspect.
