### PR TITLE
[sdk][runtime][website] Support snackOnly transport

### DIFF
--- a/packages/snack-sdk/src/transports/__mocks__/index.ts
+++ b/packages/snack-sdk/src/transports/__mocks__/index.ts
@@ -9,3 +9,7 @@ export function createTransport(options: SnackTransportOptions): SnackTransport 
 export function createSnackPubTransport(options: SnackTransportOptions): SnackTransport {
   return new TestTransport(options);
 }
+
+export function createSnackPubOnlyTransport(options: SnackTransportOptions): SnackTransport {
+  return new TestTransport(options);
+}

--- a/packages/snack-sdk/src/transports/index.ts
+++ b/packages/snack-sdk/src/transports/index.ts
@@ -1,5 +1,6 @@
 import TrafficMirroringTransport from './TrafficMirroringTransport';
 import TransportImplPubNub from './TransportImplPubNub';
+import TransportImplSocketIO from './TransportImplSocketIO';
 import { SnackTransport, SnackTransportOptions } from './types';
 
 export * from './types';
@@ -12,4 +13,8 @@ export function createTransport(options: SnackTransportOptions): SnackTransport 
 
 export function createSnackPubTransport(options: SnackTransportOptions): SnackTransport {
   return new TrafficMirroringTransport(options);
+}
+
+export function createSnackPubOnlyTransport(options: SnackTransportOptions): SnackTransport {
+  return new TransportImplSocketIO(options);
 }

--- a/runtime/src/Messaging.tsx
+++ b/runtime/src/Messaging.tsx
@@ -25,6 +25,8 @@ export const init = (deviceId: string, testTransport: string | null | undefined)
     transportClass = require('./transports/RuntimeTransportImplWebPlayer').default;
   } else if (testTransport === 'snackpub') {
     transportClass = require('./transports/RuntimeTrafficMirroringTransport').default;
+  } else if (testTransport === 'snackpubOnly') {
+    transportClass = require('./transports/RuntimeTransportImplSocketIO').default;
   } else {
     transportClass = require('./transports/RuntimeTransportImplPubNub').default;
   }

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -70,7 +70,7 @@ type Props = AuthProps &
     isEmbedded?: boolean;
     files: SnackFiles;
     defaults: SnackDefaults;
-    testTransport: 'pubnub' | 'snackpub';
+    testTransport: 'pubnub' | 'snackpub' | 'snackpubOnly';
   };
 
 type State = {
@@ -287,8 +287,8 @@ class Main extends React.Component<Props, State> {
       let webPreviewURL = state.session.webPreviewURL;
 
       let experienceURL = state.session.url;
-      if (_props.testTransport === 'snackpub') {
-        experienceURL += '?testTransport=snackpub';
+      if (['snackpub', 'snackpubOnly'].includes(_props.testTransport)) {
+        experienceURL += `?testTransport=${_props.testTransport}`;
       }
 
       if (state.isLocalWebPreview) {
@@ -852,8 +852,8 @@ class Main extends React.Component<Props, State> {
     const { isEmbedded, testTransport } = this.props;
 
     let experienceURL = this.state.session.url;
-    if (testTransport === 'snackpub') {
-      experienceURL += '?testTransport=snackpub';
+    if (['snackpub', 'snackpubOnly'].includes(testTransport)) {
+      experienceURL += `?testTransport=${testTransport}`;
     }
 
     if (this.state.isPreview) {

--- a/website/src/client/utils/snackTransports.tsx
+++ b/website/src/client/utils/snackTransports.tsx
@@ -8,7 +8,7 @@ import {
 import Analytics from './Analytics';
 
 export function createSnackWorkerTransport(
-  testTransport: 'pubnub' | 'snackpub',
+  testTransport: 'pubnub' | 'snackpub' | 'snackpubOnly',
   options: SnackTransportOptions
 ) {
   let transport: SnackTransport | null = null;

--- a/website/src/server/utils/getSplitTests.tsx
+++ b/website/src/server/utils/getSplitTests.tsx
@@ -52,7 +52,10 @@ export default async (ctx: Context) => {
   };
 
   const overrideTestTransport = ctx.request.query.testTransport;
-  if (overrideTestTransport && ['pubnub', 'snackpub'].includes(overrideTestTransport)) {
+  if (
+    overrideTestTransport &&
+    ['pubnub', 'snackpub', 'snackpubOnly'].includes(overrideTestTransport)
+  ) {
     newValues['testTransport'] = overrideTestTransport;
   }
 


### PR DESCRIPTION
# Why

next step to rollout snackpub on production - having a snackpub only transport without traffic mirroring for pubnub

# How

add `testTransport=snackpubOnly` support

# Test Plan

- ci passed
- test `http://snack.expo.test/?testTransport=snackpubOnly` and check no pubnub xhr requests.