### PR TITLE
Fix initializing embedded snacks using `data-snack-files`

### DIFF
--- a/website/src/server/EmbeddedSnackScript.tsx
+++ b/website/src/server/EmbeddedSnackScript.tsx
@@ -52,7 +52,7 @@ export const script = `
       var iframe = document.createElement('iframe');
 
       var iframeQueryParams = '?iframeId=' + iframeId;
-      
+
       if (options.preview) {
         iframeQueryParams += '&preview=' + options.preview;
       }
@@ -123,9 +123,13 @@ export const script = `
     },
 
     initialize: function() {
-      document.querySelectorAll('[data-sketch-id], [data-snack-id], [data-snack-code]').forEach(function(element) {
-        ExpoSnack.append(element);
-      });
+      document
+        .querySelectorAll(
+          "[data-sketch-id], [data-snack-id], [data-snack-code], [data-snack-files]"
+        )
+        .forEach(function (element) {
+          ExpoSnack.append(element);
+        });
     }
   }
 


### PR DESCRIPTION
# Why

`data-snack-files` allows specifying specific filenames for code, instead of `data-snack-code` which is placed as `App.js`, or `data-snack-id` which points to a saved Snack. `data-snack-files` replaces `data-snack-code` if present, but an element with only the former will not be initialized.

# How

This adds `data-snack-files` to the list of searched for elements, to catch embedded snacks not using `data-snack-code` (e.g. to embed TypeScript instead of JavaScript).

# Test Plan

Before the change, using data-snack-files in the react-native website would lead to blank snack examples when switching through tabs. Snacks show correctly after monkey-patching in the new function.
