### PR TITLE
Prepare for Google front-end servers

### DIFF
--- a/snackager/k8s/base/service.yaml
+++ b/snackager/k8s/base/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: snackager
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"80": {}}}'
 spec:
   ports:
   - name: http

--- a/snackager/k8s/production/kustomization.yaml
+++ b/snackager/k8s/production/kustomization.yaml
@@ -6,6 +6,7 @@ bases:
 patchesStrategicMerge:
 - deployment-increase-replicas.yaml
 - ingress-spec.yaml
+- service-backend.yaml
 configMapGenerator:
 - name: snackager-config
   behavior: merge

--- a/snackager/k8s/production/service-backend.yaml
+++ b/snackager/k8s/production/service-backend.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snackager
+  annotations:
+    controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snackager-production", "max_rate_per_endpoint":50}]}}'

--- a/snackager/k8s/staging/kustomization.yaml
+++ b/snackager/k8s/staging/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 - ../base
 patchesStrategicMerge:
 - ingress-spec.yaml
+- service-backend.yaml
 configMapGenerator:
 - name: snackager-config
   behavior: merge

--- a/snackager/k8s/staging/service-backend.yaml
+++ b/snackager/k8s/staging/service-backend.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snackager
+  annotations:
+    controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snackager-staging", "max_rate_per_endpoint":50}]}}'

--- a/snackager/src/app.ts
+++ b/snackager/src/app.ts
@@ -43,7 +43,12 @@ export default function createApp(): SnackagerExpressApp {
   }
 
   app.start = () => {
-    app.listen(config.port, () => logger.info({ port: config.port }, `ready`));
+    const server = app.listen(config.port, () => logger.info({ port: config.port }, `ready`));
+
+    server.keepAliveTimeout =
+      (10 * 60 + // Google Loadbalancing has an unconfigurable 10 minute timeout
+        20) * // Make our timeout 20 seconds longer than that ([This is recommended](https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries))
+      1000; // Convert to milliseconds
   };
 
   return app;

--- a/website/deploy/base/deployment.yaml
+++ b/website/deploy/base/deployment.yaml
@@ -27,15 +27,9 @@ spec:
             name: http
           readinessProbe:
             httpGet:
-              path: "/"
+              path: "/ready"
               port: 3011
             initialDelaySeconds: 1
-          livenessProbe:
-            httpGet:
-              path: "/"
-              port: 3011
-            initialDelaySeconds: 10
-            timeoutSeconds: 2
           resources:
             limits:
               cpu: 800m

--- a/website/deploy/base/service.yaml
+++ b/website/deploy/base/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: snack
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"80": {}}}'
 spec:
   ports:
   - name: http

--- a/website/deploy/production/kustomization.yaml
+++ b/website/deploy/production/kustomization.yaml
@@ -6,6 +6,7 @@ bases:
 patchesStrategicMerge:
 - ingress-spec.yaml
 - deployment-replicas.yaml
+- service-backend.yaml
 configMapGenerator:
 - name: snack
   behavior: merge

--- a/website/deploy/production/service-backend.yaml
+++ b/website/deploy/production/service-backend.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snackager
+  annotations:
+    controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snack-production", "max_rate_per_endpoint":50}]}}'

--- a/website/deploy/staging/kustomization.yaml
+++ b/website/deploy/staging/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 - ../base
 patchesStrategicMerge:
 - ingress-spec.yaml
+- service-backend.yaml
 configMapGenerator:
 - name: snack
   behavior: merge

--- a/website/deploy/staging/service-backend.yaml
+++ b/website/deploy/staging/service-backend.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snackager
+  annotations:
+    controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snack-staging", "max_rate_per_endpoint":50}]}}'

--- a/website/package.json
+++ b/website/package.json
@@ -82,7 +82,6 @@
     "snack-content": "*",
     "snack-eslint-standalone": "^1.1.3",
     "snack-sdk": "*",
-    "stoppable": "^1.1.0",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
@@ -138,7 +137,6 @@
     "@types/react-textarea-autosize": "^4.3.3",
     "@types/react-virtualized": "^9.18.12",
     "@types/sanitize-html": "^1.18.2",
-    "@types/stoppable": "^1.1.0",
     "@types/validate-npm-package-name": "^3.0.2",
     "@types/webpack": "^4.4.24",
     "@types/webpack-dev-middleware": "^2.0.2",
@@ -158,7 +156,6 @@
     "mini-css-extract-plugin": "^0.5.0",
     "null-loader": "^0.1.1",
     "source-map-support": "^0.5.10",
