### PR TITLE
[snack-content] Add back detection for all features

### DIFF
--- a/packages/snack-content/src/sdks/features.ts
+++ b/packages/snack-content/src/sdks/features.ts
@@ -1,6 +1,13 @@
 import { SDKFeature } from './types';
 
 // Minimum SDK versions that support Snack features
-const features: { [feature in SDKFeature]: string } = { TYPESCRIPT: '31.0.0' };
+const features: { [feature in SDKFeature]: string } = {
+  MULTIPLE_FILES: '21.0.0',
+  PROJECT_DEPENDENCIES: '25.0.0',
+  TYPESCRIPT: '31.0.0',
+  UNIMODULE_IMPORTS: '33.0.0',
+  POSTMESSAGE_TRANSPORT: '35.0.0',
+  VERSIONED_SNACKAGER: '37.0.0',
+};
 
 export default features;

--- a/packages/snack-content/src/sdks/types.ts
+++ b/packages/snack-content/src/sdks/types.ts
@@ -40,4 +40,10 @@ export type SDKSpec = {
 /**
  * Feature that is supported by the SDK (e.g. "TYPESCRIPT").
  */
-export type SDKFeature = 'TYPESCRIPT';
+export type SDKFeature =
+  | 'MULTIPLE_FILES'
+  | 'PROJECT_DEPENDENCIES'
+  | 'TYPESCRIPT'
+  | 'UNIMODULE_IMPORTS'
+  | 'POSTMESSAGE_TRANSPORT'
+  | 'VERSIONED_SNACKAGER';


### PR DESCRIPTION
# Why

www needs to check for some of these features. Adding back all of them since the goal of splitting out snack-content was not to change the public API.

# How

Just added back all the features

# Test Plan

Ran unit tests in snack-content