### PR TITLE
[snackager] Add explicit RN web external for react native maps

### DIFF
--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -26,6 +26,7 @@ const CORE_EXTERNALS = [
   'react-native/Libraries/Utilities/dismissKeyboard', // used by @react-native-community/viewpager@4.2.0
   'react-native/Libraries/Renderer/shims/ReactNative', // Used by moti
   'react-native/Libraries/Components/UnimplementedViews/UnimplementedView', // Used by @react-native-picker/picker@1.9.11
+  'react-native-web/dist/modules/UnimplementedView', // Used by react-native-maps
   // TODO: decide whether to treat prop-types as an external or not
   // previously it was always installed as a dependency and not treated as an external.
   // This however caused packages to be slightly larger than needed to be.


### PR DESCRIPTION
# Why

Currently, bundling of `react-native-maps@0.29.4` fails with the error:

```
Failed to resolve dependency 'react-native-maps@0.29.4' (Module not found: Error: Package path ./unstable-native-dependencies is not exported from package /tmp/snackager/snackager/buildStatus/1/react-native-maps@0.29.4-ios,android,web/package/node_modules/react-dom (see exports field in /tmp/snackager/snackager/buildStatus/1/react-native-maps@0.29.4-ios,android,web/package/node_modules/react-dom/package.json)
Retry
Module not found: Error: Package path ./unstable-native-dependencies is not exported from package /tmp/snackager/snackager/buildStatus/1/react-native-maps@0.29.4-ios,android,web/package/node_modules/react-dom (see exports field in /tmp/snackager/snackager/buildStatus/1/react-native-maps@0.29.4-ios,android,web/package/node_modules/react-dom/package.json))
```

In [this run you can see that `react-dom` and `react-native-web` are getting sucked into the bundle](https://github.com/expo/snack/runs/6276910681?check_suite_focus=true#step:6:167).

# How

- Added explicit RN web external to avoid `react-dom` getting sucked into the bundle.

# Test Plan

- See if bundling passes with this change
