### PR TITLE
Add missing external for react-native-webview

### DIFF
--- a/runtime/src/aliases/index.tsx
+++ b/runtime/src/aliases/index.tsx
@@ -19,6 +19,7 @@ const aliases: { [key: string]: any } = {
   'react-native/Libraries/Core/Devtools/symbolicateStackTrace': require('react-native/Libraries/Core/Devtools/symbolicateStackTrace'), // Used by @sentry/react-native@3.4.2
   'react-native/Libraries/Core/Devtools/getDevServer': require('react-native/Libraries/Core/Devtools/getDevServer'), // Used by @sentry/react-native@3.4.2
   'react-native/Libraries/Utilities/PolyfillFunctions': require('react-native/Libraries/Utilities/PolyfillFunctions'), // Used by @sentry/react-native@3.4.2
+  'react-native/Libraries/Utilities/codegenNativeCommands': require('react-native/Libraries/Utilities/codegenNativeCommands'), // Used by react-native-webview@11.23.0
 };
 
 export default aliases;

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -32,6 +32,7 @@ const CORE_EXTERNALS = [
   'react-native/Libraries/Core/Devtools/getDevServer', // Used by @sentry/react-native@3.4.2
   'react-native/Libraries/Utilities/PolyfillFunctions', // Used by @sentry/react-native@3.4.2
   'react-native-web/dist/modules/UnimplementedView', // Used by react-native-maps
+  'react-native/Libraries/Utilities/codegenNativeCommands', // Used by react-native-webview@11.23.0
   // TODO: decide whether to treat prop-types as an external or not
   // previously it was always installed as a dependency and not treated as an external.
   // This however caused packages to be slightly larger than needed to be.


### PR DESCRIPTION
# Why

This is being used in https://github.com/react-native-webview/react-native-webview/blob/76826691dfa1aac44e280575e98701bbef75c28f/src/WebView.android.tsx#L12.

# How

- Added external to Snackager
- Added alias to runtime

It would be great if Snackager can just return the externals we need, and just before loading the module, we could automatically set those aliases.

# Test Plan

Staging