### PR TITLE
[CI] Add rollouts to general-central

### DIFF
--- a/.github/workflows/snackager-production.yml
+++ b/.github/workflows/snackager-production.yml
@@ -78,20 +78,6 @@ jobs:
         run: ENVIRONMENT=production skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
         working-directory: ./
 
-      - name: Add change cause
-        run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
-        working-directory: snackager/k8s/production
-
-      - name: Deploy to production
-        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
-        run: ENVIRONMENT=production skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
-        working-directory: ./
-
-      - name: Prune docker images
-        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
-        run: ./bin/prune-gcr snackager
-        working-directory: ./
-
       - name: Notify build on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy != 'deploy'
@@ -102,6 +88,28 @@ jobs:
           status: ${{ job.status }}
           author_name: Build Snackager for Production
           fields: message,commit,author,took
+
+      - name: Add change cause
+        run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
+        working-directory: snackager/k8s/production
+
+      - name: Deploy to production
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ENVIRONMENT=production skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+
+      - name: Configure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central general-central
+
+      - name: Deploy to production in new cluster
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ENVIRONMENT=production skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+
+      - name: Prune docker images
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ./bin/prune-gcr snackager
+        working-directory: ./
 
       - name: Notify deploy on Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/snackager-staging.yml
+++ b/.github/workflows/snackager-staging.yml
@@ -86,6 +86,14 @@ jobs:
         run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
         working-directory: ./
 
+      - name: Configure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central general-central
+
+      - name: Deploy to staging in new cluster
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
         if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/.github/workflows/website-production.yml
+++ b/.github/workflows/website-production.yml
@@ -71,6 +71,14 @@ jobs:
         run: ENVIRONMENT=production skaffold deploy --filename website/skaffold.yaml --status-check true --build-artifacts website/build.json
         working-directory: ./
 
+      - name: Reconfigure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central1 general-central
+
+      - name: Deploy to production in new cluster
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ENVIRONMENT=production skaffold deploy --filename website/skaffold.yaml --status-check true --build-artifacts website/build.json
+        working-directory: ./
+
       - name: Notify build on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy != 'deploy'

--- a/.github/workflows/website-production.yml
+++ b/.github/workflows/website-production.yml
@@ -100,3 +100,13 @@ jobs:
           status: ${{ job.status }}
           author_name: Deploy Snack website to Production
           fields: message,commit,author,took
+
+      - name: Install python to run prune-gcr script
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Prune docker images
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ./bin/prune-gcr snack
+        working-directory: ./

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -84,3 +84,13 @@ jobs:
           status: ${{ job.status }}
           author_name: Deploy Snack website to Staging
           fields: message,commit,author,took
+
+      - name: Install python to run prune-gcr script
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Prune docker images
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event.inputs.deploy == 'deploy'
+        run: ./bin/prune-gcr snack --dry-run
+        working-directory: ./

--- a/.github/workflows/website-staging.yml
+++ b/.github/workflows/website-staging.yml
@@ -66,6 +66,14 @@ jobs:
         run: skaffold deploy --filename website/skaffold.yaml --status-check true --build-artifacts website/build.json
         working-directory: ./
 
+      - name: Reconfigure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central1 general-central
+
+      - name: Deploy to staging in new cluster
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: skaffold deploy --filename website/skaffold.yaml --status-check true --build-artifacts website/build.json
+        working-directory: ./
+
       - name: Notify Slack
         uses: 8398a7/action-slack@v3
         if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'


### PR DESCRIPTION
# Why

We are moving all our services to a new kubernetes cluster.

# How

For both snackager and the website, on both the staging and production workflows, after successfully rolling out any changes to `exp-central`, the workflow runs `gcloud container clusters get-credentials --region us-central general-central`, which both creates and activates a kubectl config context that works for the cluster named `general-central`.  Then it re-runs the `skaffold deploy` command, rolling out the same changes to the new cluster.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

On my own machine, i was able to run `skaffold run` for snackager and the website on staging and production of the new cluster, so I'm confident that the deployments can stabilize.

I'll make changes outside of this PR to migrate traffic to the services running in the new cluster.  And once I have, I can come back to remove the rollouts to the old cluster. 
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
