### PR TITLE
[snackpub] read correct remote address behind load balancer

### DIFF
--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -59,6 +59,9 @@ jobs:
       - name: 🚨 Lint snackpub
         run: yarn lint --max-warnings 0
 
+      - name: 🧪 Unit test website
+        run: yarn test --ci --maxWorkers 1
+
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -60,7 +60,7 @@ jobs:
         run: yarn lint --max-warnings 0
 
       - name: 🧪 Unit test website
-        run: yarn test --ci --maxWorkers 1
+        run: yarn test --ci
 
   build:
     if: ${{ github.event_name == 'pull_request' }}

--- a/snackpub/jest.config.js
+++ b/snackpub/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
+};

--- a/snackpub/package.json
+++ b/snackpub/package.json
@@ -31,6 +31,9 @@
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.2",
+    "@types/jest": "^26.0.20",
+    "jest": "^26.6.3",
+    "ts-jest": "^26.5.0",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.6.3"
   },

--- a/snackpub/src/NetworkUtils.ts
+++ b/snackpub/src/NetworkUtils.ts
@@ -3,7 +3,12 @@ import type { IncomingHttpHeaders, IncomingMessage } from 'http';
 type ValueOf<T> = T[keyof T];
 
 export function getRemoteAddress(req: IncomingMessage): string | undefined {
-  return getFirstHeaderValue(req.headers['x-forwarded-for']) ?? req.socket.remoteAddress;
+  return (
+    getFirstHeaderValue(req.headers['cf-connecting-ip']) ??
+    getFirstHeaderValue(req.headers['x-real-ip']) ??
+    getFirstHeaderValue(req.headers['x-forwarded-for']) ??
+    req.socket.remoteAddress
+  );
 }
 
 function getFirstHeaderValue(headerValue: ValueOf<IncomingHttpHeaders>): string | undefined {

--- a/snackpub/src/NetworkUtils.ts
+++ b/snackpub/src/NetworkUtils.ts
@@ -1,0 +1,12 @@
+import type { IncomingHttpHeaders, IncomingMessage } from 'http';
+
+type ValueOf<T> = T[keyof T];
+
+export function getRemoteAddress(req: IncomingMessage): string | undefined {
+  return getFirstHeaderValue(req.headers['x-forwarded-for']) ?? req.socket.remoteAddress;
+}
+
+function getFirstHeaderValue(headerValue: ValueOf<IncomingHttpHeaders>): string | undefined {
+  const firstValue = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  return firstValue?.split(/\s*,\s*/, 1)[0];
+}

--- a/snackpub/src/__tests__/NetworkUtils-test.ts
+++ b/snackpub/src/__tests__/NetworkUtils-test.ts
@@ -3,6 +3,30 @@ import type { IncomingMessage } from 'http';
 import { getRemoteAddress } from '../NetworkUtils';
 
 describe(getRemoteAddress, () => {
+  it('should respect `cf-connecting-ip` header', () => {
+    const req = {
+      headers: {
+        'cf-connecting-ip': '10.0.0.1',
+      },
+      socket: {
+        address: '127.0.0.1',
+      },
+    } as unknown as IncomingMessage;
+    expect(getRemoteAddress(req)).toBe('10.0.0.1');
+  });
+
+  it('should respect `x-real-ip` header', () => {
+    const req = {
+      headers: {
+        'x-real-ip': '10.0.0.1',
+      },
+      socket: {
+        address: '127.0.0.1',
+      },
+    } as unknown as IncomingMessage;
+    expect(getRemoteAddress(req)).toBe('10.0.0.1');
+  });
+
   it('should respect `x-forwarded-for` header', () => {
     const req = {
       headers: {

--- a/snackpub/src/__tests__/NetworkUtils-test.ts
+++ b/snackpub/src/__tests__/NetworkUtils-test.ts
@@ -1,0 +1,41 @@
+import type { IncomingMessage } from 'http';
+
+import { getRemoteAddress } from '../NetworkUtils';
+
+describe(getRemoteAddress, () => {
+  it('should respect `x-forwarded-for` header', () => {
+    const req = {
+      headers: {
+        'x-forwarded-for': '10.0.0.1',
+      },
+      socket: {
+        address: '127.0.0.1',
+      },
+    } as unknown as IncomingMessage;
+    expect(getRemoteAddress(req)).toBe('10.0.0.1');
+  });
+
+  it('should get first value from `x-forwarded-for` header', () => {
+    const req = {
+      headers: {
+        'x-forwarded-for': '10.0.0.1, 10.0.0.2',
+      },
+      socket: {
+        address: '127.0.0.1',
+      },
+    } as unknown as IncomingMessage;
+    expect(getRemoteAddress(req)).toBe('10.0.0.1');
+  });
+
+  it('should use socket remoteAddress as fallback', () => {
+    const req = {
+      headers: {
+        host: 'www.example.org',
+      },
+      socket: {
+        remoteAddress: '127.0.0.1',
+      },
+    } as unknown as IncomingMessage;
+    expect(getRemoteAddress(req)).toBe('127.0.0.1');
+  });
+});

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -92,7 +92,7 @@ async function runAsync() {
     const remoteAddress = getRemoteAddress(socket.request) ?? 'UNKNOWN';
     console.log(`New connection from ${remoteAddress}`);
 
-    if (await rateLimiter?.hasExceededSrcIpRateAsync(remoteAddress, socket.id)) {
+    if (await rateLimiter?.hasExceededRemoteAddressRateAsync(remoteAddress, socket.id)) {
       terminateSocket(socket, 'Too many requests.');
     }
 

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'redis';
 import { Server, Socket } from 'socket.io';
 
 import Env from './Env';
+import { getRemoteAddress } from './NetworkUtils';
 import RateLimiter from './RateLimiter';
 import { bindRedisAdapterAsync, closeRedisAdapterAsync } from './RedisAdapter';
 import type {
@@ -88,13 +89,15 @@ async function runAsync() {
   }
 
   io.on('connection', async (socket) => {
-    debug('onconnect', socket.handshake.address);
-    if (await rateLimiter?.hasExceededSrcIpRateAsync(socket.handshake.address, socket.id)) {
+    const remoteAddress = getRemoteAddress(socket.request) ?? 'UNKNOWN';
+    console.log(`New connection from ${remoteAddress}`);
+
+    if (await rateLimiter?.hasExceededSrcIpRateAsync(remoteAddress, socket.id)) {
       terminateSocket(socket, 'Too many requests.');
     }
 
     socket.on('message', async (data) => {
-      if (await rateLimiter?.hasExceededMessagesRateAsync(socket.handshake.address, socket.id)) {
+      if (await rateLimiter?.hasExceededMessagesRateAsync(remoteAddress, socket.id)) {
         terminateSocket(socket, 'Too many messages.');
       }
 
@@ -104,7 +107,7 @@ async function runAsync() {
 
     socket.on('subscribeChannel', async (data) => {
       debug('onSubscribeChannel', data);
-      if (await rateLimiter?.hasExceededChannelsRateAsync(socket.handshake.address, socket.id)) {
+      if (await rateLimiter?.hasExceededChannelsRateAsync(remoteAddress, socket.id)) {
         terminateSocket(socket, 'Too many channels.');
       }
 


### PR DESCRIPTION
# Why

follow up https://github.com/expo/snack/pull/381#discussion_r1080836193

# How

- read the address from the `X-Forwarded-For` first then the socket remote address
- because cloud run doesn't log the remote address as http access log, this pr also adds remote address to log.

# Test Plan

- add `getRemoteAddress` unit test
- ci passed
