### PR TITLE
[website] Rework dockerfile to assume monorepo structure

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,45 +1,25 @@
 ARG node_version
 
+# Set up dev image
 FROM node:${node_version}-alpine as dev
-
-# Workspace files
 WORKDIR /server
-COPY package.json yarn.lock .prettierrc ./
 
-# Workspace packages
-WORKDIR /server/packages
-COPY packages/snack-content ./snack-content
-COPY packages/snack-sdk ./snack-sdk
-
-# website
-WORKDIR /server/website
-COPY website/jest ./jest
-COPY website/src ./src
-COPY website/typings ./typings
-COPY website/package.json website/resources.json website/favicon.ico ./
-COPY website/.env-cmdrc.json ./
-COPY website/.eslintignore website/.eslintrc.js ./
-COPY website/babel.config.js website/tsconfig.json website/webpack.config.js ./
-
+# Set up monorepo
+COPY . ./
 # Install dependencies
-RUN yarn --frozen-lockfile --production=false
-
-# Build snack-content
-WORKDIR /server/packages/snack-content
+RUN yarn install --frozen-lockfile
+# Build monorepo
 RUN yarn build
 
-# Build snack-sdk
-WORKDIR /server/packages/snack-sdk
-RUN yarn build
-
-# Website
+# Start website
 WORKDIR /server/website
-
 CMD ["yarn", "start"]
 
-FROM dev
+# Set up builder image (for production)
+FROM dev as builder
+WORKDIR /server
 
-# set up the webpack/next.js build variables
+# Set up the webpack/next.js build variables
 ENV NODE_ENV "production"
 
 ARG APP_VERSION
@@ -81,19 +61,30 @@ ENV SNACK_WEBPLAYER_CDN ${SNACK_WEBPLAYER_CDN}
 ARG SNACK_AMPLITUDE_KEY
 ENV SNACK_AMPLITUDE_KEY ${SNACK_AMPLITUDE_KEY}
 
-# Build
-RUN yarn tsc --noEmit
-
-# Lint
-RUN yarn lint --max-warnings 0
-
-# Test
-RUN yarn test --maxWorkers 1
-
-# Build the JS
+# Build production files
 RUN yarn build
+RUN yarn --cwd ./website build
 
-# Remove devDependencies
-RUN yarn --frozen-lockfile --production
+# Set up production image
+FROM node:${node_version}-alpine
+WORKDIR /server
+# - root monorepo files
+COPY --from=builder /server/package.json ./
+COPY --from=builder /server/yarn.lock ./
+# - used packages files
+COPY --from=builder /server/packages/snack-content/build ./packages/snack-content/build
+COPY --from=builder /server/packages/snack-content/package.json ./packages/snack-content/package.json
+COPY --from=builder /server/packages/snack-sdk/build ./packages/snack-sdk/build
+COPY --from=builder /server/packages/snack-sdk/package.json ./packages/snack-sdk/package.json
+# - website files
+COPY --from=builder /server/website/build ./website/build
+COPY --from=builder /server/website/dist ./website/dist
+COPY --from=builder /server/website/package.json ./website/package.json
+COPY --from=builder /server/website/favicon.ico ./website/favicon.ico
+COPY --from=builder /server/website/resources.json ./website/resources.json
 
+# Reinstall production-only dependencies
+RUN yarn install --frozen-lockfile --production
+
+WORKDIR /server/website
 CMD ["node", "."]


### PR DESCRIPTION
# Why

Unblocks us from deploying the website. Will test staging first.

# How

Instead of selectively parsing/building packages, we just copy the whole repo and build it for production. In the last step, only the built files are copied into the deployed production image.

# Test Plan

- Deploy to staging and see if the website is fully functional