### PR TITLE
[runtime] Bump expo github actions to v7

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -35,10 +35,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: expo/expo-github-action@v6
+      - uses: expo/expo-github-action@v7
         with:
-          expo-version: 5.x
-          expo-cache: true
+          expo-version: latest
           token: ${{ secrets.EXPO_PRODUCTION }}
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -32,10 +32,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: expo/expo-github-action@v6
+      - uses: expo/expo-github-action@v7
         with:
-          expo-version: 5.x
-          expo-cache: true
+          expo-version: latest
           token: ${{ secrets.EXPO_STAGING }}
 
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
# Why

Always nice to keep this updated.

# How

Bumped up the workflow version

# Test Plan

See if CI works.