### PR TITLE
[runtime] Add support for dynamic imports

### DIFF
--- a/packages/snack-babel-standalone/README.md
+++ b/packages/snack-babel-standalone/README.md
@@ -8,8 +8,10 @@ Standalone version of Babel used in Snack Runtime and Snack Website. This versio
 
 - `@babel/core`
 - `@babel/plugin-proposal-decorators`
+- `@babel/plugin-proposal-dynamic-import`
 - `@babel/plugin-proposal-nullish-coalescing-operator`
 - `@babel/plugin-proposal-optional-chaining`
+- `@babel/plugin-syntax-dynamic-import`
 - `@babel/plugin-transform-arrow-functions`
 - `@babel/plugin-transform-async-to-generator`
 - `@babel/plugin-transform-shorthand-properties`

--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-babel-standalone",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Babel for Snack Runtime and Website",
   "main": "./build/runtime.js",
   "types": "./types/runtime.d.ts",
@@ -51,8 +51,10 @@
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "@babel/plugin-proposal-decorators": "^7.18.9",
+    "@babel/plugin-proposal-dynamic-import": "^7.18.6",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
     "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-arrow-functions": "^7.18.6",
     "@babel/plugin-transform-async-to-generator": "^7.18.6",
     "@babel/plugin-transform-shorthand-properties": "^7.18.6",

--- a/packages/snack-babel-standalone/src/runtime.ts
+++ b/packages/snack-babel-standalone/src/runtime.ts
@@ -191,6 +191,9 @@ export function getPlugin(name) {
 
 registerPlugins({
   '@babel/plugin-proposal-decorators': require('@babel/plugin-proposal-decorators').default,
+  // Required to map `await import()` back to `require`, which works in systemjs
+  '@babel/plugin-syntax-dynamic-import': require('@babel/plugin-syntax-dynamic-import'),
+  '@babel/plugin-proposal-dynamic-import': require('@babel/plugin-proposal-dynamic-import'),
   // Required for using JSI host objects with async functions in React Native <=0.66
   '@babel/plugin-transform-async-to-generator': require('@babel/plugin-transform-async-to-generator').default,
   // Required for the Reanimated 2.3.x plugin

--- a/packages/snack-babel-standalone/yarn.lock
+++ b/packages/snack-babel-standalone/yarn.lock
@@ -283,6 +283,14 @@
     "@babel/helper-split-export-declaration" "^7.18.6"
     "@babel/plugin-syntax-decorators" "^7.18.6"
 
+"@babel/plugin-proposal-dynamic-import@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz#72bcf8d408799f547d759298c3c27c7e7faa4d94"
+  integrity sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+
 "@babel/plugin-proposal-export-default-from@^7.0.0":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.18.9.tgz#9dfad26452e53cae8f045c6153e82dc50e9bee89"
@@ -334,7 +342,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-syntax-dynamic-import@^7.0.0":
+"@babel/plugin-syntax-dynamic-import@^7.0.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -51,7 +51,7 @@
     "react-native-safe-area-context": "4.3.1",
     "react-native-view-shot": "3.3.0",
     "react-native-web": "~0.18.7",
-    "snack-babel-standalone": "~1.1.0",
+    "snack-babel-standalone": "^2.1.0",
     "source-map": "0.6.1"
   },
   "devDependencies": {

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -373,6 +373,8 @@ const translatePipeline = async (load: Load) => {
             plugins: [
               ['@babel/plugin-transform-async-to-generator'],
               ['@babel/plugin-proposal-decorators', { legacy: true }],
+              ['@babel/plugin-syntax-dynamic-import'],
+              ['@babel/plugin-proposal-dynamic-import'],
               ...(load.source.includes('react-native-reanimated') || load.source.includes('worklet')
                 ? [Reanimated2Plugin]
                 : []),

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -12219,10 +12219,10 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-1.1.0.tgz#07f127fbfec92b52bdb4d31d81b0cbec9dbdd83e"
-  integrity sha512-23233qXBsX6B5u65zFSQyob/lgbimk1rBkQcoYFXKPs0TpL29B6WItt81rWCxIZibd/tY5oTKXxRj2JQRbCRhg==
+snack-babel-standalone@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.1.0.tgz#c2f45440ad15f2f4799f14e717755384cf24f19e"
+  integrity sha512-9DWW6IAop08ByG7K8AFX07gPgkULip6xYb3TcbyystfHqiJLVAtf5/eDKsh+vD8jMJZN6PY9tOY0ewdcakXwuQ==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

Fixes #318

# How

- Added dynamic import babel syntax + transform to `require`, this let systemjs handle the module instead. Which is what we need :)

# Test Plan

Going to staging!