### PR TITLE
[snackpub] support readiness http requests

### DIFF
--- a/snackpub/src/HttpEndpoints.ts
+++ b/snackpub/src/HttpEndpoints.ts
@@ -1,0 +1,75 @@
+import http from 'http';
+
+import { type NullableRedisClientType } from './types';
+
+export function createHttpEndpointsListener(
+  requestHandlers: RequestHandler[]
+): http.RequestListener {
+  return async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    for (const requestHandler of requestHandlers) {
+      const handled = await requestHandler.processAsync(req, res);
+      if (handled) {
+        return;
+      }
+    }
+
+    res.writeHead(404);
+    res.end();
+  };
+}
+
+export interface RequestHandler {
+  processAsync(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean>;
+}
+
+export class ReadOnlyRequestsHandler implements RequestHandler {
+  async processAsync(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
+    if (req.method != null && !['GET', 'OPTIONS'].includes(req.method)) {
+      res.writeHead(405);
+      res.end();
+      return true;
+    }
+    return false;
+  }
+}
+
+export class LivenessRequestHandler implements RequestHandler {
+  async processAsync(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
+    if (req.url === '/status/live') {
+      res.writeHead(200);
+      res.end('Live');
+      return true;
+    }
+    return false;
+  }
+}
+
+export class ReadinessRequestHandler implements RequestHandler {
+  private readonly redisClients: NullableRedisClientType[];
+
+  constructor(redisClients: NullableRedisClientType[]) {
+    this.redisClients = redisClients;
+  }
+
+  async processAsync(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
+    if (req.url === '/status/ready') {
+      let ready = true;
+      for (const redisClient of this.redisClients) {
+        if ((redisClient?.isReady ?? true) === false) {
+          ready = false;
+          break;
+        }
+      }
+
+      if (ready) {
+        res.writeHead(200);
+        res.end('Ready');
+      } else {
+        res.writeHead(503);
+        res.end('Unready');
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/snackpub/src/HttpEndpoints.ts
+++ b/snackpub/src/HttpEndpoints.ts
@@ -45,22 +45,13 @@ export class LivenessRequestHandler implements RequestHandler {
 }
 
 export class ReadinessRequestHandler implements RequestHandler {
-  private readonly redisClients: NullableRedisClientType[];
-
-  constructor(redisClients: NullableRedisClientType[]) {
+  constructor(private readonly redisClients: NullableRedisClientType[]) {
     this.redisClients = redisClients;
   }
 
   async processAsync(req: http.IncomingMessage, res: http.ServerResponse): Promise<boolean> {
     if (req.url === '/status/ready') {
-      let ready = true;
-      for (const redisClient of this.redisClients) {
-        if ((redisClient?.isReady ?? true) === false) {
-          ready = false;
-          break;
-        }
-      }
-
+      const ready = this.redisClients.every((redisClient) => redisClient?.isReady ?? true);
       if (ready) {
         res.writeHead(200);
         res.end('Ready');

--- a/snackpub/src/RedisAdapter.ts
+++ b/snackpub/src/RedisAdapter.ts
@@ -1,11 +1,12 @@
 import { createAdapter } from '@socket.io/redis-adapter';
-import type { createClient } from 'redis';
 import type { Server } from 'socket.io';
+
+import { type RedisClientType } from './types';
 
 export async function bindRedisAdapterAsync(
   server: Server,
-  redisClient: ReturnType<typeof createClient>
-): Promise<ReturnType<typeof createClient>> {
+  redisClient: RedisClientType
+): Promise<RedisClientType> {
   const redisSubscriptionClient = redisClient.duplicate();
   await redisSubscriptionClient.connect();
   server.adapter(createAdapter(redisClient, redisSubscriptionClient, { key: 'snackpub' }));

--- a/snackpub/src/__tests__/HttpEndpoints-test.ts
+++ b/snackpub/src/__tests__/HttpEndpoints-test.ts
@@ -1,0 +1,104 @@
+import http from 'http';
+
+import {
+  LivenessRequestHandler,
+  ReadinessRequestHandler,
+  ReadOnlyRequestsHandler,
+} from '../HttpEndpoints';
+import type { RedisClientType } from '../types';
+
+describe(ReadOnlyRequestsHandler, () => {
+  it('should return http 405 for any DELETE/POST/PUT requests', async () => {
+    const methods = ['DELETE', 'POST', 'PUT'];
+    for (const method of methods) {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      req.method = method;
+      await new ReadOnlyRequestsHandler().processAsync(req, res);
+      expect(res.writeHead.mock.calls[0][0]).toBe(405);
+    }
+  });
+
+  it('should allow GET/OPTIONS requests', async () => {
+    const methods = ['GET', 'OPTIONS'];
+    for (const method of methods) {
+      const req = createMockReq();
+      const res = createMockRes();
+
+      req.method = method;
+      await new ReadOnlyRequestsHandler().processAsync(req, res);
+      expect(res.writeHead.mock.calls.length).toBe(0);
+      expect(res.end.mock.calls.length).toBe(0);
+    }
+  });
+});
+
+describe(LivenessRequestHandler, () => {
+  it('should return http 200 for `/status/live` requests', async () => {
+    const req = createMockReq();
+    const res = createMockRes();
+
+    req.url = '/status/live';
+    await new LivenessRequestHandler().processAsync(req, res);
+    expect(res.writeHead.mock.calls[0][0]).toBe(200);
+  });
+});
+
+describe(ReadinessRequestHandler, () => {
+  function createMockRedisClient(isReady: boolean): RedisClientType {
+    return { isReady } as RedisClientType;
+  }
+
+  it('should return http 200 for `/status/ready` requests when not using redis adapters', async () => {
+    const req = createMockReq();
+    const res = createMockRes();
+
+    req.url = '/status/ready';
+    await new ReadinessRequestHandler([]).processAsync(req, res);
+    expect(res.writeHead.mock.calls[0][0]).toBe(200);
+  });
+
+  it('should return http 200 for `/status/ready` requests when redis clients are all ready', async () => {
+    const req = createMockReq();
+    const res = createMockRes();
+
+    req.url = '/status/ready';
+    const redisClients = [
+      createMockRedisClient(true),
+      createMockRedisClient(true),
+      createMockRedisClient(true),
+    ];
+    await new ReadinessRequestHandler(redisClients).processAsync(req, res);
+    expect(res.writeHead.mock.calls[0][0]).toBe(200);
+  });
+
+  it('should return http 503 for `/status/ready` requests if any redis client unavailable', async () => {
+    const req = createMockReq();
+    const res = createMockRes();
+
+    req.url = '/status/ready';
+    const redisClients = [
+      createMockRedisClient(true),
+      createMockRedisClient(false),
+      createMockRedisClient(true),
+    ];
+    await new ReadinessRequestHandler(redisClients).processAsync(req, res);
+    expect(res.writeHead.mock.calls[0][0]).toBe(503);
+  });
+});
+
+function createMockReq() {
+  return {
+    method: 'GET',
+    url: '/',
+  } as jest.Mocked<http.IncomingMessage>;
+}
+
+function createMockRes() {
+  return {
+    end: jest.fn(),
+    write: jest.fn(),
+    writeHead: jest.fn(),
+  } as unknown as jest.Mocked<http.ServerResponse>;
+}

--- a/snackpub/src/types.ts
+++ b/snackpub/src/types.ts
@@ -1,3 +1,5 @@
+import { type createClient } from 'redis';
+
 export interface ServerToClientEvents {
   message: (data: { channel: string; message: object; sender: string }) => void;
   joinChannel: (data: { channel: string; sender: string }) => void;
@@ -16,3 +18,6 @@ export interface InterServerEvents {}
 export interface SocketData {
   deviceId: string;
 }
+
+export type RedisClientType = ReturnType<typeof createClient>;
+export type NullableRedisClientType = RedisClientType | null;


### PR DESCRIPTION
# Why

follow up https://github.com/expo/snack/pull/377#pullrequestreview-1247080929
close ENG-7693

# How

- add `/status/live` support which always returns 200 from snackpub
- add `/status/ready` support which returns 200 when all redis clients are ready, otherwise returns 503.

# Test Plan

### Unit Test

```
 PASS  src/__tests__/HttpEndpoints-test.ts
  ReadOnlyRequestsHandler
    ✓ should return http 405 for any DELETE/POST/PUT requests (1 ms)
    ✓ should allow GET/OPTIONS requests
  LivenessRequestHandler
    ✓ should return http 200 for `/status/live` requests
  ReadinessRequestHandler
    ✓ should return http 200 for `/status/ready` requests when not using redis adapters
    ✓ should return http 200 for `/status/ready` requests when redis clients are all ready
    ✓ should return http 503 for `/status/ready` requests if any redis client unavailable
```

### Integration Test

```sh
# snackpub server startup with redis adapter
$ redis-server &
$ REDIS_URL='redis://localhost:6379' yarn start

# test live endpoint with httpie
$ http -v http://localhost:3013/status/live
# HTTP/1.1 200 OK

# test ready endpoint with httpie
$ http -v http://localhost:3013/status/ready
# HTTP/1.1 200 OK

# test stale redis clients
$ killall redis-server
$ http -v http://localhost:3013/status/ready
# HTTP/1.1 503 Service Unavailable

# test snackpub redis client reconnection when redis-server is back again
$ redis-server &
$ http -v http://localhost:3013/status/ready
# HTTP/1.1 200 OK

# cleanup
$ killall redis-server
$ kill $(jobs -p)
```