### PR TITLE
[snack-sdk][website] Fix local webplayer hanging in connecting state

### DIFF
--- a/packages/snack-sdk/src/__tests__/webplayer-test.ts
+++ b/packages/snack-sdk/src/__tests__/webplayer-test.ts
@@ -26,6 +26,26 @@ describe('webpreview', () => {
     expect(snack.getState().transports['webplayer']).toBeDefined();
   });
 
+  it('updates a webplayer url', async () => {
+    const snack = new Snack({
+      webPreviewRef: {
+        current: null,
+      },
+    });
+    const originalTransport = snack.getState().transports['webplayer'];
+    snack.setWebPlayerURL('http://snack.expo.test');
+    const newTransport = snack.getState().transports['webplayer'];
+    expect(originalTransport).not.toBe(newTransport);
+
+    // Simulate CONNECT by web-player with old origin, which will be a no-op
+    postMessage(JSON.stringify({ type: 'CONNECT', device }), origin);
+    expect(Object.keys(snack.getState().connectedClients).length).toBe(0);
+
+    // Simulate CONNECT by web-player with new origin
+    postMessage(JSON.stringify({ type: 'CONNECT', device }), 'http://snack.expo.test');
+    expect(Object.keys(snack.getState().connectedClients).length).toBe(1);
+  });
+
   it('registers for messages on the global window', async () => {
     // @ts-ignore 'snack' is declared but its value is never read.
     const snack = new Snack({

--- a/packages/snack-sdk/src/types.ts
+++ b/packages/snack-sdk/src/types.ts
@@ -220,4 +220,9 @@ export type SnackState = {
    * of the iframe.
    */
   webPreviewURL?: string;
+
+  /**
+   * The runtime URL to serve webPlayer.
+   */
+  webPlayerURL?: string;
 };

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -871,8 +871,7 @@ class Main extends React.Component<Props, State> {
 
     return (
       <LazyLoad<React.ComponentType<EditorViewProps>>
-        load={() => (isEmbedded ? import('./EmbeddedEditorView') : import('./EditorView'))}
-      >
+        load={() => (isEmbedded ? import('./EmbeddedEditorView') : import('./EditorView'))}>
         {({ loaded, data: Comp }) =>
           loaded && Comp ? (
             <Comp

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -218,11 +218,7 @@ class Main extends React.Component<Props, State> {
           ? 'staging.exp.host'
           : new URL(nullthrows(process.env.API_SERVER_URL)).host,
       webPreviewRef: typeof window !== 'undefined' ? this._previewRef : undefined,
-      // Serve local web-player through `/web-player` end-point to prevent CORS issues
-      webPlayerURL:
-        typeof window !== 'undefined' && isLocalWebPreview
-          ? `${window.location.origin}/web-player/%%SDK_VERSION%%`
-          : nullthrows(process.env.SNACK_WEBPLAYER_URL) + '/v2/%%SDK_VERSION%%',
+      webPlayerURL: this._makeWebPlayerURL(isLocalWebPreview),
       snackId: props.snack?.id,
       accountSnackId: props.snack?.accountSnackId,
     });
@@ -594,6 +590,8 @@ class Main extends React.Component<Props, State> {
     this.edited = true;
     this._snack.setSDKVersion(sdkVersion);
     if (this.state.isLocalWebPreview !== !!isLocalWebPreview) {
+      const webPlayerURL = this._makeWebPlayerURL(!!isLocalWebPreview);
+      this._snack.setWebPlayerURL(webPlayerURL);
       this.setState({ isLocalWebPreview: !!isLocalWebPreview });
     }
   };
@@ -814,6 +812,12 @@ class Main extends React.Component<Props, State> {
     }
   };
 
+  _makeWebPlayerURL = (isLocalWebPreview: boolean) =>
+    // Serve local web-player through `/web-player` end-point to prevent CORS issues
+    typeof window !== 'undefined' && isLocalWebPreview
+      ? `${window.location.origin}/web-player/%%SDK_VERSION%%`
+      : nullthrows(process.env.SNACK_WEBPLAYER_URL) + '/v2/%%SDK_VERSION%%';
+
   _updateFiles = (updateFn: (files: SnackFiles) => { [path: string]: SnackFile | null }) => {
     const state = this._snack.getState();
     const filesUpdate = updateFn(state.files);
@@ -867,7 +871,8 @@ class Main extends React.Component<Props, State> {
 
     return (
       <LazyLoad<React.ComponentType<EditorViewProps>>
-        load={() => (isEmbedded ? import('./EmbeddedEditorView') : import('./EditorView'))}>
+        load={() => (isEmbedded ? import('./EmbeddedEditorView') : import('./EditorView'))}
+      >
         {({ loaded, data: Comp }) =>
           loaded && Comp ? (
             <Comp


### PR DESCRIPTION
# Why

local webplayer is hanging in connecting state.

<img src="https://user-images.githubusercontent.com/46429/205842513-95bc2ff3-43bd-42ee-819c-e8402ec4348a.png" width="30%" />

# How

the `Snack` sdk class only supports fixed webplayer url in construction. after switching to local webplayer, the transport still send message to old origin (our cloud `SNACK_WEBPLAYER_URL`). that's why website cannot connect to runtime correctly.

this pr adds a `setWebPlayerURL` function to change the webplayer URL in snack-sdk. once we changed the url, we should also re-create a new webplayer transport.

# Test Plan

# unit test

```
 PASS  src/__tests__/webplayer-test.ts
  webpreview
    ✓ updates a webplayer url (1 ms)
```

# integration test

1. `yarn start` in workspace root
2. `NODE_OPTIONS='--openssl-legacy-provider' npx expo start -w` in runtime
3. open http://snack.expo.test and switch sdk to localhost