-    "stoppable": "^1.1.0",
     "terser-webpack-plugin": "^1.4.3",
     "ts-jest": "^26.5.0",
     "ts-node-dev": "^1.1.1",

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -143,6 +143,19 @@ httpServer.keepAliveTimeout =
 // Listen to HTTP server error events and handle shutting down the server gracefully
 let exitSignal: ShutdownSignal | null = null;
 let httpServerError: Error | null = null;
+let ready = true;
+
+app.use(
+  mount('/ready', (ctx) => {
+    if (ready) {
+      ctx.response.status = 200;
+      ctx.body = 'ready';
+    } else {
+      ctx.response.status = 503;
+      ctx.body = 'shutting down';
+    }
+  })
+);
 
 httpServer.on('error', (error) => {
   httpServerError = error;
@@ -168,6 +181,7 @@ const shutdown = (signal: ShutdownSignal) => {
   console.log(
     `Received ${signal}; the HTTP server is shutting down and draining existing connections`
   );
+  ready = false;
   exitSignal = signal;
   httpServer.close();
 };

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -7,7 +7,6 @@ import { AddressInfo } from 'net';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import Raven from 'raven';
-import stoppable from 'stoppable';
 
 import routes from './routes';
 import sw from './sw';
@@ -125,7 +124,7 @@ app.use(bodyParser());
 app.use(routes());
 
 const httpServer = app.listen(port, host, backlog, () => {
-  const { address, port } = server.address() as AddressInfo;
+  const { address, port } = httpServer.address() as AddressInfo;
 
   console.log(
     `The Snack web server is listening on http://${address}:${port}, took ${
@@ -136,24 +135,18 @@ const httpServer = app.listen(port, host, backlog, () => {
 
 httpServer.timeout = timeout;
 
-// In development, it's common to stop or restart the server so we immediately end and close all
-// sockets when stopping the server instead of waiting for the requests to finish. In production,
-// we allow the requests a grace period to complete before ending and closing the sockets.
-const gracePeriod = process.env.NODE_ENV === 'development' ? 0 : httpServer.timeout;
-const server = stoppable(httpServer, gracePeriod);
-
 // Listen to HTTP server error events and handle shutting down the server gracefully
 let exitSignal: ShutdownSignal | null = null;
 let httpServerError: Error | null = null;
 
-server.on('error', (error) => {
+httpServer.on('error', (error) => {
   httpServerError = error;
   console.error(`There was an error with the HTTP server:`, error);
   console.error(`The HTTP server is shutting down and draining existing connections`);
-  server.stop();
+  httpServer.close();
 });
 
-server.on('close', () => {
+httpServer.on('close', () => {
   console.log(`The HTTP server has drained all connections and is scheduling its exit`);
   console.log(`The HTTP server process is exiting...`);
   // Let other "close" event handlers run before exiting
@@ -171,7 +164,7 @@ const shutdown = (signal: ShutdownSignal) => {
     `Received ${signal}; the HTTP server is shutting down and draining existing connections`
   );
   exitSignal = signal;
-  server.stop();
+  httpServer.close();
 };
 
 // TODO: In Node 9, the signal is passed as the first argument to the listener

--- a/website/src/server/index.tsx
+++ b/website/src/server/index.tsx
@@ -135,6 +135,11 @@ const httpServer = app.listen(port, host, backlog, () => {
 
 httpServer.timeout = timeout;
 
+httpServer.keepAliveTimeout =
+  (10 * 60 + // Google Loadbalancing has an unconfigurable 10 minute timeout
+    20) * // Make our timeout 20 seconds longer than that ([This is recommended](https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries))
+  1000; // Convert to milliseconds
+
 // Listen to HTTP server error events and handle shutting down the server gracefully
 let exitSignal: ShutdownSignal | null = null;
 let httpServerError: Error | null = null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3410,13 +3410,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/stoppable@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/stoppable/-/stoppable-1.1.0.tgz#a5fa6a48120b109ca9233eed05c67c50bc4f3b91"
-  integrity sha512-BRR23Q9CJduH7AM6mk4JRttd8XyFkb4qIPZu4mdLF+VoP+wcjIxIWIKiBbN78NBbEuynrAyMPtzOHnIp2B/JPQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
@@ -13951,11 +13944,6 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
-
-stoppable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
-  integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
# Why

There's some things that are beneficial or required before I can set up our new front end servers to handle requests to the snack website and snackager.

# How

- [website] Don't use stoppable
- Set keep-alive timeout to 10m20s
- Connect k8s services to Google Backend Services
- [website] Fail readiness probe when shutting down
