### PR TITLE
[snack-sdk][website][runtime] add rate limiter

### DIFF
--- a/packages/snack-sdk/src/transports/TransportImplSocketIO.ts
+++ b/packages/snack-sdk/src/transports/TransportImplSocketIO.ts
@@ -10,6 +10,7 @@ interface ServerToClientEvents {
   message: (data: { channel: string; message: ProtocolIncomingMessage; sender: string }) => void;
   joinChannel: (data: { channel: string; sender: string }) => void;
   leaveChannel: (data: { channel: string; sender: string }) => void;
+  terminate: (reason: string) => void;
 }
 
 interface ClientToServerEvents {
@@ -62,6 +63,10 @@ export default class TransportImplSocketIO extends TransportImplBase {
     this.socket.on('message', this.onMessage);
     this.socket.on('joinChannel', this.onJoinChannel);
     this.socket.on('leaveChannel', this.onLeaveChannel);
+    this.socket.on('terminate', (reason) => {
+      this.logger?.comm(`Terminating connection: ${reason}`);
+      this.socket?.disconnect();
+    });
   }
 
   protected stop(): void {

--- a/runtime/src/transports/RuntimeTransportImplSocketIO.ts
+++ b/runtime/src/transports/RuntimeTransportImplSocketIO.ts
@@ -12,6 +12,7 @@ interface ServerToClientEvents {
   message: (data: { channel: string; sender: string } & RuntimeMessagePayload) => void;
   joinChannel: (data: { channel: string; sender: string }) => void;
   leaveChannel: (data: { channel: string; sender: string }) => void;
+  terminate: (reason: string) => void;
 }
 
 interface ClientToServerEvents {
@@ -34,6 +35,10 @@ export default class RuntimeTransportImplSocketIO implements RuntimeTransport {
         ? SNACKPUB_URL_STAGING
         : SNACKPUB_URL_PRODUCTION;
     this.socket = io(snackpubURL, { transports: ['websocket'] });
+    this.socket.on('terminate', (reason) => {
+      Logger.comm(`Terminating connection: ${reason}`);
+      this.socket.disconnect();
+    });
   }
 
   subscribe(channel: string) {

--- a/snackpub/src/RateLimiter.ts
+++ b/snackpub/src/RateLimiter.ts
@@ -11,7 +11,7 @@ export default class RateLimiter {
   public hasExceededSrcIpRateAsync(
     srcIp: string,
     _socketId: string,
-    options: RateLimiterOptions = { maxOperations: 30, intervalSeconds: 60 } // 30 connections per IP per hour
+    options: RateLimiterOptions = { maxOperations: 30, intervalSeconds: 60 } // 30 connections per IP per minute
   ): Promise<boolean> {
     return this.hasExceededKeyAsync(srcIp, `ip:${srcIp}`, options);
   }
@@ -45,7 +45,7 @@ export default class RateLimiter {
       .expire(redisKey, intervalSeconds)
       .exec();
 
-    const operationsInt = parseInt((operations ?? '0').toString(), 10);
+    const operationsInt = parseInt(operations ?? '0', 10);
     // The `operationsInt` is the value after incr(), we should minus one back
     if (operationsInt - 1 >= options.maxOperations) {
       await this.redisClient.decr(redisKey);
@@ -56,7 +56,7 @@ export default class RateLimiter {
   }
 
   private createRedisKey(key: string, intervalSeconds: number): string {
-    const intervalIndex = Math.floor(new Date().getTime() / 1000 / intervalSeconds);
+    const intervalIndex = Math.floor(Date.now() / 1000 / intervalSeconds);
     // Simplified rate limiter that cache hitting doesn't extend the time window.
     return `snackpub:rate:${key}:${intervalIndex}`;
   }

--- a/snackpub/src/RateLimiter.ts
+++ b/snackpub/src/RateLimiter.ts
@@ -1,0 +1,63 @@
+import type { createClient } from 'redis';
+
+interface RateLimiterOptions {
+  maxOperations: number;
+  intervalSeconds: number;
+}
+
+export default class RateLimiter {
+  constructor(private readonly redisClient: ReturnType<typeof createClient>) {}
+
+  public hasExceededSrcIpRateAsync(
+    srcIp: string,
+    _socketId: string,
+    options: RateLimiterOptions = { maxOperations: 30, intervalSeconds: 60 } // 30 connections per IP per hour
+  ): Promise<boolean> {
+    return this.hasExceededKeyAsync(srcIp, `ip:${srcIp}`, options);
+  }
+
+  public hasExceededMessagesRateAsync(
+    srcIp: string,
+    socketId: string,
+    options: RateLimiterOptions = { maxOperations: 600, intervalSeconds: 1 } // 600 messages per socket.id per second
+  ): Promise<boolean> {
+    return this.hasExceededKeyAsync(srcIp, `messages:${socketId}`, options);
+  }
+
+  public hasExceededChannelsRateAsync(
+    srcIp: string,
+    socketId: string,
+    options: RateLimiterOptions = { maxOperations: 30, intervalSeconds: 60 } // 30 channels per socket.id per minute
+  ): Promise<boolean> {
+    return this.hasExceededKeyAsync(srcIp, `channels:${socketId}`, options);
+  }
+
+  private async hasExceededKeyAsync(
+    srcIp: string,
+    key: string,
+    options: RateLimiterOptions
+  ): Promise<boolean> {
+    const { intervalSeconds } = options;
+    const redisKey = this.createRedisKey(key, intervalSeconds);
+    const [operations] = await this.redisClient
+      .multi()
+      .incr(redisKey)
+      .expire(redisKey, intervalSeconds)
+      .exec();
+
+    const operationsInt = parseInt((operations ?? '0').toString(), 10);
+    // The `operationsInt` is the value after incr(), we should minus one back
+    if (operationsInt - 1 >= options.maxOperations) {
+      await this.redisClient.decr(redisKey);
+      console.log(`[RateLimiter] exceeding limits - srcIp[${srcIp}] redisKey[${redisKey}]`);
+      return true;
+    }
+    return false;
+  }
+
+  private createRedisKey(key: string, intervalSeconds: number): string {
+    const intervalIndex = Math.floor(new Date().getTime() / 1000 / intervalSeconds);
+    // Simplified rate limiter that cache hitting doesn't extend the time window.
+    return `snackpub:rate:${key}:${intervalIndex}`;
+  }
+}

--- a/snackpub/src/RedisAdapter.ts
+++ b/snackpub/src/RedisAdapter.ts
@@ -1,4 +1,5 @@
 import { createAdapter } from '@socket.io/redis-adapter';
+import assert from 'assert';
 import type { createClient } from 'redis';
 import type { Server } from 'socket.io';
 
@@ -8,6 +9,7 @@ export async function bindRedisAdapterAsync(
   server: Server,
   redisClient: ReturnType<typeof createClient>
 ) {
+  assert(subClient == null, 'Found an orphaned Redis subscription client');
   subClient = redisClient.duplicate();
   await subClient.connect();
   server.adapter(createAdapter(redisClient, subClient, { key: 'snackpub' }));

--- a/snackpub/src/RedisAdapter.ts
+++ b/snackpub/src/RedisAdapter.ts
@@ -1,33 +1,20 @@
 import { createAdapter } from '@socket.io/redis-adapter';
-import { createClient } from 'redis';
+import type { createClient } from 'redis';
 import type { Server } from 'socket.io';
 
-import Env from './Env';
-
-let pubClient: ReturnType<typeof createClient> | null = null;
 let subClient: ReturnType<typeof createClient> | null = null;
 
-export async function maybeBindRedisAdapterAsync(
+export async function bindRedisAdapterAsync(
   server: Server,
-  inputOptions: Parameters<typeof createClient>[0] = {}
+  redisClient: ReturnType<typeof createClient>
 ) {
-  if (Env.redisURL) {
-    const options: Parameters<typeof createClient>[0] = {
-      url: Env.redisURL,
-    };
-    pubClient = createClient({ ...options, ...inputOptions });
-    subClient = pubClient.duplicate();
-
-    await Promise.all([pubClient.connect(), subClient.connect()]);
-    server.adapter(createAdapter(pubClient, subClient, { key: 'snackpub' }));
-    console.log('[RedisAdapter] Using redis adapter.');
-  }
+  subClient = redisClient.duplicate();
+  await subClient.connect();
+  server.adapter(createAdapter(redisClient, subClient, { key: 'snackpub' }));
+  console.log('[RedisAdapter] Using redis adapter.');
 }
 
-export async function maybeCloseRedisConnectionsAsync() {
+export async function closeRedisAdapterAsync() {
   subClient?.quit();
   subClient = null;
-
-  pubClient?.quit();
-  pubClient = null;
 }

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { createClient } from 'redis';
 import { Server, Socket } from 'socket.io';
 
@@ -72,12 +71,6 @@ async function runAsync() {
     const redisClientOptions: Parameters<typeof createClient>[0] = {
       url: Env.redisURL,
     };
-    if (Env.redisURL.startsWith('rediss:') && Env.redisTlsCa) {
-      redisClientOptions.socket = {
-        tls: true,
-        ca: fs.readFileSync(Env.redisTlsCa),
-      };
-    }
 
     redisClient = createClient(redisClientOptions);
     await redisClient.connect();

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -48,12 +48,20 @@ function terminateSocket(
   socket: Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
   reason: string
 ) {
+  let timeoutHandler: NodeJS.Timeout | null = null;
+  socket.once('disconnect', () => {
+    if (timeoutHandler != null) {
+      clearTimeout(timeoutHandler);
+      timeoutHandler = null;
+    }
+  });
+
   socket.emit('terminate', reason);
 
   // When clients receive the `terminate` message, they should disconnect and no longer try to reconnect back to the server.
   // In case the clients do not handle the `terminate` message, e.g. from other websocket clients other than snackpub clients.
   // We will wait three seconds to close the connections actively.
-  setTimeout(() => {
+  timeoutHandler = setTimeout(() => {
     if (socket.connected) {
       socket.disconnect(true);
     }

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -50,6 +50,10 @@ function terminateSocket(
   reason: string
 ) {
   socket.emit('terminate', reason);
+
+  // When clients receive the `terminate` message, they should disconnect and no longer try to reconnect back to the server.
+  // In case the clients do not handle the `terminate` message, e.g. from other websocket clients other than snackpub clients.
+  // We will wait three seconds to close the connections actively.
   setTimeout(() => {
     if (socket.connected) {
       socket.disconnect(true);

--- a/snackpub/src/types.ts
+++ b/snackpub/src/types.ts
@@ -2,6 +2,7 @@ export interface ServerToClientEvents {
   message: (data: { channel: string; message: object; sender: string }) => void;
   joinChannel: (data: { channel: string; sender: string }) => void;
   leaveChannel: (data: { channel: string; sender: string }) => void;
+  terminate: (reason: string) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
# Why

close ENG-7105

## pr series

#376
#377
#378 
#379
#380 
👉 #381

# How

add rate limiter:
  - 30 connections per IP per hour
  - 600 messages per socket.id per second and 6000 messages per socket.id per minute
  - 30 channels per socket.id per minute

# Test Plan

snackpub manual test
