### PR TITLE
'[website] Adds "position:sticky"-Issue 278'

### DIFF
--- a/website/src/client/components/FileList/FileListChildren.tsx
+++ b/website/src/client/components/FileList/FileListChildren.tsx
@@ -105,6 +105,6 @@ export default class FileListChildren extends React.PureComponent<Props> {
 const styles = StyleSheet.create({
   container: {
     display: 'inline-block',
-    width: '100%',
+    width: '100%',   
   },
 });

--- a/website/src/client/components/shared/ContextMenu.tsx
+++ b/website/src/client/components/shared/ContextMenu.tsx
@@ -52,7 +52,7 @@ class ContextMenu extends React.PureComponent<Props> {
         style={
           position
             ? {
-                position: 'fixed',
+                position: 'sticky',
                 top: Math.min(
                   position.pageY,
                   window.innerHeight - BOTTOM_OFFSET - shownActions.length * MENU_ITEM_HEIGHT


### PR DESCRIPTION
 Why

 #https://github.com/expo/snack/issues/278
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->
The issue, was able to be replicated after the pane was filled to the margins of my display. 

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

The addition of the 'sticky' option for position extended the overflow for the file pane, allowing the user to scroll to the bottom of the options module.

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
![filesOptionList-Issue278](https://user-images.githubusercontent.com/101910318/184563501-b32d1087-f69d-41b6-ae9b-10a38095d462.png)
![filesOptionList-Issue278(3)](https://user-images.githubusercontent.com/101910318/184563509-4b7dd282-8459-4f10-8df2-8f860f169e8b.png)
![filesOptionList-Issue278(2)](https://user-images.githubusercontent.com/101910318/184563514-1c9e0461-bdf1-40d7-9ca8-d3885bdcd2b1.png)

