### PR TITLE
[docs] Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
    - Update `~/.chalet/conf.json` to use `{ "tld": "test" }`
    - [Configure your system or browser to use the `.test` domain](https://github.com/jeansaad/chalet/blob/master/docs/README.md#system-configuration-recommended)
    - Restart or refresh your network settings to apply the chalet changes
+5. Run `yarn build` in the root directory to prepare the installation.
 
 ## 🏎️ Start the Development environment
 


### PR DESCRIPTION
# Why

Fixes #350 

# How

To update the contribution docs (`CONTRIBUTING.md`) to include `yarn build` step.

# Test Plan

Follow contributing guide (https://github.com/expo/snack/CONTRIBUTING.md) to set up Snack for local development. Ensure you are able to visit expo at http://localhost:3011 after installation.