### PR TITLE
[website] Set default back to sdk 44 and centralize switch

### DIFF
--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,6 +1,6 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '45.0.0';
+export const defaultSdkVersion: SDKVersion = '44.0.0';
 
 // Mostly used for tests
 export const oldestSdkVersion: SDKVersion = '43.0.0';

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -200,7 +200,7 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~2.2.1",
+    "wantedVersion": "~2.1.0",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.45.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.44.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
@@ -223,7 +223,7 @@ Array [
         },
         "description": "test2 @ Jan 1, 2020",
         "name": "test2",
-        "sdkVersion": "45.0.0",
+        "sdkVersion": "44.0.0",
       },
     },
     "headers": Object {
@@ -261,7 +261,7 @@ Array [
         },
         "description": "test3 @ Jan 1, 2020",
         "name": "test3",
-        "sdkVersion": "45.0.0",
+        "sdkVersion": "44.0.0",
       },
     },
     "headers": Object {
@@ -295,7 +295,7 @@ Array [
         },
         "description": "some-example @ Jan 1, 2020",
         "name": "some-example",
-        "sdkVersion": "45.0.0",
+        "sdkVersion": "44.0.0",
       },
     },
     "headers": Object {

--- a/snackager/src/utils/__tests__/resolveDependencies.test.ts
+++ b/snackager/src/utils/__tests__/resolveDependencies.test.ts
@@ -1,13 +1,14 @@
 import { Metadata } from '../../types';
 import resolveDependencies from '../resolveDependencies';
 
-const metaFixture: Metadata = {
+const fixture: Metadata = {
   name: '<package>',
   'dist-tags': {
     latest: '1.0.0',
     'vector-icons': '1.1.0',
     'windows-dep': '2.0.0',
     'windows-peer': '2.1.0',
+    'babel-peer': '3.0.0',
   },
   versions: {
     '1.0.0': { name: '<package>', version: '1.0.0', dist: {} as any },
@@ -30,37 +31,49 @@ const metaFixture: Metadata = {
       dist: {} as any,
       peerDependencies: { 'react-native-windows': 'latest' },
     },
+    '3.0.0': {
+      name: '<package>',
+      version: '3.0.0',
+      dist: {} as any,
+      peerDependencies: { '@babel/core': 'latest' },
+    },
   },
 };
 
 it('returns non-latest version', () => {
-  expect(resolveDependencies(metaFixture, '1.0.1', false)).toMatchObject({
-    pkg: metaFixture.versions['1.0.1'],
+  expect(resolveDependencies(fixture, '1.0.1', false)).toMatchObject({
+    pkg: fixture.versions['1.0.1'],
     hash: '<package>@1.0.1',
     latestHash: null,
   });
 });
 
 it('returns latest version and deep module', () => {
-  expect(resolveDependencies(metaFixture, '1.0.0', true, 'lib/some/module')).toMatchObject({
-    pkg: metaFixture.versions['1.0.0'],
+  expect(resolveDependencies(fixture, '1.0.0', true, 'lib/some/module')).toMatchObject({
+    pkg: fixture.versions['1.0.0'],
     hash: '<package>~lib~some~module@1.0.0',
     latestHash: '<package>~lib~some~module@latest',
   });
 });
 
 it('adds `@expo/vector-icons` instead of `react-native-vector-icons` as peer dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['vector-icons'], true);
-  expect(result).toHaveProperty('dependencies.@expo/vector-icons');
-  expect(result).not.toHaveProperty('dependencies.react-native-vector-icons');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['vector-icons'], true);
+  expect(result.dependencies).toHaveProperty('@expo/vector-icons');
+  expect(result.dependencies).not.toHaveProperty('react-native-vector-icons');
 });
 
 it('ignores `react-native-windows` as dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['windows-dep'], false);
-  expect(result).not.toHaveProperty('dependencies.react-native-windows');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['windows-dep'], false);
+  expect(result.dependencies).not.toHaveProperty('react-native-windows');
 });
 
 it('ignores `react-native-windows` as peer dependency', () => {
-  const result = resolveDependencies(metaFixture, metaFixture['dist-tags']['windows-peer'], false);
-  expect(result).not.toHaveProperty('dependencies.react-native-windows');
+  const result = resolveDependencies(fixture, fixture['dist-tags']['windows-peer'], false);
+  expect(result.dependencies).not.toHaveProperty('react-native-windows');
+});
+
+it('hides `@babel/core` as peer dependency', () => {
+  const result = resolveDependencies(fixture, fixture['dist-tags']['babel-peer'], false);
+  expect(result.dependencies).not.toHaveProperty('@babel/core');
+  expect(result.pkg.peerDependencies).not.toHaveProperty('@babel/core');
 });

--- a/snackager/src/utils/resolveDependencies.ts
+++ b/snackager/src/utils/resolveDependencies.ts
@@ -4,7 +4,11 @@ import { Metadata, Package } from '../types';
 // TODO: find the typescript definitions for this package, `@types/semver-utils` doesn't exists
 const semverUtils = require('semver-utils');
 
+// There are two special types of dependencies that should not be included in Snackager results.
+// 1. "Ignored dependencies" - dependencies that are ok to include in the output, but should not be bundled.
+// 2. "Hidden peer dependencies" - dependencies that should not be included in the output and the package definition, as including them would break things in the website
 const IGNORED_DEPENDENCIES = ['react-native-windows'];
+const HIDDEN_PEER_DEPENDENCIES = ['@babel/core']; // required for react-native-reanimated@2.8.0
 
 type ResolvedDependencies = {
   pkg: Package;
@@ -25,7 +29,10 @@ export default function resolveDependencies(
   const dependencies: { [key: string]: string | null } = {};
 
   for (const name in peerDependencies) {
-    if (IGNORED_DEPENDENCIES.includes(name)) {
+    if (HIDDEN_PEER_DEPENDENCIES.includes(name)) {
+      // hide from pkg
+      delete pkg.peerDependencies?.[name];
+    } else if (IGNORED_DEPENDENCIES.includes(name)) {
       // ignore
     } else if (name === 'react-native-vector-icons') {
       dependencies['@expo/vector-icons'] = null;

--- a/website/package.json
+++ b/website/package.json
@@ -78,6 +78,7 @@
     "recast": "^0.20.3",
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
+    "snack-content": "*",
     "snack-sdk": "*",
     "stoppable": "^1.1.0",
     "validate-npm-package-name": "^3.0.0"

--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -1,3 +1,4 @@
+import { defaultSdkVersion } from 'snack-content';
 import { SDKVersion } from 'snack-sdk';
 
 /**
@@ -11,5 +12,5 @@ export const versions: Record<SDKVersion, boolean> = {
   '45.0.0': true,
 };
 
-export const DEFAULT_SDK_VERSION: SDKVersion = '45.0.0';
+export const DEFAULT_SDK_VERSION: SDKVersion = defaultSdkVersion;
 export const TEST_SDK_VERSION: SDKVersion = '43.0.0';


### PR DESCRIPTION
# Why

Getting ready to publish to production, but while the #292 issue is still ongoing avoid making it the default.

# How

Set default back to 44, and centralized the switch through `snack-content` package

# Test Plan

See if CI succeeds
