### PR TITLE
[snackager] Fix workflow and unify into one

### DIFF
--- a/.github/actions/setup-google-cloud/action.yml
+++ b/.github/actions/setup-google-cloud/action.yml
@@ -4,6 +4,7 @@ description: Prepare Snackager in GitHub Actions
 inputs:
   python-version:
     description: Python version to use when installing Google Cloud SDK
+    default: '2.7'
 
   project-id:
     description: Google Cloud SDK project id

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -4,7 +4,21 @@ defaults:
   run:
     working-directory: snackager
 
+concurrency:
+  group: snackager-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: What environment should be deployed
+        type: choice
+        default: no-deploy
+        options:
+          - no-deploy
+          - staging
+          - production
   pull_request:
     paths:
       - .github/workflows/snackager.yml
@@ -13,9 +27,18 @@ on:
       - .eslint*
       - .prettier*
       - yarn.lock
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/snackager-production.yml
+      - snackager/**
+      - packages/snack-sdk/**
+      - .eslint*
+      - .prettier*
+      - yarn.lock
 
 jobs:
-  build:
+  review:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repository
@@ -37,3 +60,152 @@ jobs:
       
       - name: 🧪 E2E test snackager
         run: yarn test --ci --runInBand --testPathPattern=__integration-tests__
+        # Takes a long time, best to only run this on PRs
+        if: ${{ github.event_name == 'pull_request' }}
+  
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup secrets
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: 🏗 Setup Google Cloud SDK
+        uses: ./.github/actions/setup-google-cloud
+        with:
+          project-id: exponentjs
+          project-zone: us-central1-f
+          project-cluster: exp-central
+          service-key: ${{ secrets.GCLOUD_KEY }}
+      
+      - name: 🛠 Build snackager
+        run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
+        working-directory: ./
+
+  deploy-staging:
+    if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    needs: review
+    runs-on: ubuntu-latest
+    environment: 
+      name: snackager-staging
+      url: https://staging.snackager.expo.io
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup secrets
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: 🏗 Setup Google Cloud SDK
+        uses: ./.github/actions/setup-google-cloud
+        with:
+          project-id: exponentjs
+          project-zone: us-central1-f
+          project-cluster: exp-central
+          service-key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: 🛠 Build snackager
+        run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
+        working-directory: ./
+
+      - name: 🧹 Dry-run prune docker image
+        run: ./bin/prune-gcr snackager --dry-run
+        working-directory: ./
+
+      - name: 📋 Add change cause
+        run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
+        working-directory: snackager/k8s/staging
+
+      - name: 🚀 Deploy snackager in old cluster
+        run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+
+      - name: ⚙️ Configure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central1 general-central
+      
+      - name: 🚀 Deploy snackager in new cluster
+        run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+
+      - name: 💬 Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Snackager to Staging
+          fields: message,commit,author,job,took
+
+  deploy-production:
+    if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
+    needs: review
+    runs-on: ubuntu-latest
+    environment: 
+      name: snackager-production
+      url: https://snackager.expo.io
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup secrets
+        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: 🏗 Setup Google Cloud SDK
+        uses: ./.github/actions/setup-google-cloud
+        with:
+          project-id: exponentjs
+          project-zone: us-central1-f
+          project-cluster: exp-central
+          service-key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: 🛠 Build snackager
+        run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
+        working-directory: ./
+        env:
+          ENVIRONMENT: production
+
+      - name: 📋 Add change cause
+        run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
+        working-directory: snackager/k8s/production
+
+      - name: 🚀 Deploy snackager in old cluster
+        run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+        env:
+          ENVIRONMENT: production
+
+      - name: ⚙️ Configure kubectl for new cluster
+        run: gcloud container clusters get-credentials --region us-central1 general-central
+      
+      - name: 🚀 Deploy snackager in new cluster
+        run: skaffold deploy --filename snackager/skaffold.yaml --status-check true --build-artifacts snackager/build.json
+        working-directory: ./
+        env:
+          ENVIRONMENT: production
+
+      - name: 🧹 Prune docker image
+        if: ${{ success() }}
+        run: ./bin/prune-gcr snackager
+        working-directory: ./
+
+      - name: 💬 Notify Slack
+        if: ${{ always() }}
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Snackager to Production
+          fields: message,commit,author,job,took
+


### PR DESCRIPTION
# Why

Right now, the Snackager workflow fails. This fixes that by adding the missing python version, and some other improvements.

# How

1. Unify the Snackager review, build, and deploy workflows. Having 1 place is easier to find.
2. Add environment references to the deploy-(staging|production) workflows. Gives us a better overview of who deployed what, where, and when.
3. Add option to deploy staging manually again from main

The reasoning for the review, build, and deploy-(staging|production) jobs are:
- **review**
  → Check if the code quality, style, and tests are passing with the latest changes from PRs.
- **build** 
  → Check if we can build the image (fixed in staging mode) with the latest changes from PRs.
- **deploy-staging**
  → Auto-deploy when (merged to main or manually deploying from main), and only when both **review** and **build** passes
- **deploy-production**
  → Manually deploy from main, when **review** passes.

> When upgrading SDK 44 and Node 16, we've had some issues with the Dockerimage not being built properly. The **build** job should catch this early on next time, and is the only one which got added.

# Test Plan

- See if CI passes
