### PR TITLE
[snackager] Let bundle cli command fail on error

### DIFF
--- a/snackager/src/cli.ts
+++ b/snackager/src/cli.ts
@@ -86,4 +86,7 @@ async function main(): Promise<void> {
 
 main()
   .then(() => console.log('ok!'))
-  .catch((e) => console.error(e));
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
# Why

Makes it more obvious in the workflow when testing libraries

# How

- Added `process.exit(1)` to the error handling in CLI

# Test Plan

- See if CI passes
