### PR TITLE
fix(snackager): explicitly add the app version to the final image

### DIFF
--- a/snackager/Dockerfile
+++ b/snackager/Dockerfile
@@ -47,11 +47,18 @@ ENV APP_VERSION ${APP_VERSION}
 # Build
 RUN yarn build
 
-# Minimize image
+# Minimize node_modules
 RUN yarn install --frozen-lockfile --offline --production
+
+# Build minimized production image
 FROM node:${node_version}-alpine
+
+ARG APP_VERSION
+ENV APP_VERSION ${APP_VERSION}
+
 RUN apk --no-cache add git openssh-client
 RUN npm install --global npm@^6
+
 COPY --from=builder /app/snackager/package.json ./
 COPY --from=builder /app/node_modules node_modules
 COPY --from=builder /app/snackager/build build

--- a/snackager/skaffold.yaml
+++ b/snackager/skaffold.yaml
@@ -13,7 +13,7 @@ build:
         dockerfile: snackager/Dockerfile
         buildArgs:
           node_version: 16.14.2
-          APP_VERSION: v{{.GITHUB_SHA}}
+          APP_VERSION: {{.GITHUB_SHA}}
   tagPolicy:
     sha256: {}
   local:

--- a/snackager/skaffold.yaml
+++ b/snackager/skaffold.yaml
@@ -13,7 +13,7 @@ build:
         dockerfile: snackager/Dockerfile
         buildArgs:
           node_version: 16.14.2
-          APP_VERSION: {{.GITHUB_SHA}}
+          APP_VERSION: v{{.GITHUB_SHA}}
   tagPolicy:
     sha256: {}
   local:

--- a/snackager/src/app.ts
+++ b/snackager/src/app.ts
@@ -35,12 +35,7 @@ export default function createApp(): SnackagerExpressApp {
 
   app.get('/version', (_req, res) => {
     res.status(200);
-    res.end(
-      JSON.stringify({
-        version: process.env.APP_VERSION ?? 'development',
-        timestamp: process.env.BUILD_TIMESTAMP ?? '',
-      })
-    );
+    res.end(JSON.stringify({ version: process.env.APP_VERSION ?? 'development' }));
   });
 
   if (process.env.DEBUG_LOCAL_FILES) {


### PR DESCRIPTION
# Why

This seems to be missing from the current image, causing `https://<snackager>/version` to return `development` in production.

# How

- Added `APP_VERSION` to the final image, based on skaffold build argument

# Test Plan

- `https://<snackager>/version` should not return `development` as version
