### PR TITLE
chore: use expo sdk 47 by default

### DIFF
--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,6 +1,6 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '46.0.0';
+export const defaultSdkVersion: SDKVersion = '47.0.0';
 
 // Mostly used for tests
 export const oldestSdkVersion: SDKVersion = '45.0.0';

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -68,7 +68,7 @@
     "nullthrows": "^1.1.1",
     "pubnub": "^7.2.0",
     "semver": "^7.3.4",
-    "snack-content": "^1.2.0",
+    "snack-content": "~1.2.0",
     "ua-parser-js": "^0.7.22",
     "validate-npm-package-name": "^3.0.0"
   }

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -200,7 +200,7 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~2.5.0",
+    "wantedVersion": "~2.8.0",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.46.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.47.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
@@ -223,7 +223,7 @@ Array [
         },
         "description": "test2 @ Jan 1, 2020",
         "name": "test2",
-        "sdkVersion": "46.0.0",
+        "sdkVersion": "47.0.0",
       },
     },
     "headers": Object {
@@ -261,7 +261,7 @@ Array [
         },
         "description": "test3 @ Jan 1, 2020",
         "name": "test3",
-        "sdkVersion": "46.0.0",
+        "sdkVersion": "47.0.0",
       },
     },
     "headers": Object {
@@ -295,7 +295,7 @@ Array [
         },
         "description": "some-example @ Jan 1, 2020",
         "name": "some-example",
-        "sdkVersion": "46.0.0",
+        "sdkVersion": "47.0.0",
       },
     },
     "headers": Object {


### PR DESCRIPTION
# Why

We are preparing to add SDK 48, this wasn't done yet.

# How

Updated the packages and config

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
