### PR TITLE
[snack-sdk][website] add snackpub metrics

### DIFF
--- a/packages/snack-sdk/src/transports/ConnectionMetricsEmitter.ts
+++ b/packages/snack-sdk/src/transports/ConnectionMetricsEmitter.ts
@@ -39,7 +39,7 @@ class ConnectionMetricsEmitter {
       payload.attempts >= METRICS_FAILED_FOR_RECONNECT_ATTEMPTS
     ) {
       // To reduce the duplicated events, e.g. keeping failed events.
-      // We only log undefined -> succeeded, undefined -> failed, and failed -> successed
+      // We only log undefined -> succeeded, undefined -> failed, and failed -> succeeded
       this.emit({ name: 'TRANSPORT_CONNECTION_FAILED', ...payload });
       this.lastEmitState = 'TRANSPORT_CONNECTION_FAILED';
     }

--- a/packages/snack-sdk/src/transports/ConnectionMetricsEmitter.ts
+++ b/packages/snack-sdk/src/transports/ConnectionMetricsEmitter.ts
@@ -1,0 +1,63 @@
+interface ConnectionMetricsCommonPayload {
+  timeMs: number;
+  attempts: number;
+}
+
+export interface ConnectionMetricsSucceeded extends ConnectionMetricsCommonPayload {
+  name: 'TRANSPORT_CONNECTION_SUCCEEDED';
+}
+
+export interface ConnectionMetricsFailed extends ConnectionMetricsCommonPayload {
+  name: 'TRANSPORT_CONNECTION_FAILED';
+}
+
+type ConnectionMetricsEvents = ConnectionMetricsSucceeded | ConnectionMetricsFailed;
+
+export type ConnectionMetricsUpdateListener = (event: ConnectionMetricsEvents) => void;
+
+class ConnectionMetricsEmitter {
+  private readonly METRICS_FAILED_FOR_RECONNECT_ATTEMPTS = 5;
+  private _listener: ConnectionMetricsUpdateListener | null = null;
+  private _lastEmitState:
+    | undefined
+    | 'TRANSPORT_CONNECTION_SUCCEEDED'
+    | 'TRANSPORT_CONNECTION_FAILED';
+
+  public emitSuccessed(payload: ConnectionMetricsCommonPayload) {
+    if (
+      this._lastEmitState === undefined ||
+      this._lastEmitState === 'TRANSPORT_CONNECTION_FAILED'
+    ) {
+      // To reduce the duplicated events, e.g. keeping failed events.
+      // We only log undefined -> succeeded, undefined -> failed, and failed -> successed
+      this.emit({ name: 'TRANSPORT_CONNECTION_SUCCEEDED', ...payload });
+      this._lastEmitState = 'TRANSPORT_CONNECTION_SUCCEEDED';
+    }
+  }
+
+  public emitFailed(payload: ConnectionMetricsCommonPayload) {
+    if (
+      this._lastEmitState === undefined &&
+      payload.attempts >= this.METRICS_FAILED_FOR_RECONNECT_ATTEMPTS
+    ) {
+      // To reduce the duplicated events, e.g. keeping failed events.
+      // We only log undefined -> succeeded, undefined -> failed, and failed -> successed
+      this.emit({ name: 'TRANSPORT_CONNECTION_FAILED', ...payload });
+      this._lastEmitState = 'TRANSPORT_CONNECTION_FAILED';
+    }
+  }
+
+  public resetState() {
+    this._lastEmitState = undefined;
+  }
+
+  public setUpdateListener(listener: ConnectionMetricsUpdateListener) {
+    this._listener = listener;
+  }
+
+  private emit(event: ConnectionMetricsEvents) {
+    this._listener?.(event);
+  }
+}
+
+export default new ConnectionMetricsEmitter();

--- a/packages/snack-sdk/src/transports/index.ts
+++ b/packages/snack-sdk/src/transports/index.ts
@@ -1,11 +1,10 @@
-import ConnectionMetricsEmitter from './ConnectionMetricsEmitter';
 import TrafficMirroringTransport from './TrafficMirroringTransport';
 import TransportImplPubNub from './TransportImplPubNub';
 import { SnackTransport, SnackTransportOptions } from './types';
 
 export * from './types';
 export * from './ConnectionMetricsEmitter';
-export { ConnectionMetricsEmitter };
+export { default as ConnectionMetricsEmitter } from './ConnectionMetricsEmitter';
 
 export function createTransport(options: SnackTransportOptions): SnackTransport {
   return new TransportImplPubNub(options);

--- a/packages/snack-sdk/src/transports/index.ts
+++ b/packages/snack-sdk/src/transports/index.ts
@@ -1,8 +1,11 @@
+import ConnectionMetricsEmitter from './ConnectionMetricsEmitter';
 import TrafficMirroringTransport from './TrafficMirroringTransport';
 import TransportImplPubNub from './TransportImplPubNub';
 import { SnackTransport, SnackTransportOptions } from './types';
 
 export * from './types';
+export * from './ConnectionMetricsEmitter';
+export { ConnectionMetricsEmitter };
 
 export function createTransport(options: SnackTransportOptions): SnackTransport {
   return new TransportImplPubNub(options);

--- a/website/src/client/utils/snackTransports.tsx
+++ b/website/src/client/utils/snackTransports.tsx
@@ -5,6 +5,8 @@ import {
   SnackTransportListener,
 } from 'snack-sdk';
 
+import Analytics from './Analytics';
+
 export function createSnackWorkerTransport(
   testTransport: 'pubnub' | 'snackpub',
   options: SnackTransportOptions
@@ -24,6 +26,10 @@ export function createSnackWorkerTransport(
       if (!transportListener) {
         transportListener = (event: any) => {
           const message = event.data;
+          if (message?.type === 'transportConnectionUpdates' && message?.payload?.name) {
+            Analytics.getInstance().logEvent(message.payload.name, message.payload);
+            return;
+          }
           listener(message);
         };
       }

--- a/website/src/client/workers/SnackTransport.worker.tsx
+++ b/website/src/client/workers/SnackTransport.worker.tsx
@@ -5,7 +5,7 @@ declare const self: WorkerGlobalScope;
 // @ts-ignore
 self.window = self; // Needed for pubnub to work
 
-const { createSnackPubTransport, createTransport } = require('snack-sdk');
+const { createSnackPubTransport, createTransport, ConnectionMetricsEmitter } = require('snack-sdk');
 
 let transport: SnackTransport | undefined = undefined;
 const transportCallback = (event: SnackTransportEvent) => postMessage(event);
@@ -28,3 +28,7 @@ onmessage = (event) => {
     }
   }
 };
+
+ConnectionMetricsEmitter.setUpdateListener((event: object) => {
+  postMessage({ type: 'transportConnectionUpdates', payload: event });
+});


### PR DESCRIPTION
# Why

close ENG-7102

## pr series

#376
#377
#378 
#379
👉 #380 
#381

# How

- [website] Add two snackpub metrics for connection quality analytics
  - `TRANSPORT_CONNECTION_SUCCEEDED` with elapsed time ms and attempt times
  - `TRANSPORT_CONNECTION_FAILED` with elapsed time ms and attempt times
- we don't have analytics for runtime, so runtime is not covered by this metrics

# Test Plan

snackpub integration test
