### PR TITLE
[website] Fix double generic typescript method eslint errors

### DIFF
--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-babel-standalone",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Babel for Snack Runtime and Website",
   "main": "./build/runtime.js",
   "types": "./types/runtime.d.ts",

--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-babel-standalone",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Babel for Snack Runtime and Website",
   "main": "./build/runtime.js",
   "types": "./types/runtime.d.ts",

--- a/packages/snack-babel-standalone/src/eslint.ts
+++ b/packages/snack-babel-standalone/src/eslint.ts
@@ -3,12 +3,8 @@
  * Without this, the parser would not know how to fetch the presets and plugins in babel.
  */
 import { parseSync as babelParseSync } from '@babel/core';
-import { default as transformPlugin } from '@babel/plugin-transform-typescript';
 
-import { processOptions, registerPlugin } from './runtime';
-
-// Note(cedric): we need this to fix async functions with 2 or more generics
-registerPlugin('@babel/plugin-transform-typescript', transformPlugin);
+import { processOptions } from './runtime';
 
 // Re-export the functionality from the runtime, to keep presets and plugins in sync.
 export * from './runtime';

--- a/packages/snack-babel-standalone/src/eslint.ts
+++ b/packages/snack-babel-standalone/src/eslint.ts
@@ -3,8 +3,12 @@
  * Without this, the parser would not know how to fetch the presets and plugins in babel.
  */
 import { parseSync as babelParseSync } from '@babel/core';
+import { default as transformPlugin } from '@babel/plugin-transform-typescript';
 
-import { processOptions } from './runtime';
+import { processOptions, registerPlugin } from './runtime';
+
+// Note(cedric): we need this to fix async functions with 2 or more generics
+registerPlugin('@babel/plugin-transform-typescript', transformPlugin);
 
 // Re-export the functionality from the runtime, to keep presets and plugins in sync.
 export * from './runtime';

--- a/packages/snack-eslint-standalone/README.md
+++ b/packages/snack-eslint-standalone/README.md
@@ -54,6 +54,12 @@ Because we need to run Babel inside the Snack Runtime, we already have a standal
 
 This plugin tries to resolve the React version from local files. It does that using some Node tooling. Because this isn't available in the browser, we patched the version detection to always return `999.999.999` (the default version). This avoids including modules, like `fs` or `resolve`, in the ESLint bundle.
 
+### TypeScript async functions with 2 generics or more
+
+This seems to be an issue with Babel trying to parse something like `async process<Input, Output>` typescript code. We fixed it by being verbose in the ESLint config, and include the `@babel/plugin-transform-typescript` explicitly as babel plugin.
+
+This fix also introduced `getLinterConfig(fileName: string, customConfig?: object|any): any`.
+
 ## Contributing
 
 This package has a few commands, mainly to build, analyze and build for publishing.

--- a/packages/snack-eslint-standalone/README.md
+++ b/packages/snack-eslint-standalone/README.md
@@ -37,7 +37,8 @@ const code = `
   }
 `;
 
