### PR TITLE
[runtime] Unify github workflows like snackager

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -1,0 +1,37 @@
+name: Setup Runtime
+description: Prepare Runtime in GitHub Actions
+
+inputs:
+  node-version:
+    description: Version of Node to use
+    default: 16.x
+  
+  expo-version:
+    description: Version of Expo CLI to use
+    default: latest
+  
+  expo-token:
+    description: Expo authentication token to publish
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: 🏗 Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: runtime/yarn.lock
+
+    - name: 🏗 Setup Expo
+      uses: expo/expo-github-action@v7
+      with:
+        expo-version: ${{ inputs.expo-version }}
+        token: ${{ inputs.expo-token }}
+
+    # Runtime is detached from the monorepo, we only need to install this
+    - name: 📦 Install dependencies
+      run: yarn install --frozen-lockfile --ignore-scripts
+      working-directory: runtime
+      shell: bash

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,7 +1,32 @@
 name: Runtime
 
+defaults:
+  run:
+    working-directory: runtime
+
+concurrency:
+  group: runtime-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: What environment should be deployed
+        type: choice
+        default: no-deploy
+        options:
+          - no-deploy
+          - staging
+          - production
   pull_request:
+    paths:
+      - .github/workflows/runtime.yml
+      - runtime/**
+      - .eslint*
+      - .prettier*
+  push:
+    branches: [main]
     paths:
       - .github/workflows/runtime.yml
       - runtime/**
@@ -9,35 +34,89 @@ on:
       - .prettier*
 
 jobs:
-  build:
+  review:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3
-
-      - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-          cache-dependency-path: |
-            yarn.lock
-            runtime/yarn.lock
-
-      - name: 📦 Install monorepo dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: 📦 Install runtime dependencies
-        run: yarn install --frozen-lockfile
-        working-directory: runtime
+      
+      - name: 🏗 Setup runtime
+        uses: ./.github/actions/setup-runtime
 
       - name: 👷 Build runtime
         run: yarn tsc --noEmit
-        working-directory: runtime
       
-      - name: ✅ Lint runtime
+      - name: 🚨 Lint runtime
         run: yarn lint --max-warnings 0
-        working-directory: runtime
+  
+  deploy-staging:
+    if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    needs: review
+    runs-on: ubuntu-latest
+    environment:
+      name: runtime-staging
+      url: https://staging.expo.dev/@exponent/snack
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+      
+      - name: 🏗 Setup runtime
+        uses: ./.github/actions/setup-snackager
+        with:
+          expo-token: ${{ secrets.EXPO_STAGING }}
+      
+      - name: 🌐 Deploy web-player
+        run: yarn deploy:web:staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
+
+      - name: 📱 Deploy native runtime
+        run: yarn deploy:staging
+
+      - name: 💬 Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: ${{ always() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Staging
+          fields: message,commit,author,job,took
+
+  deploy-production:
+    if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
+    needs: review
+    runs-on: ubuntu-latest
+    environment:
+      name: runtime-production
+      url: https://expo.dev/@exponent/snack
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+      
+      - name: 🏗 Setup runtime
+        uses: ./.github/actions/setup-snackager
+        with:
+          expo-token: ${{ secrets.EXPO_PRODUCTION }}
+      
+      - name: 🌐 Deploy web-player
+        run: yarn deploy:web:prod
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RUNTIME_KEY_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RUNTIME_SECRET_STAGING }}
+
+      - name: 📱 Deploy native runtime
+        run: yarn deploy:prod
+
+      - name: 💬 Notify Slack
+        uses: 8398a7/action-slack@v3
+        if: ${{ always() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SNACK }}
+        with:
+          channel: '#snack'
+          status: ${{ job.status }}
+          author_name: Deploy Runtime to Production
+          fields: message,commit,author,job,took

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -93,7 +93,7 @@ jobs:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: snackager-staging
       url: https://staging.snackager.expo.io
     steps:
@@ -151,7 +151,7 @@ jobs:
     if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
     needs: review
     runs-on: ubuntu-latest
-    environment: 
+    environment:
       name: snackager-production
       url: https://snackager.expo.io
     steps:


### PR DESCRIPTION
# Why

Just like Snackager's workflow #285, unify the runtime.

# How

- Unified with environments and additional manual deploy options.

# Test Plan

- See if CI successfully deploys
