### PR TITLE
[website] Pin prettier to last known working version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -60,7 +60,7 @@
     "nanoid": "^3.1.16",
     "node-fetch": "^2.6.1",
     "nullthrows": "^1.1.1",
-    "prettier": "^2.6.2",
+    "prettier": "~2.3.2",
     "prismjs": "^1.21.0",
     "qrcode.react": "^1.0.0",
     "query-string": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4474,11 +4474,6 @@ b64u-lite@^1.0.1:
   dependencies:
     b64-lite "^1.4.0"
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -12179,6 +12174,11 @@ prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
+prettier@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
# Why

Right now, prettier throws an internal error caused by some Terser processing issues.

# How

Pinned prettier to the last known working version (the [one supporting `jsxBracketSameLine`](https://prettier.io/blog/2021/09/09/2.4.0.html#replace-jsxbracketsameline-option-with-bracketsameline-option-11006httpsgithubcomprettierprettierpull11006-by-kurtztechhttpsgithubcomkurtztech))

# Test Plan

Run from docker, or run on staging. Click the prettier button.
