### PR TITLE
chore: skip git crypt unlock when running in forks

### DIFF
--- a/.github/actions/setup-secrets/action.yml
+++ b/.github/actions/setup-secrets/action.yml
@@ -12,5 +12,5 @@ runs:
     - name: 🏗 Setup secrets
       if: ${{ inputs.git-crypt-key != '' }}
       uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+      env:
+        GIT_CRYPT_KEY: ${{ inputs.git-crypt-key }}

--- a/.github/actions/setup-secrets/action.yml
+++ b/.github/actions/setup-secrets/action.yml
@@ -1,0 +1,16 @@
+name: Setup Secrets
+description: Prepare Snack repository secrets in GitHub Actions
+
+inputs:
+  git-crypt-key:
+    description: The key to unlock the secrets
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: 🏗 Setup secrets
+      if: ${{ inputs.git-crypt-key != '' }}
+      uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
+        env:
+          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -41,15 +41,15 @@ jobs:
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
-      
+
       - name: 🏗 Setup runtime
         uses: ./.github/actions/setup-runtime
-      
+
       - name: 🚨 Lint runtime
         run: |
           yarn tsc --noEmit
           yarn lint --max-warnings 0
-  
+
   deploy-staging:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
@@ -60,10 +60,10 @@ jobs:
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
-      
+
       - name: 🏗 Setup runtime
         uses: ./.github/actions/setup-runtime
-      
+
       - name: 🌐 Deploy web-player
         run: yarn deploy:web:staging
         env:
@@ -97,10 +97,10 @@ jobs:
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
-      
+
       - name: 🏗 Setup runtime
         uses: ./.github/actions/setup-runtime
-      
+
       - name: 🌐 Deploy web-player
         run: yarn deploy:web:prod
         env:

--- a/.github/workflows/snackager-bundle.yml
+++ b/.github/workflows/snackager-bundle.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup snackager
         uses: ./.github/actions/setup-snackager

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -21,6 +21,8 @@ on:
           - production
   pull_request:
     paths:
+      - .github/actions/setup-google-cloud/**
+      - .github/actions/setup-secrets/**
       - .github/actions/setup-snackager/**
       - .github/workflows/snackager.yml
       - snackager/**
@@ -32,6 +34,8 @@ on:
   push:
     branches: [main]
     paths:
+      - .github/actions/setup-google-cloud/**
+      - .github/actions/setup-secrets/**
       - .github/actions/setup-snackager/**
       - .github/workflows/snackager.yml
       - snackager/**

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -49,9 +49,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup snackager
         uses: ./.github/actions/setup-snackager
@@ -61,12 +61,12 @@ jobs:
 
       - name: 🧪 Unit test snackager
         run: yarn test --ci --maxWorkers 1 --testPathIgnorePatterns=__integration-tests__
-      
+
       - name: 🧪 E2E test snackager
         run: yarn test --ci --maxWorkers 1 --testPathPattern=__integration-tests__
         # Takes a long time, best to only run this on PRs
         if: ${{ github.event_name == 'pull_request' }}
-  
+
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
@@ -86,7 +86,7 @@ jobs:
           project-zone: us-central1
           project-cluster: general-central
           service-key: ${{ secrets.GCLOUD_KEY }}
-      
+
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
         working-directory: ./
@@ -103,9 +103,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
@@ -158,9 +158,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,13 +50,13 @@ jobs:
 
       - name: 🏗 Setup website
         uses: ./.github/actions/setup-website
-      
+
       - name: 🚨 Lint website
         run: yarn lint --max-warnings 0
 
       - name: 🧪 Unit test website
         run: yarn test --ci --maxWorkers 1
-  
+
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
@@ -65,9 +65,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
@@ -76,11 +76,11 @@ jobs:
           project-zone: us-central1
           project-cluster: general-central
           service-key: ${{ secrets.GCLOUD_KEY }}
-      
+
       - name: 🛠 Build website
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json
         working-directory: ./
-  
+
   deploy-staging:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
@@ -93,9 +93,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
@@ -118,7 +118,7 @@ jobs:
       - name: 📋 Add change cause
         run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
         working-directory: website/deploy/staging
-      
+
       - name: 🚀 Deploy website
         run: skaffold deploy --filename website/skaffold.yaml --status-check --build-artifacts website/build.json
         working-directory: ./
@@ -148,9 +148,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🏗 Setup secrets
-        uses: sliteteam/github-action-git-crypt-unlock@a09ea5079c1b0e1887d4c8d7a4b20f00b5c2d06b
-        env:
-          GIT_CRYPT_KEY: ${{ secrets.GIT_CRYPT_KEY }}
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
@@ -170,19 +170,19 @@ jobs:
       - name: 📋 Add change cause
         run: kustomize edit add annotation kubernetes.io/change-cause:"Github Actions deploying $GITHUB_SHA at $(date)"
         working-directory: website/deploy/production
-      
+
       - name: 🚀 Deploy website
         run: skaffold deploy --filename website/skaffold.yaml --status-check --build-artifacts website/build.json
         working-directory: ./
         env:
           ENVIRONMENT: production
           SKAFFOLD_PUSH_IMAGE: 'true'
-    
+
       - name: 🧹 Prune docker image
         if: ${{ success() }}
         run: ./bin/prune-gcr snack
         working-directory: ./
-      
+
       - name: 💬 Notify Slack
         uses: 8398a7/action-slack@v3
         if: ${{ always() }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,6 +21,8 @@ on:
           - production
   pull_request:
     paths:
+      - .github/actions/setup-google-cloud/**
+      - .github/actions/setup-secrets/**
       - .github/actions/setup-website/**
       - .github/workflows/website.yml
       - website/**
@@ -32,6 +34,8 @@ on:
   push:
     branches: [main]
     paths:
+      - .github/actions/setup-google-cloud/**
+      - .github/actions/setup-secrets/**
       - .github/actions/setup-website/**
       - .github/workflows/website.yml
       - website/**


### PR DESCRIPTION
# Why

This should help not-failing CI when external contributors are opening PRs.

# How

Moved unlock to composite action, and skip it when the key isn't available (e.g. in forks).

# Test Plan

Check if CI works.
