### PR TITLE
[runtime] Add missing web external for react-native-maps

### DIFF
--- a/runtime/src/aliases/index.web.tsx
+++ b/runtime/src/aliases/index.web.tsx
@@ -7,6 +7,8 @@ const aliases: { [key: string]: any } = {
   'react-native': require('react-native-web'),
   'react-native-web': require('react-native-web'),
   'react-native-web/dist/modules/AssetRegistry': AssetRegistry,
+
+  'react-native-web/dist/modules/UnimplementedView': require('react-native-web/dist/modules/UnimplementedView'), // for react-native-maps@0.29.4
 };
 
 export default aliases;


### PR DESCRIPTION
# Why

Without this, it can't resolve the external added in #283 

# How

- Added external in runtime web aliases

# Test Plan

- See if staging works.