### PR TITLE
Fix docker images for website and snackager with eslint

### DIFF
--- a/snackager/Dockerfile
+++ b/snackager/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add git openssh-client
 
 # Workspace files
 WORKDIR /app
-COPY package.json yarn.lock .eslintrc.base.js .prettierrc ./
+COPY package.json yarn.lock .prettierrc ./
 
 # Workspace packages
 WORKDIR /app/packages

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -4,7 +4,7 @@ FROM mhart/alpine-node:${node_version} as dev
 
 # Workspace files
 WORKDIR /server
-COPY package.json yarn.lock .eslintrc.base.js .prettierrc ./
+COPY package.json yarn.lock .prettierrc ./
 
 # Workspace packages
 WORKDIR /server/packages


### PR DESCRIPTION
# Why

We don't have the `.eslintrc.base.js` anymore.

# How

Removed them from the docker images.

# Test Plan

See if staging deployments succeed