### PR TITLE
[snack-sdk] Add versioned endpoints for modules

### DIFF
--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -174,6 +174,7 @@ export default class Snack {
     this.state.unsaved = false;
 
     this.wantedDependencyVersions = new WantedDependencyVersions({
+      apiUrl: this.apiURL,
       logger: this.logger,
       callback: this.onWantedDependencyVersions,
     });

--- a/packages/snack-sdk/src/WantedVersions.ts
+++ b/packages/snack-sdk/src/WantedVersions.ts
@@ -10,13 +10,22 @@ export type WantedDependencyVersionsCallback = (
   error?: SnackError
 ) => any;
 
+interface WantedDependencyVersionsOptions {
+  /** The Expo API URL to fetch the remote versioned modules from */
+  apiUrl: string;
+  logger?: Logger;
+  callback: WantedDependencyVersionsCallback;
+}
+
 export class WantedDependencyVersions {
   private readonly callback: WantedDependencyVersionsCallback;
   private readonly logger?: Logger;
   private sdkVersion?: SDKVersion;
   private promise: Promise<any>;
+  private apiUrl: string;
 
-  constructor(options: { logger?: Logger; callback: WantedDependencyVersionsCallback }) {
+  constructor(options: WantedDependencyVersionsOptions) {
+    this.apiUrl = options.apiUrl;
     this.logger = options.logger;
     this.callback = options.callback;
     this.promise = Promise.resolve();
@@ -25,7 +34,7 @@ export class WantedDependencyVersions {
   setSDKVersion(sdkVersion: SDKVersion) {
     if (this.sdkVersion !== sdkVersion) {
       this.sdkVersion = sdkVersion;
-      this.promise = this._fetch(sdkVersion);
+      this.promise = this.fetchModules(sdkVersion);
     }
   }
 
@@ -33,25 +42,90 @@ export class WantedDependencyVersions {
     return this.promise;
   }
 
-  private async _fetch(sdkVersion: SDKVersion): Promise<any> {
-    let json: any;
-    try {
-      this.logger?.module('fetching bundledNativeModules for SDK', sdkVersion, '...');
-      const url = `https://cdn.jsdelivr.net/npm/expo@${encodeURIComponent(
-        sdks[sdkVersion]?.version || sdkVersion
-      )}/bundledNativeModules.json`;
-      const response = await fetch(url);
-      json = await response.json();
-    } catch (e) {
-      if (this.sdkVersion === sdkVersion) {
-        this.logger?.error(e);
-        this.callback(sdkVersion, undefined, e);
-      }
+  /**
+   * Fetch all versioned modules from an SDK.
+   * This is similar to the `getCombinedKnownVersionsAsync` method.
+   * @see https://github.com/expo/expo/blob/0f1b5f0cd1caa86db3c01a001b14def93062a07e/packages/%40expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts#L34
+   */
+  private async fetchModules(sdkVersion: SDKVersion): Promise<void> {
+    if (this.sdkVersion !== sdkVersion) {
       return;
     }
-    if (this.sdkVersion === sdkVersion) {
-      this.logger?.module('fetched bundledNativeModules for SDK', sdkVersion, json);
-      this.callback(sdkVersion, json);
+
+    try {
+      this.logger?.module('fetching versioned modules for SDK', sdkVersion, '...');
+
+      // TODO(cedric): check why this is still necessary
+      const sdkVersionString = sdks[sdkVersion]?.version || sdkVersion;
+      const [remoteVersions, bundledVersions] = await Promise.all([
+        this.fetchRemoteVersionedModules(sdkVersionString),
+        this.fetchBundledNativeModules(sdkVersionString),
+      ]);
+
+      const versions = {
+        ...remoteVersions,
+        ...bundledVersions,
+      };
+
+      // Note(cedric): SDK could have changed during fetching
+      if (this.sdkVersion === sdkVersion) {
+        this.logger?.module('fetched versioned modules for SDK', sdkVersion, versions);
+        this.callback(sdkVersion, versions);
+      }
+    } catch (error) {
+      // Note(cedric): SDK could have changed during fetching
+      if (this.sdkVersion === sdkVersion) {
+        this.logger?.error(error);
+        this.callback(sdkVersion, undefined, error);
+      }
     }
+  }
+
+  /**
+   * Fetch all bundled native modules from the `expo/bundledNativeModules.json` file.
+   */
+  private fetchBundledNativeModules(sdkVersion: string): Promise<Record<string, string>> {
+    const urlVersion = encodeURIComponent(sdkVersion);
+    return fetch(`https://cdn.jsdelivr.net/npm/expo@${urlVersion}/bundledNativeModules.json`)
+      .then((response) => response.json())
+      .then((data) => data || {});
+  }
+
+  /**
+   * Fetch all remote versioned modules from the `/versions/latest` API endpoint.
+   */
+  private fetchRemoteVersionedModules(sdkVersion: string): Promise<Record<string, string>> {
+    return fetch(`${this.apiUrl}/--/api/v2/versions/latest`)
+      .then((response) => response.json())
+      .then((data) => this.normalizeRemoteVersionResponse(sdkVersion, data));
+  }
+
+  /**
+   * Normalize the versions response, and account for incorrect settings.
+   * @see https://github.com/expo/expo/blob/0f1b5f0cd1caa86db3c01a001b14def93062a07e/packages/%40expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts#L13-L31
+   */
+  private normalizeRemoteVersionResponse(sdkVersion: string, response: any = {}) {
+    const sdkVersionSettings = response?.data?.sdkVersions?.[sdkVersion];
+
+    if (!sdkVersionSettings) {
+      return {};
+    }
+
+    const { relatedPackages, facebookReactVersion, facebookReactNativeVersion } =
+      sdkVersionSettings;
+
+    const reactVersion = facebookReactVersion
+      ? {
+          react: facebookReactVersion,
+          'react-dom': facebookReactVersion,
+        }
+      : undefined;
+
+    // Adds `react-dom`, `react`, and `react-native` to the list of known package versions (`relatedPackages`)
+    return {
+      ...relatedPackages,
+      ...reactVersion,
+      'react-native': facebookReactNativeVersion,
+    };
   }
 }

--- a/packages/snack-sdk/src/__mocks__/www.ts
+++ b/packages/snack-sdk/src/__mocks__/www.ts
@@ -33,6 +33,98 @@ export default function createWww() {
       hash,
     };
   });
+  router.get('/--/api/v2/versions/latest', (ctx) => {
+    ctx.body = {
+      data: {
+        sdkVersions: {
+          '44.0.0': {
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.23.2.tar.gz',
+            releaseNoteUrl: 'https://blog.expo.dev/expo-sdk-44-4c4b8306584a',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '~4.3.5',
+              '@babel/core': '^7.12.9',
+              '@types/react': '~17.0.21',
+              '@types/react-dom': '~17.0.9',
+              'react-native-web': '0.17.1',
+              'babel-preset-expo': '9.0.2',
+              '@types/react-native': '~0.64.12',
+              '@expo/webpack-config': '~0.16.2',
+              'react-native-unimodules': '~0.15.0',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.23.2.apk',
+            iosClientVersion: '2.23.2',
+            expoReactNativeTag: 'sdk-44.0.0',
+            androidClientVersion: '2.23.2',
+            facebookReactVersion: '17.0.1',
+            facebookReactNativeVersion: '0.64.3',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-44.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+          '45.0.0': {
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.24.3.tar.gz',
+            releaseNoteUrl: 'https://blog.expo.dev/expo-sdk-45-f4e332954a68',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '~4.3.5',
+              '@babel/core': '^7.12.9',
+              '@expo/config': '~6.0.19',
+              '@types/react': '~17.0.21',
+              '@types/react-dom': '~17.0.11',
+              'react-native-web': '0.17.7',
+              'babel-preset-expo': '~9.1.0',
+              '@types/react-native': '~0.67.6',
+              '@expo/config-plugins': '^4.1.0',
+              '@expo/webpack-config': '~0.16.21',
+              '@expo/prebuild-config': '^4.0.0',
+              'expo-modules-autolinking': '~0.8.1 || ~0.9.0',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.24.6.apk',
+            iosClientVersion: '2.24.3',
+            expoReactNativeTag: 'sdk-45.0.0',
+            androidClientVersion: '2.24.6',
+            facebookReactVersion: '17.0.2',
+            facebookReactNativeVersion: '0.68.2',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-45.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+          '46.0.0': {
+            beta: 'true',
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.25.1.tar.gz',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '^4.6.3',
+              '@babel/core': '^7.18.6',
+              '@expo/config': '^7.0.0',
+              '@types/react': '~18.0.0',
+              '@types/react-dom': '~18.0.0',
+              'react-native-web': '~0.18.7',
+              'babel-preset-expo': '~9.2.0',
+              '@types/react-native': '~0.69.1',
+              '@expo/config-plugins': '^5.0.0',
+              '@expo/webpack-config': '^0.17.0',
+              '@expo/prebuild-config': '^5.0.1',
+              'expo-modules-autolinking': '~0.10.1',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.25.1.apk',
+            iosClientVersion: '2.25.1',
+            expoReactNativeTag: 'sdk-46.0.0',
+            androidClientVersion: '2.25.1',
+            facebookReactVersion: '18.0.0',
+            facebookReactNativeVersion: '0.69.3',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-46.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+        },
+      },
+    };
+  });
   app.use(router.routes()).use(router.allowedMethods());
   return app;
 }


### PR DESCRIPTION
# Why

Fixes [ENG-5177](https://linear.app/expo/issue/ENG-5177/implement-native-module-api-endpoint)

Adds the versioned modules endpoint next to `bundledNativeModules.json` in the SDK.

# How

See SDK

# Test Plan

Will go to staging too
