### PR TITLE
Enable automatic jsx runtime

### DIFF
--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-babel-standalone",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Babel for Snack Runtime and Website",
   "main": "./build/runtime.js",
   "types": "./types/runtime.d.ts",
@@ -57,6 +57,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-arrow-functions": "^7.18.6",
     "@babel/plugin-transform-async-to-generator": "^7.18.6",
+    "@babel/plugin-transform-react-jsx": "^7.18.6",
     "@babel/plugin-transform-shorthand-properties": "^7.18.6",
     "@babel/plugin-transform-template-literals": "^7.18.9",
     "@babel/preset-typescript": "^7.18.6",

--- a/packages/snack-babel-standalone/src/runtime.ts
+++ b/packages/snack-babel-standalone/src/runtime.ts
@@ -194,6 +194,8 @@ registerPlugins({
   // Required to map `await import()` back to `require`, which works in systemjs
   '@babel/plugin-syntax-dynamic-import': require('@babel/plugin-syntax-dynamic-import'),
   '@babel/plugin-proposal-dynamic-import': require('@babel/plugin-proposal-dynamic-import'),
+  // Required to skip the `import React from 'react';`
+  '@babel/plugin-transform-react-jsx': require('@babel/plugin-transform-react-jsx'),
   // Required for using JSI host objects with async functions in React Native <=0.66
   '@babel/plugin-transform-async-to-generator': require('@babel/plugin-transform-async-to-generator').default,
   // Required for the Reanimated 2.3.x plugin

--- a/packages/snack-babel-standalone/yarn.lock
+++ b/packages/snack-babel-standalone/yarn.lock
@@ -540,7 +540,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-react-jsx@^7.0.0":
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.6.tgz#2721e96d31df96e3b7ad48ff446995d26bc028ff"
   integrity sha512-Mz7xMPxoy9kPS/JScj6fJs03TZ/fZ1dJPlMjRAgTaxaS0fUBk8FV/A2rRgfPsVCZqALNwMexD+0Uaf5zlcKPpw==

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-eslint-standalone",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint for Snack Website",
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
@@ -47,7 +47,7 @@
     "webpack-cli": "^4.10.0"
   },
   "peerDependencies": {
-    "snack-babel-standalone": ">=2.0.0"
+    "snack-babel-standalone": ">=2.2.0"
   },
   "volta": {
     "node": "16.14.2"

--- a/packages/snack-eslint-standalone/src/config.ts
+++ b/packages/snack-eslint-standalone/src/config.ts
@@ -143,7 +143,7 @@ export const defaultConfig = {
     'react/no-direct-mutation-state': 'error',
     'react/no-is-mounted': 'error',
     'react/no-string-refs': 'error',
-    'react/react-in-jsx-scope': 'error',
+    'react/react-in-jsx-scope': 'off', // Disabled for React 17+, where its optional
     'react/require-render-return': 'error',
 
     'react-native/no-single-element-style-arrays': 'error',

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -51,7 +51,7 @@
     "react-native-safe-area-context": "4.3.1",
     "react-native-view-shot": "3.3.0",
     "react-native-web": "~0.18.7",
-    "snack-babel-standalone": "^2.1.0",
+    "snack-babel-standalone": "^2.2.0",
     "source-map": "0.6.1"
   },
   "devDependencies": {

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -375,6 +375,7 @@ const translatePipeline = async (load: Load) => {
               ['@babel/plugin-proposal-decorators', { legacy: true }],
               ['@babel/plugin-syntax-dynamic-import'],
               ['@babel/plugin-proposal-dynamic-import'],
+              ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
               ...(load.source.includes('react-native-reanimated') || load.source.includes('worklet')
                 ? [Reanimated2Plugin]
                 : []),

--- a/runtime/src/aliases/common.tsx
+++ b/runtime/src/aliases/common.tsx
@@ -4,6 +4,7 @@ import * as SkiaWeb from '../NativeModules/ReactNativeSkia';
 const aliases: { [key: string]: any } = {
   expo: require('expo'),
   react: require('react'),
+  'react/jsx-runtime': require('react/jsx-runtime'),
 
   // Needed for loading assets from packages bundled by snackager
   AssetRegistry,

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -12297,10 +12297,10 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.1.0.tgz#c2f45440ad15f2f4799f14e717755384cf24f19e"
-  integrity sha512-9DWW6IAop08ByG7K8AFX07gPgkULip6xYb3TcbyystfHqiJLVAtf5/eDKsh+vD8jMJZN6PY9tOY0ewdcakXwuQ==
+snack-babel-standalone@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.0.tgz#cbcf51d0390fad0c07ba756b333f64712e1aeaa1"
+  integrity sha512-2qR2930Jafkd3rPfSRWwQ/OmTStzVKjxXpcmOHeI5pfRkxF183mwn9UhqjnRdd/KUW2g1b9iA9rSVLWOmntnKw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"

--- a/website/package.json
+++ b/website/package.json
@@ -78,9 +78,9 @@
     "recast": "^0.20.3",
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
-    "snack-babel-standalone": "^2.0.0",
+    "snack-babel-standalone": "^2.2.0",
     "snack-content": "*",
-    "snack-eslint-standalone": "^1.0.0",
+    "snack-eslint-standalone": "^1.1.0",
     "snack-sdk": "*",
     "stoppable": "^1.1.0",
     "validate-npm-package-name": "^3.0.0"

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -6,7 +6,6 @@ import { initVimMode } from 'monaco-vim';
 import * as React from 'react';
 import { getPreloadedModules, isValidSemver } from 'snack-sdk';
 
-import type { TypingsResult } from '../../workers/typings.worker';
 import { SDKVersion, Annotation, SnackDependencies } from '../../types';
 import getFileLanguage from '../../utils/getFileLanguage';
 import { getRelativePath, getAbsolutePath } from '../../utils/path';

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -6,6 +6,7 @@ import { initVimMode } from 'monaco-vim';
 import * as React from 'react';
 import { getPreloadedModules, isValidSemver } from 'snack-sdk';
 
+import type { TypingsResult } from '../../workers/typings.worker';
 import { SDKVersion, Annotation, SnackDependencies } from '../../types';
 import getFileLanguage from '../../utils/getFileLanguage';
 import { getRelativePath, getAbsolutePath } from '../../utils/path';

--- a/website/src/client/components/Editor/MonacoEditor.tsx
+++ b/website/src/client/components/Editor/MonacoEditor.tsx
@@ -91,7 +91,7 @@ const compilerOptions: monaco.languages.typescript.CompilerOptions = {
   esModuleInterop: true,
   forceConsistentCasingInFileNames: true,
   isolatedModules: true,
-  jsx: monaco.languages.typescript.JsxEmit.React,
+  jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
   module: monaco.languages.typescript.ModuleKind.ESNext,
   moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
   noEmit: true,

--- a/website/src/client/components/Editor/types/vendored.ts
+++ b/website/src/client/components/Editor/types/vendored.ts
@@ -1,19 +1,22 @@
 /** All hard-coded and vendored types */
 export const vendoredTypes: Record<string, string> = {
+  // Workaround for React 17+ and auto jsx runtime
+  // See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d7b179c7a9a4aa4ff13f0608606ae10a94349014/types/react/jsx-runtime.d.ts#L2
+  ...makeModuleType('react/jsx-runtime', `import 'react';`),
   // See: /runtime/src/NativeModules/ReactNativeSkia.tsx
   ...makeModuleType(
     '@shopify/react-native-skia/dist/web',
-    `
-    import { Suspense, ComponentProps, ComponentType } from 'react';
-    interface WithSkiaProps {
-        fallback?: ComponentProps<typeof Suspense>['fallback'];
-        getComponent: () => Promise<{
-            default: ComponentType;
-        }>;
-    }
-    export function WithSkia({ fallback, getComponent }: WithSkiaProps): JSX.Element;
-    export function LoadSkia(): Promise<void>;
-  `
+    `declare module "@shopify/react-native-skia/dist/web" {
+      import { Suspense, ComponentProps, ComponentType } from 'react';
+      interface WithSkiaProps {
+          fallback?: ComponentProps<typeof Suspense>['fallback'];
+          getComponent: () => Promise<{
+              default: ComponentType;
+          }>;
+      }
+      export function WithSkia({ fallback, getComponent }: WithSkiaProps): JSX.Element;
+      export function LoadSkia(): Promise<void>;
+    }`
   ),
 };
 
@@ -31,10 +34,6 @@ function makeModuleType(importName: string, declarationContent: string): Record<
       types: './index.d.ts',
     }),
     // The declaration also needs to be wrapped inside `declare module "<pkg>" { ... }`
-    [`node_modules/${importName}/index.d.ts`]: `
-      declare module "${importName}" {
-        ${declarationContent}
-      }
-    `,
+    [`node_modules/${importName}/index.d.ts`]: declarationContent,
   };
 }

--- a/website/src/client/configs/defaults.tsx
+++ b/website/src/client/configs/defaults.tsx
@@ -8,8 +8,7 @@ export const DEFAULT_DESCRIPTION = 'No description';
 
 export const DEFAULT_CODE: SnackFiles = {
   'App.js': {
-    contents: `import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+    contents: `import { Text, View, StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
 
 // You can import from local files
@@ -55,8 +54,7 @@ const styles = StyleSheet.create({
     type: 'ASSET',
   },
   'components/AssetExample.js': {
-    contents: `import * as React from 'react';
-import { Text, View, StyleSheet, Image } from 'react-native';
+    contents: `import { Text, View, StyleSheet, Image } from 'react-native';
 
 export default function AssetExample() {
   return (

--- a/website/src/client/configs/defaults.tsx
+++ b/website/src/client/configs/defaults.tsx
@@ -6,9 +6,11 @@ export const DEFAULT_METADATA_DESCRIPTION_SAVED = `Try this project on your phon
 
 export const DEFAULT_DESCRIPTION = 'No description';
 
+// TODO(cedric): Drop `import React from 'react';` when dropping SDK 45
 export const DEFAULT_CODE: SnackFiles = {
   'App.js': {
-    contents: `import { Text, View, StyleSheet } from 'react-native';
+    contents: `import * as React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
 
 // You can import from local files
@@ -54,7 +56,8 @@ const styles = StyleSheet.create({
     type: 'ASSET',
   },
   'components/AssetExample.js': {
-    contents: `import { Text, View, StyleSheet, Image } from 'react-native';
+    contents: `import * as React from 'react';
+import { Text, View, StyleSheet, Image } from 'react-native';
 
 export default function AssetExample() {
   return (

--- a/website/src/client/workers/typings.worker.tsx
+++ b/website/src/client/workers/typings.worker.tsx
@@ -262,7 +262,7 @@ function fallbackAnyType(dependency: string, version: string, output: FetchOutpu
 
   // Throw a custom error to block caching, while still passing generic any declaration.
   const error: any = new Error('Failed to load types, using fallback instead.');
-  error.code = 'FALLBACK_TYPES';
+  error.code = 'FALLBACK_TYPES'
   error.typings = output.paths;
   throw error;
 }

--- a/website/src/client/workers/typings.worker.tsx
+++ b/website/src/client/workers/typings.worker.tsx
@@ -262,7 +262,7 @@ function fallbackAnyType(dependency: string, version: string, output: FetchOutpu
 
   // Throw a custom error to block caching, while still passing generic any declaration.
   const error: any = new Error('Failed to load types, using fallback instead.');
-  error.code = 'FALLBACK_TYPES'
+  error.code = 'FALLBACK_TYPES';
   error.typings = output.paths;
   throw error;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13733,15 +13733,15 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.0.0.tgz#29f010abb49d792b292c4fd363b4fd3393860119"
-  integrity sha512-RLYH69lrAw9ZGD+gVDU2i9LrHocqC7Qnor1b4ynRkVmL3frcIBwKOYfblWMpCOGgG0QXYyhN1OjL2fT1GEzGMA==
+snack-babel-standalone@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.0.tgz#cbcf51d0390fad0c07ba756b333f64712e1aeaa1"
+  integrity sha512-2qR2930Jafkd3rPfSRWwQ/OmTStzVKjxXpcmOHeI5pfRkxF183mwn9UhqjnRdd/KUW2g1b9iA9rSVLWOmntnKw==
 
-snack-eslint-standalone@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.0.0.tgz#de1dac479a2f94cc257fcb3d866408951f1e1565"
-  integrity sha512-F+2SeW3rVhtPOvzQlktv0qLgM+vDHHM/pPhFUH5nhGRWgBGbvbDySBPbWfnEQ4NUzgmKvjJSxMg0Q/nbyARYFg==
+snack-eslint-standalone@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.0.tgz#32b41e866a17b86cae14b7fbf876634469677432"
+  integrity sha512-B+Ya6swslbAAn1Q9QyYiuEbYlgXH2Zt8HSCHcixJZCHY2o8MgowIdtTSCQYi0vYjAqC5SAd2VCeGq4ydMr60FQ==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

Enables the automatic JSX runtime, which means not having to do `import React from 'react';` in every file.

# How

- Added plugin to `snack-babel-standalone`
- Disabled rule `react-jsx-in-scope` in `snack-eslint-standalone`
- Updated `runtime` with the new plugin
- Updated `website` for the new eslint default config

# Test Plan

Going to staging!
