### PR TITLE
[website] Update Readme.md file defaults

### DIFF
--- a/website/src/client/configs/defaults.tsx
+++ b/website/src/client/configs/defaults.tsx
@@ -96,11 +96,11 @@ const styles = StyleSheet.create({
 
 Open the \`App.js\` file to start writing some code. You can preview the changes directly on your phone or tablet by scanning the **QR code** or use the iOS or Android emulators. When you're done, click **Save** and share the link!
 
-When you're ready to see everything that Expo provides (or if you want to use your own editor) you can **Download** your project and use it with [expo-cli](https://docs.expo.io/get-started/installation).
+When you're ready to see everything that Expo provides (or if you want to use your own editor) you can **Download** your project and use it with [Expo CLI](/get-started/installation/#expo-cli).
 
 All projects created in Snack are publicly available, so you can easily share the link to this project via link, or embed it on a web page with the \`<>\` button.
 
-If you're having problems, you can tweet to us [@expo](https://twitter.com/expo) or ask in our [forums](https://forums.expo.io/c/snack).
+If you're having problems, you can tweet to us [@expo](https://twitter.com/expo) or ask in our [forums](https://forums.expo.io/c/snack) or [Discord](https://chat.expo.dev/).
 
 Snack is Open Source. You can find the code on the [GitHub repo](https://github.com/expo/snack).
 `,


### PR DESCRIPTION
# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Currently:
- The `Readme.md` file doesn't mention Discord community
- The docs link (even though redirect works) is outdated

![CleanShot 2023-04-01 at 22 48 21@2x](https://user-images.githubusercontent.com/10234615/229306351-8c47d71c-0608-4826-8fd8-5a31c43a27c9.png)

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

This PR:
- Adds a link to the Discord community
- Updates the docs link
- Fixes how we use "Expo CLI" as a term (we're now using `expo-cli` for deprecated global CLI)

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->

N/A
