### PR TITLE
Update website to Node 16

### DIFF
--- a/.github/workflows/runtime-production.yml
+++ b/.github/workflows/runtime-production.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-       - name: 🏗 Setup repo
+      - name: 🏗 Setup repo
         uses: actions/checkout@v3
 
       - name: 🏗 Setup Node

--- a/.github/workflows/website-production.yml
+++ b/.github/workflows/website-production.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,7 +51,8 @@ jobs:
       - run: yarn install --ignore-scripts --frozen-lockfile
       - run: yarn prepare
         working-directory: packages/snack-content
-      - run: yarn tsc --noEmit
+      - run: yarn build
+        working-directory: packages/snack-sdk
       - run: yarn test --maxWorkers 1
       - run: yarn lint --max-warnings 0
       - run: ../node_modules/.bin/env-cmd -f deploy/development/snack.env yarn build

--- a/website/package.json
+++ b/website/package.json
@@ -16,14 +16,15 @@
     "clean": "yarn clean:server && yarn clean:client",
     "clean:server": "del build/",
     "clean:client": "del dist/",
-    "lint": "eslint ./src ./typings",
+    "lint": "eslint ./src",
     "test": "env-cmd -e test jest --config jest/unit.config.js",
     "prebuild": "yarn clean"
   },
   "author": "Expo",
   "license": "MIT",
   "volta": {
-    "node": "12.18.4"
+    "node": "16.14.2",
+    "npm": "6.14.16"
   },
   "dependencies": {
     "@babel/parser": "^7.12.16",
@@ -89,7 +90,7 @@
     "@babel/preset-env": "^7.12.16",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
-    "@tsconfig/node12": "^1.0.7",
+    "@tsconfig/node16": "^1.0.2",
     "@types/amplitude-js": "^6.0.0",
     "@types/aphrodite": "^0.5.13",
     "@types/bunyan": "^1.8.6",
@@ -157,7 +158,7 @@
     "ts-jest": "^26.5.0",
     "ts-node-dev": "^1.1.1",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.3",
     "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1",
     "webpack-dev-middleware": "^3.5.1",

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: website/Dockerfile
         buildArgs:
-          node_version: 12.22.11
+          node_version: 16.14.2
           LEGACY_SERVER_URL: https://staging.expo.io
           SERVER_URL: https://staging.expo.dev
           API_SERVER_URL: https://staging.exp.host
@@ -42,7 +42,7 @@ profiles:
           docker:
             dockerfile: website/Dockerfile
             buildArgs:
-              node_version: 12.22.11
+              node_version: 16.14.2
               LEGACY_SERVER_URL: https://expo.io
               SERVER_URL: https://expo.dev
               API_SERVER_URL: https://exp.host

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
     "allowJs": true,
@@ -15,11 +15,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false,
     "strict": true,
-    "baseUrl": "./",
-    "paths": {
-      "snack-content": ["../packages/snack-content/src"],
-      "snack-sdk": ["../packages/snack-sdk/src"]
-    }
-  },
+    "baseUrl": "./"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14965,11 +14965,6 @@ typescript@^4.1.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-
 typescript@^4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"


### PR DESCRIPTION
# Why

We want all of snack to be using Node 16 over 12

# How

* [website] Update CI to use Node 16

* [website] Bump to Node 16.14.2

* [website] Remove TS reference to snack-sdk and snack-content

* [website] Update skaffold to reflect node 16.14.2

# Test Plan

TBD
