### PR TITLE
[website] Bump node to 12.22.11 and use node alpine image

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,6 +1,6 @@
 ARG node_version
 
-FROM mhart/alpine-node:${node_version} as dev
+FROM node:${node_version}-alpine as dev
 
 # Workspace files
 WORKDIR /server

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: website/Dockerfile
         buildArgs:
-          node_version: 12.18.4
+          node_version: 12.22.11
           LEGACY_SERVER_URL: https://staging.expo.io
           SERVER_URL: https://staging.expo.dev
           API_SERVER_URL: https://staging.exp.host
@@ -42,7 +42,7 @@ profiles:
           docker:
             dockerfile: website/Dockerfile
             buildArgs:
-              node_version: 12.18.4
+              node_version: 12.22.11
               LEGACY_SERVER_URL: https://expo.io
               SERVER_URL: https://expo.dev
               API_SERVER_URL: https://exp.host


### PR DESCRIPTION
# Why

- Fixes our pipeline again
- Probably should upgrade this to node 16 too

# How

- Upgraded Dockerfile for website
- Upgraded Skaffold node versions
- CI is left intact, as it uses the latest 12 already

# Test Plan

- See if CI staging deployment passes
