### PR TITLE
[packages] Prepare snack-sdk and snack-content for SDK 44

### DIFF
--- a/packages/snack-content/package.json
+++ b/packages/snack-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-content",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Functions and types that describe the contents of Snack projects",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "yarn clean && tsc",
-    "clean": "rm -fr build",
+    "clean": "rimraf build",
     "prepare": "yarn build",
     "test": "jest",
     "lint": "eslint src"
@@ -35,6 +35,7 @@
     "@types/jest": "^27.4.0",
     "@types/semver": "^7.3.9",
     "jest": "^27.5.1",
+    "rimraf": "^3.0.2",
     "ts-jest": "~27.1.3",
     "typescript": "^4.1.2"
   }

--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,6 +1,6 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '43.0.0';
+export const defaultSdkVersion: SDKVersion = '44.0.0';
 
 // Mostly used for tests
 export const oldestSdkVersion: SDKVersion = '41.0.0';

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-sdk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "The Expo Snack SDK",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -61,7 +61,7 @@
     "nullthrows": "^1.1.1",
     "pubnub": "^4.29.10",
     "semver": "^7.3.4",
-    "snack-content": "^1.0.0",
+    "snack-content": "^1.1.0",
     "ua-parser-js": "^0.7.22",
     "validate-npm-package-name": "^3.0.0"
   }

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -200,7 +200,7 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~1.10.2",
+    "wantedVersion": "~2.1.0",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.43.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.44.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/packages/snack-sdk/src/__tests__/sdkversion-test.ts
+++ b/packages/snack-sdk/src/__tests__/sdkversion-test.ts
@@ -1,5 +1,5 @@
 import '../__mocks__/fetch';
-import { getSupportedSDKVersions, newestSdkVersion } from 'snack-content';
+import { getSupportedSDKVersions, oldestSdkVersion, newestSdkVersion } from 'snack-content';
 
 import Snack, { defaultConfig } from './snack-sdk';
 
@@ -20,7 +20,7 @@ describe('sdkVersion', () => {
   });
 
   it('can be changed', async () => {
-    const snack = new Snack({});
+    const snack = new Snack({ sdkVersion: oldestSdkVersion });
     snack.setSDKVersion(newestSdkVersion);
     expect(snack.getState()).toMatchObject({
       unsaved: true,


### PR DESCRIPTION
# Why

Rolling out SDK 44 support fully.

# How

Minor updated `snack-sdk` and `snack-content`.

# Test Plan

- Tested on both staging and production (in that order ofc 😄)
