### PR TITLE
[website] Add type failure warning and vendored types

### DIFF
--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -174,6 +174,7 @@ export default class Snack {
     this.state.unsaved = false;
 
     this.wantedDependencyVersions = new WantedDependencyVersions({
+      apiUrl: this.apiURL,
       logger: this.logger,
       callback: this.onWantedDependencyVersions,
     });

--- a/packages/snack-sdk/src/WantedVersions.ts
+++ b/packages/snack-sdk/src/WantedVersions.ts
@@ -10,13 +10,22 @@ export type WantedDependencyVersionsCallback = (
   error?: SnackError
 ) => any;
 
+interface WantedDependencyVersionsOptions {
+  /** The Expo API URL to fetch the remote versioned modules from */
+  apiUrl: string;
+  logger?: Logger;
+  callback: WantedDependencyVersionsCallback;
+}
+
 export class WantedDependencyVersions {
   private readonly callback: WantedDependencyVersionsCallback;
   private readonly logger?: Logger;
   private sdkVersion?: SDKVersion;
   private promise: Promise<any>;
+  private apiUrl: string;
 
-  constructor(options: { logger?: Logger; callback: WantedDependencyVersionsCallback }) {
+  constructor(options: WantedDependencyVersionsOptions) {
+    this.apiUrl = options.apiUrl;
     this.logger = options.logger;
     this.callback = options.callback;
     this.promise = Promise.resolve();
@@ -25,7 +34,7 @@ export class WantedDependencyVersions {
   setSDKVersion(sdkVersion: SDKVersion) {
     if (this.sdkVersion !== sdkVersion) {
       this.sdkVersion = sdkVersion;
-      this.promise = this._fetch(sdkVersion);
+      this.promise = this.fetchModules(sdkVersion);
     }
   }
 
@@ -33,25 +42,90 @@ export class WantedDependencyVersions {
     return this.promise;
   }
 
-  private async _fetch(sdkVersion: SDKVersion): Promise<any> {
-    let json: any;
-    try {
-      this.logger?.module('fetching bundledNativeModules for SDK', sdkVersion, '...');
-      const url = `https://cdn.jsdelivr.net/npm/expo@${encodeURIComponent(
-        sdks[sdkVersion]?.version || sdkVersion
-      )}/bundledNativeModules.json`;
-      const response = await fetch(url);
-      json = await response.json();
-    } catch (e) {
-      if (this.sdkVersion === sdkVersion) {
-        this.logger?.error(e);
-        this.callback(sdkVersion, undefined, e);
-      }
+  /**
+   * Fetch all versioned modules from an SDK.
+   * This is similar to the `getCombinedKnownVersionsAsync` method.
+   * @see https://github.com/expo/expo/blob/0f1b5f0cd1caa86db3c01a001b14def93062a07e/packages/%40expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts#L34
+   */
+  private async fetchModules(sdkVersion: SDKVersion): Promise<void> {
+    if (this.sdkVersion !== sdkVersion) {
       return;
     }
-    if (this.sdkVersion === sdkVersion) {
-      this.logger?.module('fetched bundledNativeModules for SDK', sdkVersion, json);
-      this.callback(sdkVersion, json);
+
+    try {
+      this.logger?.module('fetching versioned modules for SDK', sdkVersion, '...');
+
+      // TODO(cedric): check why this is still necessary
+      const sdkVersionString = sdks[sdkVersion]?.version || sdkVersion;
+      const [remoteVersions, bundledVersions] = await Promise.all([
+        this.fetchRemoteVersionedModules(sdkVersionString),
+        this.fetchBundledNativeModules(sdkVersionString),
+      ]);
+
+      const versions = {
+        ...remoteVersions,
+        ...bundledVersions,
+      };
+
+      // Note(cedric): SDK could have changed during fetching
+      if (this.sdkVersion === sdkVersion) {
+        this.logger?.module('fetched versioned modules for SDK', sdkVersion, versions);
+        this.callback(sdkVersion, versions);
+      }
+    } catch (error) {
+      // Note(cedric): SDK could have changed during fetching
+      if (this.sdkVersion === sdkVersion) {
+        this.logger?.error(error);
+        this.callback(sdkVersion, undefined, error);
+      }
     }
+  }
+
+  /**
+   * Fetch all bundled native modules from the `expo/bundledNativeModules.json` file.
+   */
+  private fetchBundledNativeModules(sdkVersion: string): Promise<Record<string, string>> {
+    const urlVersion = encodeURIComponent(sdkVersion);
+    return fetch(`https://cdn.jsdelivr.net/npm/expo@${urlVersion}/bundledNativeModules.json`)
+      .then((response) => response.json())
+      .then((data) => data || {});
+  }
+
+  /**
+   * Fetch all remote versioned modules from the `/versions/latest` API endpoint.
+   */
+  private fetchRemoteVersionedModules(sdkVersion: string): Promise<Record<string, string>> {
+    return fetch(`${this.apiUrl}/--/api/v2/versions/latest`)
+      .then((response) => response.json())
+      .then((data) => this.normalizeRemoteVersionResponse(sdkVersion, data));
+  }
+
+  /**
+   * Normalize the versions response, and account for incorrect settings.
+   * @see https://github.com/expo/expo/blob/0f1b5f0cd1caa86db3c01a001b14def93062a07e/packages/%40expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts#L13-L31
+   */
+  private normalizeRemoteVersionResponse(sdkVersion: string, response: any = {}) {
+    const sdkVersionSettings = response?.data?.sdkVersions?.[sdkVersion];
+
+    if (!sdkVersionSettings) {
+      return {};
+    }
+
+    const { relatedPackages, facebookReactVersion, facebookReactNativeVersion } =
+      sdkVersionSettings;
+
+    const reactVersion = facebookReactVersion
+      ? {
+          react: facebookReactVersion,
+          'react-dom': facebookReactVersion,
+        }
+      : undefined;
+
+    // Adds `react-dom`, `react`, and `react-native` to the list of known package versions (`relatedPackages`)
+    return {
+      ...relatedPackages,
+      ...reactVersion,
+      'react-native': facebookReactNativeVersion,
+    };
   }
 }

--- a/packages/snack-sdk/src/__mocks__/www.ts
+++ b/packages/snack-sdk/src/__mocks__/www.ts
@@ -33,6 +33,98 @@ export default function createWww() {
       hash,
     };
   });
+  router.get('/--/api/v2/versions/latest', (ctx) => {
+    ctx.body = {
+      data: {
+        sdkVersions: {
+          '44.0.0': {
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.23.2.tar.gz',
+            releaseNoteUrl: 'https://blog.expo.dev/expo-sdk-44-4c4b8306584a',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '~4.3.5',
+              '@babel/core': '^7.12.9',
+              '@types/react': '~17.0.21',
+              '@types/react-dom': '~17.0.9',
+              'react-native-web': '0.17.1',
+              'babel-preset-expo': '9.0.2',
+              '@types/react-native': '~0.64.12',
+              '@expo/webpack-config': '~0.16.2',
+              'react-native-unimodules': '~0.15.0',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.23.2.apk',
+            iosClientVersion: '2.23.2',
+            expoReactNativeTag: 'sdk-44.0.0',
+            androidClientVersion: '2.23.2',
+            facebookReactVersion: '17.0.1',
+            facebookReactNativeVersion: '0.64.3',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-44.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+          '45.0.0': {
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.24.3.tar.gz',
+            releaseNoteUrl: 'https://blog.expo.dev/expo-sdk-45-f4e332954a68',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '~4.3.5',
+              '@babel/core': '^7.12.9',
+              '@expo/config': '~6.0.19',
+              '@types/react': '~17.0.21',
+              '@types/react-dom': '~17.0.11',
+              'react-native-web': '0.17.7',
+              'babel-preset-expo': '~9.1.0',
+              '@types/react-native': '~0.67.6',
+              '@expo/config-plugins': '^4.1.0',
+              '@expo/webpack-config': '~0.16.21',
+              '@expo/prebuild-config': '^4.0.0',
+              'expo-modules-autolinking': '~0.8.1 || ~0.9.0',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.24.6.apk',
+            iosClientVersion: '2.24.3',
+            expoReactNativeTag: 'sdk-45.0.0',
+            androidClientVersion: '2.24.6',
+            facebookReactVersion: '17.0.2',
+            facebookReactNativeVersion: '0.68.2',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-45.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+          '46.0.0': {
+            beta: 'true',
+            iosClientUrl: 'https://dpq5q02fu5f55.cloudfront.net/Exponent-2.25.1.tar.gz',
+            relatedPackages: {
+              jest: '^26.6.3',
+              typescript: '^4.6.3',
+              '@babel/core': '^7.18.6',
+              '@expo/config': '^7.0.0',
+              '@types/react': '~18.0.0',
+              '@types/react-dom': '~18.0.0',
+              'react-native-web': '~0.18.7',
+              'babel-preset-expo': '~9.2.0',
+              '@types/react-native': '~0.69.1',
+              '@expo/config-plugins': '^5.0.0',
+              '@expo/webpack-config': '^0.17.0',
+              '@expo/prebuild-config': '^5.0.1',
+              'expo-modules-autolinking': '~0.10.1',
+            },
+            androidClientUrl: 'https://d1ahtucjixef4r.cloudfront.net/Exponent-2.25.1.apk',
+            iosClientVersion: '2.25.1',
+            expoReactNativeTag: 'sdk-46.0.0',
+            androidClientVersion: '2.25.1',
+            facebookReactVersion: '18.0.0',
+            facebookReactNativeVersion: '0.69.3',
+            packagesToInstallWhenEjecting: {
+              'react-native': 'https://github.com/expo/react-native/archive/sdk-46.0.0.tar.gz',
+              'react-native-unimodules': '0.15.0',
+            },
+          },
+        },
+      },
+    };
+  });
   app.use(router.routes()).use(router.allowedMethods());
   return app;
 }

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -6,11 +6,11 @@ import { initVimMode } from 'monaco-vim';
 import * as React from 'react';
 import { getPreloadedModules, isValidSemver } from 'snack-sdk';
 
-import type { TypingsResult } from '../../workers/typings.worker';
 import { SDKVersion, Annotation, SnackDependencies } from '../../types';
 import getFileLanguage from '../../utils/getFileLanguage';
 import { getRelativePath, getAbsolutePath } from '../../utils/path';
 import prettierCode from '../../utils/prettierCode';
+import type { TypingsResult } from '../../workers/typings.worker';
 import withThemeName, { ThemeName } from '../Preferences/withThemeName';
 import ResizeDetector from '../shared/ResizeDetector';
 import { EditorProps, EditorMode } from './EditorProps';

--- a/website/src/client/components/Editor/types/README.md
+++ b/website/src/client/components/Editor/types/README.md
@@ -1,0 +1,7 @@
+# Vendored types
+
+Some libraries are bundled inside the Runtime, without their types. This means we have to manually add them to Monaco.
+
+## Existing types
+
+- `@shopify/react-native-skia/dist/web` → See `runtime/src/NativeModules/ReactNativeSkia.tsx`.

--- a/website/src/client/components/Editor/types/vendored.ts
+++ b/website/src/client/components/Editor/types/vendored.ts
@@ -1,0 +1,37 @@
+/** All hard-coded and vendored types */
+export const vendoredTypes: Record<string, string> = {
+  // See: /runtime/src/NativeModules/ReactNativeSkia.tsx
+  ...makeModuleType('@shopify/react-native-skia/dist/web', `
+    import { Suspense, ComponentProps, ComponentType } from 'react';
+    interface WithSkiaProps {
+        fallback?: ComponentProps<typeof Suspense>['fallback'];
+        getComponent: () => Promise<{
+            default: ComponentType;
+        }>;
+    }
+    export function WithSkia({ fallback, getComponent }: WithSkiaProps): JSX.Element;
+    export function LoadSkia(): Promise<void>;
+  `),
+};
+
+/**
+ * Create a declaration file for a specific import path.
+ * This outputs both the `<pkg>/package.json` and `<pkg>/index.d.ts` files.
+ * The package file needs to point to the loaded declaration file, without that the types are not picked up.
+ */
+function makeModuleType(importName: string, declarationContent: string): Record<string, string> {
+  return {
+    // For each import path, we need to fake a package file, pointing to the right declarations.
+    [`node_modules/${importName}/package.json`]: JSON.stringify({
+      name: importName,
+      version: '1.0.0',
+      types: './index.d.ts',
+    }),
+    // The declaration also needs to be wrapped inside `declare module "<pkg>" { ... }`
+    [`node_modules/${importName}/index.d.ts`]: `
+      declare module "${importName}" {
+        ${declarationContent}
+      }
+    `,
+  }
+}

--- a/website/src/client/components/Editor/types/vendored.ts
+++ b/website/src/client/components/Editor/types/vendored.ts
@@ -1,7 +1,9 @@
 /** All hard-coded and vendored types */
 export const vendoredTypes: Record<string, string> = {
   // See: /runtime/src/NativeModules/ReactNativeSkia.tsx
-  ...makeModuleType('@shopify/react-native-skia/dist/web', `
+  ...makeModuleType(
+    '@shopify/react-native-skia/dist/web',
+    `
     import { Suspense, ComponentProps, ComponentType } from 'react';
     interface WithSkiaProps {
         fallback?: ComponentProps<typeof Suspense>['fallback'];
@@ -11,7 +13,8 @@ export const vendoredTypes: Record<string, string> = {
     }
     export function WithSkia({ fallback, getComponent }: WithSkiaProps): JSX.Element;
     export function LoadSkia(): Promise<void>;
-  `),
+  `
+  ),
 };
 
 /**
@@ -33,5 +36,5 @@ function makeModuleType(importName: string, declarationContent: string): Record<
         ${declarationContent}
       }
     `,
-  }
+  };
 }

--- a/website/src/client/workers/typings.worker.tsx
+++ b/website/src/client/workers/typings.worker.tsx
@@ -262,7 +262,7 @@ function fallbackAnyType(dependency: string, version: string, output: FetchOutpu
 
   // Throw a custom error to block caching, while still passing generic any declaration.
   const error: any = new Error('Failed to load types, using fallback instead.');
-  error.code = 'FALLBACK_TYPES'
+  error.code = 'FALLBACK_TYPES';
   error.typings = output.paths;
   throw error;
 }
@@ -317,7 +317,7 @@ self.addEventListener('message', (event) => {
         typings: result,
       } as TypingsResult),
     (error) => {
-      if (error.code = 'FALLBACK_TYPES') {
+      if (error.code === 'FALLBACK_TYPES') {
         return self.postMessage({
           name,
           version,
@@ -332,7 +332,7 @@ If you are the library author of "${name}":
 
 Falling back to "declare module '${name}';".
           `.trim(),
-        } as TypingsResult)
+        } as TypingsResult);
       }
 
       if (process.env.NODE_ENV !== 'production') {

--- a/website/src/client/workers/typings.worker.tsx
+++ b/website/src/client/workers/typings.worker.tsx
@@ -6,6 +6,13 @@ import resources from '../../../resources.json';
 declare const self: DedicatedWorkerGlobalScope;
 declare const ts: any;
 
+export interface TypingsResult {
+  name: string;
+  version: string;
+  typings: FetchOutput['paths'];
+  errorMessage?: string;
+}
+
 type FetchOutput = {
   resolvedVersion?: string;
   paths: {
@@ -242,6 +249,24 @@ function fetchFromTypings(dependency: string, version: string, output: FetchOutp
     });
 }
 
+function fallbackAnyType(dependency: string, version: string, output: FetchOutput) {
+  output.paths[`node_modules/${dependency}/package.json`] = JSON.stringify({
+    name: dependency,
+    version,
+    types: './index.d.ts',
+  });
+
+  output.paths[`node_modules/${dependency}/index.d.ts`] = `
+    declare module "${dependency}";
+  `;
+
+  // Throw a custom error to block caching, while still passing generic any declaration.
+  const error: any = new Error('Failed to load types, using fallback instead.');
+  error.code = 'FALLBACK_TYPES'
+  error.typings = output.paths;
+  throw error;
+}
+
 async function fetchDefinitions(name: string, version: string) {
   if (!version) {
     throw new Error(`No version specified for ${name}`);
@@ -268,7 +293,10 @@ async function fetchDefinitions(name: string, version: string) {
     // Not available in package.json, try checking meta for inline .d.ts files
     .catch(() => fetchFromMeta(name, output.resolvedVersion ?? version, output))
     // Not available in package.json or inline from meta, try checking in @types/
-    .catch(() => fetchFromDefinitelyTyped(name, output.resolvedVersion ?? version, output));
+    .catch(() => fetchFromDefinitelyTyped(name, output.resolvedVersion ?? version, output))
+    // Add a fallback type when the types couldn't be loaded
+    .catch(() => fallbackAnyType(name, output.resolvedVersion ?? version, output));
+
   if (!Object.keys(output.paths).length) {
     throw new Error(`Type definitions are empty for ${key}`);
   }
@@ -287,8 +315,26 @@ self.addEventListener('message', (event) => {
         name,
         version,
         typings: result,
-      }),
+      } as TypingsResult),
     (error) => {
+      if (error.code = 'FALLBACK_TYPES') {
+        return self.postMessage({
+          name,
+          version,
+          typings: error.typings,
+          errorMessage: `
+Could not fetch the types for ${name}@${version}.
+
+If you are the library author of "${name}":
+  - Check if the '@types/${name.replace('@', '').replace(/\//g, '__')}' are published.
+  - Or your '${name}/package.json' includes valid 'typings' or 'types' properties.
+    - And your library can be viewed through ${ROOT_URL}npm/${name}@${version}/.
+
+Falling back to "declare module '${name}';".
+          `.trim(),
+        } as TypingsResult)
+      }
+
       if (process.env.NODE_ENV !== 'production') {
         console.error(error);
       }


### PR DESCRIPTION
# Why

This adds two main things to the website's editor:

1. Warning when types couldn't be loaded + steps to fix it.
2. Vendored types, where `@shopify/react-native-skia/dist/web` is the vendored type.

# How

- Updated typescript worker to add `errorMessage` and skip caching in cases of failures
- Added vendored types

# Test Plan

Onwards to staging, and try to load [https://staging.snack.expo.dev/@bycedrictest/universal-skia-demo](https://staging.snack.expo.dev/@bycedrictest/universal-skia-demo)
