### PR TITLE
Use eslint to rely on unused code detection

### DIFF
--- a/packages/snack-content/tsconfig.json
+++ b/packages/snack-content/tsconfig.json
@@ -9,8 +9,6 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "outDir": "./build",
     "skipLibCheck": true,
     "sourceMap": true,

--- a/packages/snack-proxies/tsconfig.json
+++ b/packages/snack-proxies/tsconfig.json
@@ -11,8 +11,6 @@
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,
     "baseUrl": "./"

--- a/packages/snack-sdk/tsconfig.json
+++ b/packages/snack-sdk/tsconfig.json
@@ -14,8 +14,6 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/snack-term/tsconfig.json
+++ b/packages/snack-term/tsconfig.json
@@ -12,8 +12,6 @@
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,
     "baseUrl": "./"

--- a/runtime/tsconfig.json
+++ b/runtime/tsconfig.json
@@ -13,8 +13,6 @@
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "strict": true,
   },
   "extends": "expo/tsconfig.base"

--- a/snackager/tsconfig.json
+++ b/snackager/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "allowJs": true,
     "noEmit": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitAny": false,
     "isolatedModules": true,
     "noImplicitReturns": true,

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -12,8 +12,6 @@
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noStrictGenericChecks": false,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": false,
     "strict": true,


### PR DESCRIPTION
# Why

During development this could easily happen, e.g. when testing parts of the code. By letting the code be built, even though it contains dead code, it should help improve DX. We still test for unused code through eslint.

# How

Removed two typescript rules:
- `noUnusedLocals`
- `noUnusedParameters`

# Test Plan

See if CI still works.