### PR TITLE
[snackager] Hide babel peer dependencies from dependency list

### DIFF
--- a/snackager/src/utils/__tests__/resolveDependencies.test.ts
+++ b/snackager/src/utils/__tests__/resolveDependencies.test.ts
@@ -1,13 +1,14 @@
 import { Metadata } from '../../types';
 import resolveDependencies from '../resolveDependencies';
 
-const metaFixture: Metadata = {
+const fixture: Metadata = {
   name: '<package>',
   'dist-tags': {
     latest: '1.0.0',
     'vector-icons': '1.1.0',
     'windows-dep': '2.0.0',
     'windows-peer': '2.1.0',
+    'babel-peer': '3.0.0',
   },
   versions: {
     '1.0.0': { name: '<package>', version: '1.0.0', dist: {} as any },
@@ -30,37 +31,49 @@ const metaFixture: Metadata = {
       dist: {} as any,
       peerDependencies: { 'react-native-windows': 'latest' },
     },
+    '3.0.0': {
+      name: '<package>',
+      version: '3.0.0',
+      dist: {} as any,
+      peerDependencies: { '@babel/core': 'latest' },
+    },
   },
 };
 
 it('returns non-latest version', () => {
-  expect(resolveDependencies(metaFixture, '1.0.1', false)).toMatchObject({
-    pkg: metaFixture.versions['1.0.1'],
+  expect(resolveDependencies(fixture, '1.0.1', false)).toMatchObject({
+    pkg: fixture.versions['1.0.1'],
     hash: '<package>@1.0.1',
     latestHash: null,
   });
 });
 
 it('returns latest version and deep module', () => {
-  expect(resolveDependencies(metaFixture, '1.0.0', true, 'lib/some/module')).toMatchObject({
-    pkg: metaFixture.versions['1.0.0'],
+  expect(resolveDependencies(fixture, '1.0.0', true, 'lib/some/module')).toMatchObject({
+    pkg: fixture.versions['1.0.0'],
     hash: '<package>~lib~some~module@1.0.0',
     latestHash: '<package>~lib~some~module@latest',
   });
 });
 
 it('adds `@expo/vector-icons` instead of `react-native-vector-icons` as peer dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['vector-icons'], true);
-  expect(result).toHaveProperty('dependencies.@expo/vector-icons');
-  expect(result).not.toHaveProperty('dependencies.react-native-vector-icons');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['vector-icons'], true);
+  expect(result.dependencies).toHaveProperty('@expo/vector-icons');
+  expect(result.dependencies).not.toHaveProperty('react-native-vector-icons');
 });
 
 it('ignores `react-native-windows` as dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['windows-dep'], false);
-  expect(result).not.toHaveProperty('dependencies.react-native-windows');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['windows-dep'], false);
+  expect(result.dependencies).not.toHaveProperty('react-native-windows');
 });
 
 it('ignores `react-native-windows` as peer dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['windows-peer'], false);
-  expect(result).not.toHaveProperty('dependencies.react-native-windows');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['windows-peer'], false);
+  expect(result.dependencies).not.toHaveProperty('react-native-windows');
+});
+
+it('hides `@babel/core` as peer dependency', () => {
+  const result = resolveDependencies(fixture, fixture['dist-tags']['babel-peer'], false);
+  expect(result.dependencies).not.toHaveProperty('@babel/core');
+  expect(result.pkg.peerDependencies).not.toHaveProperty('@babel/core');
 });

--- a/snackager/src/utils/resolveDependencies.ts
+++ b/snackager/src/utils/resolveDependencies.ts
@@ -4,7 +4,11 @@ import { Metadata, Package } from '../types';
 // TODO: find the typescript definitions for this package, `@types/semver-utils` doesn't exists
 const semverUtils = require('semver-utils');
 
+// There are two special types of dependencies that should not be included in Snackager results.
+// 1. "Ignored dependencies" - dependencies that are ok to include in the output, but should not be bundled.
+// 2. "Hidden peer dependencies" - dependencies that should not be included in the output and the package definition, as including them would break things in the website
 const IGNORED_DEPENDENCIES = ['react-native-windows'];
+const HIDDEN_PEER_DEPENDENCIES = ['@babel/core']; // required for react-native-reanimated@2.8.0
 
 type ResolvedDependencies = {
   pkg: Package;
@@ -25,7 +29,10 @@ export default function resolveDependencies(
   const dependencies: { [key: string]: string | null } = {};
 
   for (const name in peerDependencies) {
-    if (IGNORED_DEPENDENCIES.includes(name)) {
+    if (HIDDEN_PEER_DEPENDENCIES.includes(name)) {
+      // hide from pkg
+      delete pkg.peerDependencies?.[name];
+    } else if (IGNORED_DEPENDENCIES.includes(name)) {
       // ignore
     } else if (name === 'react-native-vector-icons') {
       dependencies['@expo/vector-icons'] = null;


### PR DESCRIPTION
# Why

Reanimated has listed `@babel/core` as peer dependency, and is therefore triggering a "Package requires babel, do you want to install it?". This package specifically should never be added manually. We use a custom babel pipeline in the runtime to transpile user-input on the fly, and it would break with adding babel inside babel.

# How

Added _hidden peer dependencies_, next to _ignored dependencies_ when resolving package dependencies.

# Test Plan

See added unit test + CI