### PR TITLE
[snackager] Add missing text input external for Stripe

### DIFF
--- a/runtime/src/aliases/index.tsx
+++ b/runtime/src/aliases/index.tsx
@@ -14,6 +14,7 @@ const aliases: { [key: string]: any } = {
   'react-native/Libraries/Utilities/dismissKeyboard': require('react-native/Libraries/Utilities/dismissKeyboard'), // for @react-native-community/viewpager
   'react-native/Libraries/Renderer/shims/ReactNative': require('react-native/Libraries/Renderer/shims/ReactNative'), // for react-native-reanimated
   'react-native/Libraries/Components/UnimplementedViews/UnimplementedView': require('react-native/Libraries/Components/UnimplementedViews/UnimplementedView'), // for @react-native-picker/picker@1.9.11
+  'react-native/Libraries/Components/TextInput/TextInputState': require('react-native/Libraries/Components/TextInput/TextInputState'), // for @stripe/stripe-react-native
 };
 
 export default aliases;

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -26,6 +26,7 @@ const CORE_EXTERNALS = [
   'react-native/Libraries/Utilities/dismissKeyboard', // used by @react-native-community/viewpager@4.2.0
   'react-native/Libraries/Renderer/shims/ReactNative', // Used by moti
   'react-native/Libraries/Components/UnimplementedViews/UnimplementedView', // Used by @react-native-picker/picker@1.9.11
+  'react-native/Libraries/Components/TextInput/TextInputState', // Used by @stripe/stripe-react-native
   // TODO: decide whether to treat prop-types as an external or not
   // previously it was always installed as a dependency and not treated as an external.
   // This however caused packages to be slightly larger than needed to be.


### PR DESCRIPTION
# Why

Stripe uses this one, so we need to mark it as external.

# How

Would be better if we can use the package-spec instead. e.g.

- `react-native/*` → external because of `react-native`

# Test Plan

- Check if `@stripe/stripe-react-native` builds with Snackager
> [There is an ongoing issue with the files pointing to a non-existing `package.json`. Once this is resolved, we can test this](https://github.com/stripe/stripe-react-native/pull/924).