### PR TITLE
[snack-sdk] fix 404 page not found in example

### DIFF
--- a/packages/snack-sdk/example/next.config.js
+++ b/packages/snack-sdk/example/next.config.js
@@ -4,6 +4,7 @@ module.exports = {
   reactStrictMode: true,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.resolve.alias['snack-sdk'] = path.resolve(__dirname, '../../../packages/snack-sdk');
+    config.resolve.alias['vm2'] = false;
     return config;
   },
 };


### PR DESCRIPTION
# Why

when loading example project, there is an error dependency. nextjs cannot build the page and cause 404 not found.

```
event - build page: /
wait  - compiling...
warn  - ../../../node_modules/vm2/lib/compiler.js
Module not found: Can't resolve 'coffee-script' in '/Users/kudo/01_Work/Repos/expo/snack/node_modules/vm2/lib'

../../../node_modules/vm2/lib/resolver-compat.js
Critical dependency: the request of a dependency is an expression
```

pubnub has a transitive dependency to vm2 and vm2 doesn't well support webpack.

```
=> Found "vm2@3.9.13"
info Reasons this module exists
   - "snack-sdk#pubnub#superagent-proxy#proxy-agent#pac-proxy-agent#pac-resolver#degenerator" depends on it
   - Hoisted from "snack-sdk#pubnub#superagent-proxy#proxy-agent#pac-proxy-agent#pac-resolver#degenerator#vm2"
```

vm2 related issue: https://github.com/patriksimek/vm2/issues/70

# How

on web, i think we don't have to use vm2. this pr removes the vm2 required dependency.

# Test Plan

```
$ cd packages/snack-sdk/example
$ yarn dev
```