### PR TITLE
Bump node to 16.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Expo",
   "license": "MIT",
   "volta": {
-    "node": "12.16.2"
+    "node": "16.14.2"
   },
   "scripts": {
     "start": "cd packages/snack-term && yarn start && cd .."


### PR DESCRIPTION
# Why

Running the project via `yarn start` does not work with the current version of node, nor does it work with 12.22.11. There don't seem to be any issues with upgrading directly to the latest stable version of Node 16.

# How

Bump the volta node version in package.json.

# Test Plan

Run `yarn start` in root of the repo.
