### PR TITLE
[runtime] Fix linting in CI for runtime

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -27,36 +27,53 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+       - name: 🏗 Setup repo
+        uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            runtime/yarn.lock
 
-      - uses: expo/expo-github-action@v7
+      - name: 🏗 Setup Expo
+        uses: expo/expo-github-action@v7
         with:
           expo-version: latest
-          token: ${{ secrets.EXPO_PRODUCTION }}
+          token: ${{ secrets.EXPO_STAGING }}
 
-      - run: yarn install --frozen-lockfile
-      - run: yarn tsc --noEmit
-      - run: yarn lint --max-warnings 0
-      # - run: yarn test --ci --maxWorkers 15%
+      - name: 📦 Install monorepo dependencies
+        run: yarn install --frozen-lockfile
 
-      - name: Deploy web-player
+      - name: 📦 Install runtime dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: runtime
+
+      - name: 👷 Build runtime
+        run: yarn tsc --noEmit
+        working-directory: runtime
+      
+      - name: ✅ Lint runtime
+        run: yarn lint --max-warnings 0
+        working-directory: runtime
+
+      - name: 🌐 Deploy web-player
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:web:prod
+        working-directory: runtime
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_PRODUCTION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_PRODUCTION }}
 
-      - name: Deploy native runtime
+      - name: 📱 Deploy native runtime
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         run: yarn deploy:prod
+        working-directory: runtime
 
-      - name: Notify Slack
+      - name: 💬 Notify Slack
         uses: 8398a7/action-slack@v3
         if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-')) && github.event.inputs.deploy == 'deploy'
         env:

--- a/.github/workflows/runtime-staging.yml
+++ b/.github/workflows/runtime-staging.yml
@@ -1,9 +1,5 @@
 name: RuntimeStaging
 
-defaults:
-  run:
-    working-directory: runtime
-
 on:
   push:
     branches:
@@ -24,36 +20,53 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            runtime/yarn.lock
 
-      - uses: expo/expo-github-action@v7
+      - name: 🏗 Setup Expo
+        uses: expo/expo-github-action@v7
         with:
           expo-version: latest
           token: ${{ secrets.EXPO_STAGING }}
 
-      - run: yarn install --frozen-lockfile
-      - run: yarn tsc --noEmit
-      - run: yarn lint --max-warnings 0
-      # - run: yarn test --ci --maxWorkers 15%
+      - name: 📦 Install monorepo dependencies
+        run: yarn install --frozen-lockfile
 
-      - name: Deploy web-player
+      - name: 📦 Install runtime dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: runtime
+
+      - name: 👷 Build runtime
+        run: yarn tsc --noEmit
+        working-directory: runtime
+      
+      - name: ✅ Lint runtime
+        run: yarn lint --max-warnings 0
+        working-directory: runtime
+
+      - name: 🌐 Deploy web-player
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         run: yarn deploy:web:staging
+        working-directory: runtime
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
 
-      - name: Deploy native runtime
+      - name: 📱 Deploy native runtime
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         run: yarn deploy:staging
+        working-directory: runtime
 
-      - name: Notify Slack
+      - name: 💬 Notify Slack
         uses: 8398a7/action-slack@v3
         if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/sdk-'))
         env:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,9 +1,5 @@
 name: Runtime
 
-defaults:
-  run:
-    working-directory: runtime
-
 on:
   pull_request:
     paths:
@@ -19,15 +15,29 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
+            runtime/yarn.lock
 
-      - run: yarn install --frozen-lockfile
-      - run: yarn tsc --noEmit
-      - run: yarn lint --max-warnings 0
-      # - run: yarn test --ci --maxWorkers 15%
+      - name: 📦 Install root dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: 📦 Install runtime dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: runtime
+
+      - name: 👷 Build runtime
+        run: yarn tsc --noEmit
+        working-directory: runtime
+      
+      - name: ✅ Lint runtime
+        run: yarn lint --max-warnings 0
+        working-directory: runtime


### PR DESCRIPTION
# Why

The runtime still inherits some basic eslint tools from the root of the monorepo. That's why it also should install those dependecies.

# How

- Added "install monorepo dependencies"
- Added names for each steps to identify what they are doing

# Test Plan

CI should pass after merging #271