### PR TITLE
[website] Add prettier to dependencies to lazy load in production

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -60,6 +60,7 @@
     "nanoid": "^3.1.16",
     "node-fetch": "^2.6.1",
     "nullthrows": "^1.1.1",
+    "prettier": "^2.6.2",
     "prismjs": "^1.21.0",
     "qrcode.react": "^1.0.0",
     "query-string": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4474,6 +4474,11 @@ b64u-lite@^1.0.1:
   dependencies:
     b64-lite "^1.4.0"
 
+babel-core@7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"


### PR DESCRIPTION
# Why

Fixes #291

We lazy-load prettier in the website whenever it's requested ([here](https://github.com/expo/snack/blob/main/website/src/client/utils/prettierCode.tsx#L12)), but we don't explicitly mention prettier as dependency in website. This will not install prettier as dependency in the production environment.

# How

Added prettier dependency to website

# Test Plan

Deploy to staging, see if it works.
