### PR TITLE
[snackpub] better join/leave channel

### DIFF
--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -85,41 +85,31 @@ async function runAsync() {
       const { channel, sender } = data;
       socket.join(channel);
       socket.data.deviceId = sender;
+      debug('joinChannel', { channel, sender });
+      socket.to(channel).emit('joinChannel', { channel, sender });
     });
 
     socket.on('unsubscribeChannel', (data) => {
       debug('onUnsubscribeChannel', data);
-      const { channel } = data;
+      const { channel, sender } = data;
       socket.leave(channel);
+      debug('leaveChannel', { channel, sender });
+      socket.to(channel).emit('leaveChannel', { channel, sender });
     });
-  });
 
-  io.of('/').adapter.on('join-room', async (channel: string, id: string) => {
-    const sockets = await io.in(channel).fetchSockets();
-    const sender = sockets.filter((socket) => socket.id === id)[0]?.data.deviceId;
-    if (!sender) {
-      return;
-    }
-    for (const socket of sockets) {
-      if (socket.id !== id) {
-        debug('joinChannel', { channel, sender });
-        socket.emit('joinChannel', { channel, sender });
-      }
-    }
-  });
-
-  io.of('/').adapter.on('leave-room', async (channel: string, id: string) => {
-    const sockets = await io.in(channel).fetchSockets();
-    const sender = sockets.filter((socket) => socket.id === id)[0]?.data.deviceId;
-    if (!sender) {
-      return;
-    }
-    for (const socket of sockets) {
-      if (socket.id !== id) {
+    socket.on('disconnecting', () => {
+      const sender = socket.data.deviceId;
+      assert(sender);
+      for (const channel of socket.rooms) {
+        if (channel === socket.id) {
+          // socket.io implicitly creates a default channel for each socket which id is socket.id,
+          // we should skip this one from broadcasting the leaveChannel event.
+          continue;
+        }
         debug('leaveChannel', { channel, sender });
-        socket.emit('leaveChannel', { channel, sender });
+        socket.to(channel).emit('leaveChannel', { channel, sender });
       }
-    }
+    });
   });
 
   const redisClients = [redisClient, redisSubscriptionClient];

--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -102,8 +102,8 @@ async function runAsync() {
       assert(sender);
       for (const channel of socket.rooms) {
         if (channel === socket.id) {
-          // socket.io implicitly creates a default channel for each socket which id is socket.id,
-          // we should skip this one from broadcasting the leaveChannel event.
+          // socket.io implicitly creates a default channel for each socket. The default channel's name is the socket's ID.
+          // We should skip the default channel when broadcasting the leaveChannel event.
           continue;
         }
         debug('leaveChannel', { channel, sender });


### PR DESCRIPTION
# Why

remove the `fetchSockets` code which getting timeout occasionally.
```
Error: timeout reached while waiting for fetchSockets response at Timeout._onTimeout (/app/node_modules/@socket.io/redis-adapter/dist/index.js:559:28) at listOnTimeout (node:internal/timers:559:17) at processTimers (node:internal/timers:502:7)
```
close ENG-7773

(this should be the last one pr for us to test snackpub on production. there's still a server readiness check task and i'll do it after production testing).

# How

originally i used `fetchSockets` to get the socket's custom data - `deviceId` when `join-room`/`leave-room`.  the `fetchSockets` is not efficient and requires more expensive work for querying data from redis adapter. it turns out that we don't have to send the `joinChannel`/`leaveChannel` from `join-room`/`leave-room` time. we could do it at the exact timing:
  - when receiving the `subscribeChannel` command
  - when receiving the `unsubscribeChannel` command
  - if case client disconnects network without sending the `unsubscribeChannel` command, we should also broadcast `leaveChannel` when some clients get disconnected.

# Test Plan

- deploy to staging snackpub and test with expo go where joinChannel and leaveChannel are received from website
![Screenshot 2023-03-15 at 1 09 58 AM](https://user-images.githubusercontent.com/46429/225086594-9f29d806-2684-45b4-be64-7656f1e2a25c.png)

