### PR TITLE
[runtime] Replace non-deterministic yarn behavior with two same packages

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "expo start",
     "web": "expo start --web",
-    "postinstall": "patch-package",
+    "postinstall": "yarn prepare-reanimated && patch-package",
     "lint": "eslint ./src ./types",
     "typescript": "tsc",
     "test": "jest",
@@ -18,7 +18,8 @@
     "predeploy:web:staging": "expo build:web",
     "predeploy:web:prod": "CLOUD_ENV=production NODE_ENV=production expo build:web",
     "deploy:web:staging": "s3-deploy './web-build/**' --cwd './web-build' --region us-west-1 --bucket snack-web-player-staging --filePrefix v2/$(node -pe \"require('./app.json').expo.sdkVersion.split('.')[0]\")",
-    "deploy:web:prod": "s3-deploy './web-build/**' --cwd './web-build' --region us-west-1 --bucket snack-web-player --filePrefix v2/$(node -pe \"require('./app.json').expo.sdkVersion.split('.')[0]\")"
+    "deploy:web:prod": "s3-deploy './web-build/**' --cwd './web-build' --region us-west-1 --bucket snack-web-player --filePrefix v2/$(node -pe \"require('./app.json').expo.sdkVersion.split('.')[0]\")",
+    "prepare-reanimated": "cp node_modules/react-native-reanimated/plugin.js node_modules/react-native-reanimated/plugin-standalone.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.3",
@@ -46,7 +47,6 @@
     "react-native": "0.64.3",
     "react-native-gesture-handler": "~2.1.0",
     "react-native-reanimated": "~2.3.3",
-    "react-native-reanimated-babel-standalone": "npm:react-native-reanimated@~2.3.3",
     "react-native-safe-area-context": "3.3.2",
     "react-native-view-shot": "3.1.2",
     "react-native-web": "0.17.1",

--- a/runtime/patches/react-native-reanimated+2.3.3.patch
+++ b/runtime/patches/react-native-reanimated+2.3.3.patch
@@ -1,7 +1,7 @@
-diff --git a/node_modules/react-native-reanimated-babel-standalone/plugin.js b/node_modules/react-native-reanimated-babel-standalone/plugin.js
+diff --git a/node_modules/react-native-reanimated/plugin-standalone.js b/node_modules/react-native-reanimated/plugin-standalone.js
 index 2fb0c21..050cc8b 100644
---- a/node_modules/react-native-reanimated-babel-standalone/plugin.js
-+++ b/node_modules/react-native-reanimated-babel-standalone/plugin.js
+--- a/node_modules/react-native-reanimated/plugin-standalone.js
++++ b/node_modules/react-native-reanimated/plugin-standalone.js
 @@ -1,8 +1,12 @@
  'use strict';
 -const generate = require('@babel/generator').default;

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { Platform, PixelRatio } from 'react-native';
 import * as GestureHandler from 'react-native-gesture-handler';
 // @ts-ignore: Could not find a declaration file for module 'react-native-reanimated/plugin'
-import Reanimated2Plugin from 'react-native-reanimated-babel-standalone/plugin';
+import Reanimated2Plugin from 'react-native-reanimated-babel-standalone/plugin-standalone';
 import * as babel from 'snack-babel-standalone';
 // Highest supported version of source-map is 0.6.1. As of 7.x source-map uses
 // web-assembly which is not yet supported on react-native.

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -10326,8 +10326,8 @@ react-native-gesture-handler@~2.1.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
-"react-native-reanimated-babel-standalone@npm:react-native-reanimated@~2.3.3", react-native-reanimated@~2.3.3:
-  name react-native-reanimated-babel-standalone
+react-native-reanimated@~2.3.3:
+  name react-native-reanimated
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.3.3.tgz#73de8ea495e59a091d848741e7037ac55d0235c4"
   integrity sha512-uQofwsWUoKLY4QDgSdNbRxnqQDaQEPLLBNO9SP64JfQ2fDRJD5rjb4d3S29F0z9FqTnsWEwTL2Sl0spdx9xvHA==


### PR DESCRIPTION
# Why

Instead of letting yarn install two separate instances of a package, we copy the plugin before applying a patch to it. That way, we can use a version in the snack runtime, and one in the snack code itself.

We might want to look for alternatives to this issue though.

# How

- Replaced "install this package twice" with:
- Copy `plugin.js` to `plugin-standalone.js`
- Apply the patch to `plugin-standalone.js`

# Test Plan

See if staging works
