### PR TITLE
[snackpub] Fix disconnecting server assertion error

### DIFF
--- a/snackpub/src/index.ts
+++ b/snackpub/src/index.ts
@@ -114,7 +114,10 @@ async function runAsync() {
 
     socket.on('disconnecting', () => {
       const sender = socket.data.deviceId;
-      assert(sender);
+      if (!sender) {
+        // No-op if the disconnecting socket doesn't bind with a device ID
+        return;
+      }
       for (const channel of socket.rooms) {
         if (channel === socket.id) {
           // socket.io implicitly creates a default channel for each socket. The default channel's name is the socket's ID.


### PR DESCRIPTION
# Why

fix server crash from the staging/production log

```
node:assert:399
throw err;
^
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
(0, assert_1.default)(sender)
at Socket.<anonymous> (/app/snackpub/build/index.js:86:34)
at Socket.emit (node:events:526:28)
at Socket.emitReserved (/app/node_modules/socket.io/dist/typed-events.js:56:22)
at Socket._onclose (/app/node_modules/socket.io/dist/socket.js:467:14)
at Client.onclose (/app/node_modules/socket.io/dist/client.js:246:20)
at Socket.emit (node:events:538:35)
at Socket.onClose (/app/node_modules/engine.io/build/socket.js:304:18)
at Object.onceWrapper (node:events:645:28)
at WebSocket.emit (node:events:526:28)
at WebSocket.onClose (/app/node_modules/engine.io/build/transport.js:110:14) {
generatedMessage: true,
code: 'ERR_ASSERTION',
actual: undefined,
expected: true,
operator: '=='
}
```
 
# How

the hypothesis is a client connecting and then disconnecting immediately. it doesn't have a chance to bind deviceId and break my original assumption. in this case we should just ignore to leave broadcasting without server crash.

# Test Plan

ci passed