### PR TITLE
[website] Set status code for not found responses to avoid CDN caching

### DIFF
--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -28,7 +28,7 @@ export default function Router(props: RouterProps) {
     }
 
     return <NonExistent />;
-  }, []);
+  }, [props.ctx]);
 
   const renderRoute = React.useCallback(
     (routeProps: any) => {

--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -18,8 +18,8 @@ type RouterProps = {
 export default function Router(props: RouterProps) {
   const render404 = React.useCallback(() => {
     if (props.ctx) {
-      // If te router is server-side rendered, we need to set the right response code and headers.
-      // Without this, possible CDNs might cache the invalid path.
+      // If the router is server-side rendered, we need to set the right response code and headers.
+      // Without this, it's possible CDNs might cache the invalid path.
       props.ctx.response.status = 404;
       props.ctx.response.set(
         'Cache-Control',

--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -30,27 +30,24 @@ export default function Router(props: RouterProps) {
     return <NonExistent />;
   }, [props.ctx]);
 
-  const renderRoute = React.useCallback(
-    (routeProps: any) => {
-      const { data, ...rest } = props;
-      const isEmbedded = routeProps.location.pathname.split('/')[1] === 'embedded';
+  function renderRoute(routeProps: any) {
+    const { data } = props;
+    const isEmbedded = routeProps.location.pathname.split('/')[1] === 'embedded';
 
-      if (!data || data.type !== 'success') {
-        return render404();
-      }
+    if (!data || data.type !== 'success') {
+      return render404();
+    }
 
-      const appProps = {
-        ...routeProps,
-        ...rest,
-        query: props.queryParams,
-        snack: data.snack,
-        defaults: data.defaults,
-      };
+    const appProps: React.ComponentProps<typeof App | typeof EmbeddedApp> = {
+      ...routeProps,
+      userAgent: props.userAgent,
+      query: props.queryParams,
+      snack: data.snack,
+      defaults: data.defaults,
+    };
 
-      return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
-    },
-    [render404]
-  );
+    return isEmbedded ? <EmbeddedApp {...appProps} /> : <App  {...appProps} />;
+  }
 
   return (
     <Switch>

--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -46,7 +46,7 @@ export default function Router(props: RouterProps) {
       defaults: data.defaults,
     };
 
-    return isEmbedded ? <EmbeddedApp {...appProps} /> : <App  {...appProps} />;
+    return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
   }
 
   return (

--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -21,31 +21,36 @@ export default function Router(props: RouterProps) {
       // If te router is server-side rendered, we need to set the right response code and headers.
       // Without this, possible CDNs might cache the invalid path.
       props.ctx.response.status = 404;
-      props.ctx.response.set('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+      props.ctx.response.set(
+        'Cache-Control',
+        'private, no-cache, no-store, max-age=0, must-revalidate'
+      );
     }
 
     return <NonExistent />;
   }, []);
 
-  const renderRoute = React.useCallback((routeProps: any) => {
-    const { data, ...rest } = props;
-    const isEmbedded = routeProps.location.pathname.split('/')[1] === 'embedded';
+  const renderRoute = React.useCallback(
+    (routeProps: any) => {
+      const { data, ...rest } = props;
+      const isEmbedded = routeProps.location.pathname.split('/')[1] === 'embedded';
 
-    if (!data || data.type !== 'success') {
-      return render404();
-    }
+      if (!data || data.type !== 'success') {
+        return render404();
+      }
 
-    const appProps = {
-      ...routeProps,
-      ...rest,
-      query: props.queryParams,
-      snack: data.snack,
-      defaults: data.defaults,
-    };
-      
-    return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
-  }, [render404]);
-  
+      const appProps = {
+        ...routeProps,
+        ...rest,
+        query: props.queryParams,
+        snack: data.snack,
+        defaults: data.defaults,
+      };
+
+      return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
+    },
+    [render404]
+  );
 
   return (
     <Switch>

--- a/website/src/client/components/Router.tsx
+++ b/website/src/client/components/Router.tsx
@@ -1,3 +1,4 @@
+import { Context as ServerContext } from 'koa';
 import * as React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
@@ -6,42 +7,55 @@ import App from './App';
 import EmbeddedApp from './EmbeddedApp';
 import NonExistent from './NonExistent';
 
-type Props = {
+type RouterProps = {
+  /** The server context if Snack is being server-side rendered */
+  ctx?: ServerContext;
   data: RouterData;
   queryParams: QueryParams;
   userAgent: string;
 };
 
-export default class Router extends React.Component<Props> {
-  private _renderRoute = (props: any) => {
-    const { data, ...rest } = this.props;
-    const isEmbedded = props.location.pathname.split('/')[1] === 'embedded';
-
-    if (data && data.type === 'success') {
-      const appProps = {
-        ...props,
-        ...rest,
-        query: this.props.queryParams,
-        snack: data.snack,
-        defaults: data.defaults,
-      };
-      return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
-    } else {
-      return <NonExistent />;
+export default function Router(props: RouterProps) {
+  const render404 = React.useCallback(() => {
+    if (props.ctx) {
+      // If te router is server-side rendered, we need to set the right response code and headers.
+      // Without this, possible CDNs might cache the invalid path.
+      props.ctx.response.status = 404;
+      props.ctx.response.set('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
     }
-  };
 
-  render() {
-    return (
-      <Switch>
-        <Route exact path="/embedded/@:username/:projectName+" render={this._renderRoute} />
-        <Route exact path="/embedded/:id" render={this._renderRoute} />
-        <Route exact path="/embedded" render={this._renderRoute} />
-        <Route exact path="/@:username/:projectName+" render={this._renderRoute} />
-        <Route exact path="/:id" render={this._renderRoute} />
-        <Route exact path="/" render={this._renderRoute} />
-        <Route component={NonExistent} />
-      </Switch>
-    );
-  }
+    return <NonExistent />;
+  }, []);
+
+  const renderRoute = React.useCallback((routeProps: any) => {
+    const { data, ...rest } = props;
+    const isEmbedded = routeProps.location.pathname.split('/')[1] === 'embedded';
+
+    if (!data || data.type !== 'success') {
+      return render404();
+    }
+
+    const appProps = {
+      ...routeProps,
+      ...rest,
+      query: props.queryParams,
+      snack: data.snack,
+      defaults: data.defaults,
+    };
+      
+    return isEmbedded ? <EmbeddedApp {...appProps} /> : <App {...appProps} />;
+  }, [render404]);
+  
+
+  return (
+    <Switch>
+      <Route exact path="/embedded/@:username/:projectName+" render={renderRoute} />
+      <Route exact path="/embedded/:id" render={renderRoute} />
+      <Route exact path="/embedded" render={renderRoute} />
+      <Route exact path="/@:username/:projectName+" render={renderRoute} />
+      <Route exact path="/:id" render={renderRoute} />
+      <Route exact path="/" render={renderRoute} />
+      <Route render={render404} />
+    </Switch>
+  );
 }

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -76,18 +76,23 @@ app.use(sw());
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
   // Always try to send static files ASAP. For files that don't exist,
   // the server will server-side render the client router and set the appropriate status code.
-  app.use(mount('/dist', serve(path.join(__dirname, '..', '..', 'dist'), {
-    setHeaders(res, path) {
-      if (path.endsWith('.cached.js') || path.endsWith('.cached.worker.js')) {
-        // All files ending with `.cached.js` should be cached, they change every build.
-        // This is defined in the webpack.config.js and applies mostly to chunks.
-        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-      } else {
-        // Everything else should not be cached at all, they don't change every build.
-        res.setHeader('Cache-Control', 'public, no-cache');
-      }
-    },
-  })));
+  app.use(
+    mount(
+      '/dist',
+      serve(path.join(__dirname, '..', '..', 'dist'), {
+        setHeaders(res, path) {
+          if (path.endsWith('.cached.js') || path.endsWith('.cached.worker.js')) {
+            // All files ending with `.cached.js` should be cached, they change every build.
+            // This is defined in the webpack.config.js and applies mostly to chunks.
+            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+          } else {
+            // Everything else should not be cached at all, they don't change every build.
+            res.setHeader('Cache-Control', 'public, no-cache');
+          }
+        },
+      })
+    )
+  );
 } else {
   // Use webpack dev middleware in development
   const webpack = require('webpack');

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -74,8 +74,8 @@ if (process.env.COMPRESS_ASSETS === 'true') {
 app.use(sw());
 
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
-  // Always try to send static files asap. For files that doesnt exist,
-  // it will server-side render the client router and set the appropriate status code.
+  // Always try to send static files ASAP. For files that don't exist,
+  // the server will server-side render the client router and set the appropriate status code.
   app.use(mount('/dist', serve(path.join(__dirname, '..', '..', 'dist'))));
 } else {
   // Use webpack dev middleware in development

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -82,11 +82,11 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
       serve(path.join(__dirname, '..', '..', 'dist'), {
         setHeaders(res, path) {
           if (path.endsWith('.cached.js') || path.endsWith('.cached.worker.js')) {
-            // All files ending with `.cached.js` should be cached, they change every build.
+            // All files ending with `.cached.js` should be cached, the file names change every build.
             // This is defined in the webpack.config.js and applies mostly to chunks.
             res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
           } else {
-            // Everything else should not be cached at all, they don't change every build.
+            // Everything else should not be cached at all, the file names won't change every build.
             res.setHeader('Cache-Control', 'public, no-cache');
           }
         },

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -76,7 +76,18 @@ app.use(sw());
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
   // Always try to send static files ASAP. For files that don't exist,
   // the server will server-side render the client router and set the appropriate status code.
-  app.use(mount('/dist', serve(path.join(__dirname, '..', '..', 'dist'))));
+  app.use(mount('/dist', serve(path.join(__dirname, '..', '..', 'dist'), {
+    setHeaders(res, path) {
+      if (path.endsWith('.cached.js') || path.endsWith('.cached.worker.js')) {
+        // All files ending with `.cached.js` should be cached, they change every build.
+        // This is defined in the webpack.config.js and applies mostly to chunks.
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+      } else {
+        // Everything else should not be cached at all, they don't change every build.
+        res.setHeader('Cache-Control', 'public, no-cache');
+      }
+    },
+  })));
 } else {
   // Use webpack dev middleware in development
   const webpack = require('webpack');

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -74,6 +74,8 @@ if (process.env.COMPRESS_ASSETS === 'true') {
 app.use(sw());
 
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') {
+  // Always try to send static files asap. For files that doesnt exist,
+  // it will server-side render the client router and set the appropriate status code.
   app.use(mount('/dist', serve(path.join(__dirname, '..', '..', 'dist'))));
 } else {
   // Use webpack dev middleware in development

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -142,7 +142,12 @@ const render = async (ctx: Context) => {
                 <PreferencesProvider cookies={cookies} queryParams={queryParams}>
                   <ThemeProvider>
                     <StaticRouter location={ctx.request.url} context={context}>
-                      <ClientRouter ctx={ctx} data={data} queryParams={queryParams} userAgent={userAgent} />
+                      <ClientRouter
+                        ctx={ctx}
+                        data={data}
+                        queryParams={queryParams}
+                        userAgent={userAgent}
+                      />
                     </StaticRouter>
                   </ThemeProvider>
                 </PreferencesProvider>

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -142,7 +142,7 @@ const render = async (ctx: Context) => {
                 <PreferencesProvider cookies={cookies} queryParams={queryParams}>
                   <ThemeProvider>
                     <StaticRouter location={ctx.request.url} context={context}>
-                      <ClientRouter data={data} queryParams={queryParams} userAgent={userAgent} />
+                      <ClientRouter ctx={ctx} data={data} queryParams={queryParams} userAgent={userAgent} />
                     </StaticRouter>
                   </ThemeProvider>
                 </PreferencesProvider>

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/dist/',
     filename: '[name].bundle.js',
-    chunkFilename: '[id].[hash].chunk.js',
+    chunkFilename: '[id].[hash].chunk.cached.js',
   },
   optimization: {
     noEmitOnErrors: true,


### PR DESCRIPTION
# Why

Fixes [ENG-5064](https://linear.app/expo/issue/ENG-5064/fix-caching-headers-for-snacks-static-assets-and-404s)

Our CDN cached a 404 response for some chunks of assets, causing Snack to break until the CDN was flushed. This should help tell the CDN to not-cache 404 responses.

# How

Snack's website is a kind of custom-built, a legacy from how it was created years ago. So the implementation is not ideal, but here is how it works:
- Koa tries to serve static files first. If that doesn't exist, it continues through the other middlewares.
- When no static files are found, it server-side renders the **src/client/components/Router.tsx** 
- If that client router is being rendered server-side, pass the server context.
- Whenever the client router needs to respond with a not-found page, set the right status and header (if available, so if server-side rendered).

The unfortunate part here is that we need to "leak" the server context to the client-side router. We have no other way to determine if a 404 hit was rendered since we only get the HTML output from that.

# Test Plan

Run it locally, or deploy to staging and try the following URLs:
- https://staging.snack.expo.dev/this-path-doesnt-exist
- https://staging.snack.expo.dev/@bycedricstaging/this-snack-doesnt-exist
- https://staging.snack.expo.dev/dist/0.3babf018b826ac329594.chunk.FAKE.js

Either one of these URLs should return with a 404 status code, and the right cache headers.

Optionally, [test the URLs from the client router](https://github.com/expo/snack/blob/main/website/src/client/components/Router.tsx#L37-L42), these should respond with 200 status codes.

```jsx
<Route exact path="/embedded/@:username/:projectName+" render={renderRoute} />
<Route exact path="/embedded/:id" render={renderRoute} />
<Route exact path="/embedded" render={renderRoute} />
<Route exact path="/@:username/:projectName+" render={renderRoute} />
<Route exact path="/:id" render={renderRoute} />
<Route exact path="/" render={renderRoute} />
```