### PR TITLE
[website] Correct service backend patches

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -85,6 +85,25 @@ jobs:
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json
         working-directory: ./
 
+  check-config:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+
+      - name: 🏗 Setup Google Cloud SDK
+        uses: ./.github/actions/setup-google-cloud
+
+      - run: kustomize build deploy/staging
+
+      - run: kustomize build deploy/production
+
   deploy-staging:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review

--- a/website/deploy/production/service-backend.yaml
+++ b/website/deploy/production/service-backend.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: snackager
+  name: snack
   annotations:
     controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snack-production", "max_rate_per_endpoint":50}]}}'

--- a/website/deploy/staging/service-backend.yaml
+++ b/website/deploy/staging/service-backend.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: snackager
+  name: snack
   annotations:
     controller.autoneg.dev/neg: '{"backend_services": {"80": [{"name":"snack-staging", "max_rate_per_endpoint":50}]}}'


### PR DESCRIPTION

# Why

This fixes deployment.

# How

This was surprisingly difficult to find; `skaffold deploy` is silently exiting with status 1 because `kustomize build` exits with status 1, but skaffold doesnt expose the error message which kustomize prints.  Maybe newer versions of skaffold handle this better.

# Test Plan

I ran `kustomize build` on the staging and production configuration.  (CI could detect mistakes like this in future PRs by running that command).