-const result: LintMessage[] = linter.verify(code, defaultConfig);
+// The file name is important to enable certain presets in babel
+const result: LintMessage[] = linter.verify(code, defaultConfig, { filename: '...' });
 ```
 
 ## Caveats
@@ -53,12 +54,6 @@ Because we need to run Babel inside the Snack Runtime, we already have a standal
 ### ESLint React plugin
 
 This plugin tries to resolve the React version from local files. It does that using some Node tooling. Because this isn't available in the browser, we patched the version detection to always return `999.999.999` (the default version). This avoids including modules, like `fs` or `resolve`, in the ESLint bundle.
-
-### TypeScript async functions with 2 generics or more
-
-This seems to be an issue with Babel trying to parse something like `async process<Input, Output>` typescript code. We fixed it by being verbose in the ESLint config, and include the `@babel/plugin-transform-typescript` explicitly as babel plugin.
-
-This fix also introduced `getLinterConfig(fileName: string, customConfig?: object|any): any`.
 
 ## Contributing
 

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-eslint-standalone",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint for Snack Website",
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
@@ -40,14 +40,14 @@
     "eslint-plugin-react-native": "^4.0.0",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "patch-package": "^6.4.7",
-    "snack-babel-standalone": "^2.0.0",
+    "snack-babel-standalone": "^2.2.1",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0"
   },
   "peerDependencies": {
-    "snack-babel-standalone": ">=2.2.0"
+    "snack-babel-standalone": ">=2.2.1"
   },
   "volta": {
     "node": "16.14.2"

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-eslint-standalone",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ESLint for Snack Website",
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
@@ -40,14 +40,14 @@
     "eslint-plugin-react-native": "^4.0.0",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "patch-package": "^6.4.7",
-    "snack-babel-standalone": "^2.2.1",
+    "snack-babel-standalone": "^2.2.2",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0"
   },
   "peerDependencies": {
-    "snack-babel-standalone": ">=2.2.1"
+    "snack-babel-standalone": ">=2.2.2"
   },
   "volta": {
     "node": "16.14.2"

--- a/packages/snack-eslint-standalone/src/config.ts
+++ b/packages/snack-eslint-standalone/src/config.ts
@@ -2,10 +2,12 @@ export const defaultConfig = {
   parser: '@babel/eslint-parser',
   parserOptions: {
     sourceType: 'module',
+    errorRecovery: true,
     requireConfigFile: false,
     babelOptions: {
       babelrc: false,
       configFile: false,
+      ast: false,
       presets: [
         'module:metro-react-native-babel-preset',
         '@babel/preset-typescript',
@@ -153,3 +155,36 @@ export const defaultConfig = {
     'react-hooks/exhaustive-deps': 'error',
   },
 };
+
+export const tsConfig = {
+  ...defaultConfig,
+  parserOptions: {
+    ...defaultConfig.parserOptions,
+    babelOptions: {
+      ...defaultConfig.parserOptions.babelOptions,
+      plugins: ['@babel/plugin-transform-typescript'],
+    },
+  },
+};
+
+/**
+ * Get the ESLint config that should be used for the to-lint file.
+ * This will return either `defaultConfig`, or `tsConfig`.
+ * When a custom config is provided, it will merge the parser options.
+ */
+export function getLinterConfig(fileName: string, customConfig?: any): any {
+  const isTs = /\.tsx?$/.test(fileName);
+  let baseConfig = isTs ? tsConfig : defaultConfig;
+
+  if (customConfig) {
+    baseConfig = {
+      // Reuse the same bundled parser, we can't really change that
+      parser: baseConfig.parser,
+      parserOptions: baseConfig.parserOptions,
+      // Use the configuration provided by the user
+      ...customConfig,
+    };
+  }
+
+  return baseConfig;
+}

--- a/packages/snack-eslint-standalone/src/config.ts
+++ b/packages/snack-eslint-standalone/src/config.ts
@@ -156,35 +156,21 @@ export const defaultConfig = {
   },
 };
 
-export const tsConfig = {
-  ...defaultConfig,
-  parserOptions: {
-    ...defaultConfig.parserOptions,
-    babelOptions: {
-      ...defaultConfig.parserOptions.babelOptions,
-      plugins: ['@babel/plugin-transform-typescript'],
-    },
-  },
-};
-
 /**
  * Get the ESLint config that should be used for the to-lint file.
- * This will return either `defaultConfig`, or `tsConfig`.
- * When a custom config is provided, it will merge the parser options.
+ * This takes custom config from users into account,
+ * but sets the parser options to the bundled babel parser.
  */
-export function getLinterConfig(fileName: string, customConfig?: any): any {
-  const isTs = /\.tsx?$/.test(fileName);
-  let baseConfig = isTs ? tsConfig : defaultConfig;
-
-  if (customConfig) {
-    baseConfig = {
-      // Reuse the same bundled parser, we can't really change that
-      parser: baseConfig.parser,
-      parserOptions: baseConfig.parserOptions,
-      // Use the configuration provided by the user
-      ...customConfig,
-    };
+export function getLinterConfig(_fileName: string, customConfig?: any): any {
+  if (!customConfig) {
+    return defaultConfig;
   }
 
-  return baseConfig;
+  return  {
+    // Use the configuration provided by the user
+    ...customConfig,
+    // Reuse the same bundled parser, we can't really change that
+    parser: defaultConfig.parser,
+    parserOptions: defaultConfig.parserOptions,
+  };
 }

--- a/packages/snack-eslint-standalone/src/eslint.ts
+++ b/packages/snack-eslint-standalone/src/eslint.ts
@@ -6,7 +6,7 @@ import { rules as reactHooksRules } from 'eslint-plugin-react-hooks';
 import { rules as reactNativeRules } from 'eslint-plugin-react-native';
 
 /** The default ESLint config with the bundled parser and plugins. */
-export { getLinterConfig, defaultConfig, tsConfig } from './config';
+export { getLinterConfig, defaultConfig } from './config';
 
 /** The ESLint linter instance containing the bundled parser and plugins. */
 export const linter = new Linter();

--- a/packages/snack-eslint-standalone/src/eslint.ts
+++ b/packages/snack-eslint-standalone/src/eslint.ts
@@ -6,7 +6,7 @@ import { rules as reactHooksRules } from 'eslint-plugin-react-hooks';
 import { rules as reactNativeRules } from 'eslint-plugin-react-native';
 
 /** The default ESLint config with the bundled parser and plugins. */
-export { defaultConfig } from './config';
+export { getLinterConfig, defaultConfig, tsConfig } from './config';
 
 /** The ESLint linter instance containing the bundled parser and plugins. */
 export const linter = new Linter();

--- a/packages/snack-eslint-standalone/types/eslint.d.ts
+++ b/packages/snack-eslint-standalone/types/eslint.d.ts
@@ -2,6 +2,14 @@ import { Linter } from 'eslint/lib/linter/linter';
 
 export const linter: InstanceType<typeof Linter>;
 export const defaultConfig: any;
+export const tsConfig: any;
+
+/**
+ * Get the ESLint config that should be used for the to-lint file.
+ * This will return either `defaultConfig`, or `tsConfig`.
+ * When a custom config is provided, it will merge the parser options.
+ */
+export function getLinterConfig(fileName: string, customConfig?: any): any;
 
 /**
  * Return type of `linter.verify`, but without eslint as dependency

--- a/packages/snack-eslint-standalone/types/eslint.d.ts
+++ b/packages/snack-eslint-standalone/types/eslint.d.ts
@@ -1,13 +1,21 @@
 import { Linter } from 'eslint/lib/linter/linter';
 
+/**
+ * The prepared ESLint instance to lint code.
+ * Note, the filename is important for the bundled babel parser.
+ */
 export const linter: InstanceType<typeof Linter>;
+
+/**
+ * The default configuration for the linter.
+ * This has JS and TS support by default, using the bundled parser.
+ */
 export const defaultConfig: any;
-export const tsConfig: any;
 
 /**
  * Get the ESLint config that should be used for the to-lint file.
- * This will return either `defaultConfig`, or `tsConfig`.
- * When a custom config is provided, it will merge the parser options.
+ * This takes custom config from users into account,
+ * but sets the parser options to the bundled babel parser.
  */
 export function getLinterConfig(fileName: string, customConfig?: any): any;
 

--- a/packages/snack-eslint-standalone/yarn.lock
+++ b/packages/snack-eslint-standalone/yarn.lock
@@ -3358,10 +3358,10 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
-snack-babel-standalone@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.0.0.tgz#29f010abb49d792b292c4fd363b4fd3393860119"
-  integrity sha512-RLYH69lrAw9ZGD+gVDU2i9LrHocqC7Qnor1b4ynRkVmL3frcIBwKOYfblWMpCOGgG0QXYyhN1OjL2fT1GEzGMA==
+snack-babel-standalone@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.1.tgz#61773a898f297a526bcd2f1438ec7c5fc733e147"
+  integrity sha512-6d2KGCRh4EwqNVL8ShQmwS/BTDuxoBiw291snbPcdk8USsqaaZlufJ3jzVl9arLZRZxMuERRJ9l+KO97+EMMVw==
 
 source-map-support@~0.5.20:
   version "0.5.21"

--- a/packages/snack-eslint-standalone/yarn.lock
+++ b/packages/snack-eslint-standalone/yarn.lock
@@ -3358,10 +3358,10 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
-snack-babel-standalone@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.1.tgz#61773a898f297a526bcd2f1438ec7c5fc733e147"
-  integrity sha512-6d2KGCRh4EwqNVL8ShQmwS/BTDuxoBiw291snbPcdk8USsqaaZlufJ3jzVl9arLZRZxMuERRJ9l+KO97+EMMVw==
+snack-babel-standalone@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
+  integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
 
 source-map-support@~0.5.20:
   version "0.5.21"

--- a/website/package.json
+++ b/website/package.json
@@ -78,9 +78,9 @@
     "recast": "^0.20.3",
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
-    "snack-babel-standalone": "^2.2.0",
+    "snack-babel-standalone": "^2.2.2",
     "snack-content": "*",
-    "snack-eslint-standalone": "^1.1.0",
+    "snack-eslint-standalone": "^1.1.2",
     "snack-sdk": "*",
     "stoppable": "^1.1.0",
     "validate-npm-package-name": "^3.0.0"

--- a/website/src/client/utils/lintCode.tsx
+++ b/website/src/client/utils/lintCode.tsx
@@ -1,4 +1,5 @@
-import { linter, defaultConfig, LintMessage } from 'snack-eslint-standalone';
+import type { LintMessage } from 'snack-eslint-standalone';
+import { linter, getLinterConfig } from 'snack-eslint-standalone';
 
 import { Annotation } from '../types';
 import { isTS } from './fileUtilities';
@@ -6,9 +7,10 @@ import { isTS } from './fileUtilities';
 export default function lintCode(
   fileName: string,
   code: string,
-  config: object = defaultConfig
+  userConfig?: object
 ): Annotation[] {
-  const errors: LintMessage[] = linter.verify(code, config);
+  const config = getLinterConfig(fileName, userConfig);
+  const errors: LintMessage[] = linter.verify(code, config, { filename: fileName });
 
   return errors
     .map((err) => {

--- a/website/src/client/utils/lintFile.tsx
+++ b/website/src/client/utils/lintFile.tsx
@@ -6,10 +6,9 @@ async function lintCode(path: string, code: string, files: SnackFiles): Promise<
   let config: object | undefined;
   if (eslintrc) {
     try {
-      // Use the babel-eslint parser by default since it's what we bundle
-      // This avoids having to specify the parser which might not be obvious
+      // Use the custom config provided by the user, must be JSON
       // @ts-ignore
-      config = { parser: 'babel-eslint', ...JSON.parse(files[eslintrc].contents) };
+      config = JSON.parse(files[eslintrc].contents);
     } catch (e) {
       return [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4440,11 +4440,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -13733,15 +13728,15 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.0.tgz#cbcf51d0390fad0c07ba756b333f64712e1aeaa1"
-  integrity sha512-2qR2930Jafkd3rPfSRWwQ/OmTStzVKjxXpcmOHeI5pfRkxF183mwn9UhqjnRdd/KUW2g1b9iA9rSVLWOmntnKw==
+snack-babel-standalone@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
+  integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
 
-snack-eslint-standalone@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.0.tgz#32b41e866a17b86cae14b7fbf876634469677432"
-  integrity sha512-B+Ya6swslbAAn1Q9QyYiuEbYlgXH2Zt8HSCHcixJZCHY2o8MgowIdtTSCQYi0vYjAqC5SAd2VCeGq4ydMr60FQ==
+snack-eslint-standalone@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.2.tgz#def4a5db28c6abd739bc3b07d561c1bd935b3f1e"
+  integrity sha512-2KBQ0aBK1ZKWoL8pWVPXOfU5TwRpFmQk4Z9LheJzbsWFkuYWZBU8iO33TyPBXmuGD6weE0V9tDBcvw/iEW3b8w==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

ESLint provided a false-positive on the following code:

```ts
async process<Input, Output>(inputData);
```

# How

- Added custom config merging `getLinterConfig` method in eslint standalone
- Added filename to eslint linting code in website, to enable babel features

# Test Plan

Test staging with this snack: https://snack.expo.dev/@ansonsyfang/anime-reality