### PR TITLE
[sdk] add default snackpubURL

### DIFF
--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -114,7 +114,7 @@ export default class Snack {
     const dependencies = options.dependencies ? { ...options.dependencies } : {};
     this.options = options;
     this.apiURL = options.apiURL ?? defaultConfig.apiURL;
-    this.snackpubURL = options.snackpubURL;
+    this.snackpubURL = options.snackpubURL ?? defaultConfig.snackpubURL;
     this.host = options.host ?? new URL(this.apiURL).host;
     this.logger = options.verbose ? createLogger(true) : undefined;
     this.codeChangesDelay = options.codeChangesDelay ?? 0;

--- a/packages/snack-sdk/src/__tests__/snack-sdk.ts
+++ b/packages/snack-sdk/src/__tests__/snack-sdk.ts
@@ -4,10 +4,12 @@ switch (process.env.SNACK_ENV) {
   case 'local':
     defaultConfig.apiURL = 'http://localhost:3000';
     defaultConfig.snackagerURL = 'https://localhost:3012';
+    defaultConfig.snackpubURL = 'http://localhost:3013';
     break;
   case 'staging':
     defaultConfig.apiURL = 'https://staging.exp.host';
     defaultConfig.snackagerURL = 'https://staging.snackager.expo.io';
+    defaultConfig.snackpubURL = 'https://staging-snackpub.expo.dev';
     break;
 }
 

--- a/packages/snack-sdk/src/defaultConfig.ts
+++ b/packages/snack-sdk/src/defaultConfig.ts
@@ -4,6 +4,7 @@ import { SnackState } from './types';
 
 export const apiURL: string = 'https://exp.host';
 export const snackagerURL: string = 'https://snackager.expo.io';
+export const snackpubURL: string = 'https://snackpub.expo.dev';
 export const webPlayerURL: string =
   'https://snack-web-player.s3.us-west-1.amazonaws.com/v2/%%SDK_VERSION%%';
 
@@ -26,6 +27,7 @@ export const SnackIdentityState: SnackState = {
 const defaultConfig = {
   apiURL,
   snackagerURL,
+  snackpubURL,
   sdkVersion: defaultSdkVersion,
   webPlayerURL,
 };


### PR DESCRIPTION
# Why

originally, the snackpub server url is passed from website. to serve snack for third party partners, we should have default snackpub server url inside snack-sdk.

# How

add default `snackpubURL` to snack-sdk

# Test Plan

ci passed
