### PR TITLE
Fix snackager build

### DIFF
--- a/.github/workflows/snackager-production.yml
+++ b/.github/workflows/snackager-production.yml
@@ -64,6 +64,10 @@ jobs:
           gcloud auth configure-docker gcr.io
 
       - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn build
+        working-directory: packages/snack-content
+      - run: yarn build
+        working-directory: packages/snack-sdk
       - run: yarn tsc --noEmit
       - run: yarn lint --max-warnings 0
       - run: yarn test --ci --testPathIgnorePatterns=__integration-tests__

--- a/.github/workflows/snackager-staging.yml
+++ b/.github/workflows/snackager-staging.yml
@@ -59,6 +59,10 @@ jobs:
           gcloud auth configure-docker gcr.io
 
       - run: yarn install --ignore-scripts --frozen-lockfile
+      - run: yarn build
+        working-directory: packages/snack-content
+      - run: yarn build
+        working-directory: packages/snack-sdk
       - run: yarn tsc --noEmit
       - run: yarn lint --max-warnings 0
       - run: yarn test --ci --testPathIgnorePatterns=__integration-tests__


### PR DESCRIPTION
# Why

The Snackager production and staging workflows were failing because tsc could not find snack-content's types. Perhaps we could use skipLibChecks in tsconfig.json but I addressed this by building the snack-content and snack-sdk packages before running tsc in snackager.

# Test Plan

In a completely clean repo (`git clean -dfx`) I ran the same steps as CI:
```
cd snackager
yarn install --ignore-scripts --frozen-lockfile
yarn tsc --noEmit
```
Verified I got type lookup errors. Then built snack-content and snack-sdk and ran tsc successfully.