### PR TITLE
Fix syntax highlighting for embedded tsx files

### DIFF
--- a/website/src/client/components/Editor/SimpleEditor.tsx
+++ b/website/src/client/components/Editor/SimpleEditor.tsx
@@ -12,6 +12,7 @@ import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-markdown';
+import 'prismjs/components/prism-tsx';
 import withThemeName, { ThemeName } from '../Preferences/withThemeName';
 import { EditorProps } from './EditorProps';
 import { light, dark } from './themes/simple-editor';
@@ -64,8 +65,10 @@ class SimpleEditor extends React.Component<Props> {
   }
 
   _highlight = (path: string, code: string) => {
-    if (path.endsWith('.ts') || path.endsWith('.tsx')) {
+    if (path.endsWith('.ts')) {
       return highlight(code, languages.ts, 'typescript');
+    } else if (path.endsWith('.tsx')) {
+      return highlight(code, languages.tsx, 'tsx');
     } else if (path.endsWith('.js')) {
       return highlight(code, languages.jsx, 'jsx');
     } else if (path.endsWith('.json')) {


### PR DESCRIPTION
This is a copy of #366 that we can validate in CI and push to staging. DO NOT MERGE THIS PR.

Syntax highlighting for embedded snacks using tsx is poor in comparison to jsx.

I haven't tried to test this, but looking through to find where syntax highlighting was happening, I noticed that `SimpleEditor` was setting a language of 'typescript' for tsx files, instead of 'tsx' https://github.com/PrismJS/prism/blob/master/components/prism-tsx.js This makes it so that tsx files in SimpleEditor set the correct language.

I am not familiar with this code, so please let me know if this isn't the right place for embedded snacks, or if there is a way to easily test.
