### PR TITLE
[sdk][runtime][website] use snackpub as default transport

### DIFF
--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -114,7 +114,7 @@ export default class Snack {
     const dependencies = options.dependencies ? { ...options.dependencies } : {};
     this.options = options;
     this.apiURL = options.apiURL ?? defaultConfig.apiURL;
-    this.snackpubURL = options.snackpubURL;
+    this.snackpubURL = options.snackpubURL ?? defaultConfig.snackpubURL;
     this.host = options.host ?? new URL(this.apiURL).host;
     this.logger = options.verbose ? createLogger(true) : undefined;
     this.codeChangesDelay = options.codeChangesDelay ?? 0;

--- a/packages/snack-sdk/src/__tests__/snack-sdk.ts
+++ b/packages/snack-sdk/src/__tests__/snack-sdk.ts
@@ -4,10 +4,12 @@ switch (process.env.SNACK_ENV) {
   case 'local':
     defaultConfig.apiURL = 'http://localhost:3000';
     defaultConfig.snackagerURL = 'https://localhost:3012';
+    defaultConfig.snackpubURL = 'http://localhost:3013';
     break;
   case 'staging':
     defaultConfig.apiURL = 'https://staging.exp.host';
     defaultConfig.snackagerURL = 'https://staging.snackager.expo.io';
+    defaultConfig.snackpubURL = 'https://staging-snackpub.expo.dev';
     break;
 }
 

--- a/packages/snack-sdk/src/defaultConfig.ts
+++ b/packages/snack-sdk/src/defaultConfig.ts
@@ -4,6 +4,7 @@ import { SnackState } from './types';
 
 export const apiURL: string = 'https://exp.host';
 export const snackagerURL: string = 'https://snackager.expo.io';
+export const snackpubURL: string = 'https://snackpub.expo.dev';
 export const webPlayerURL: string =
   'https://snack-web-player.s3.us-west-1.amazonaws.com/v2/%%SDK_VERSION%%';
 
@@ -26,6 +27,7 @@ export const SnackIdentityState: SnackState = {
 const defaultConfig = {
   apiURL,
   snackagerURL,
+  snackpubURL,
   sdkVersion: defaultSdkVersion,
   webPlayerURL,
 };

--- a/packages/snack-sdk/src/transports/__mocks__/index.ts
+++ b/packages/snack-sdk/src/transports/__mocks__/index.ts
@@ -6,10 +6,6 @@ export function createTransport(options: SnackTransportOptions): SnackTransport 
   return result;
 }
 
-export function createSnackPubTransport(options: SnackTransportOptions): SnackTransport {
-  return new TestTransport(options);
-}
-
-export function createSnackPubOnlyTransport(options: SnackTransportOptions): SnackTransport {
+export function createTrafficMirroringTransport(options: SnackTransportOptions): SnackTransport {
   return new TestTransport(options);
 }

--- a/packages/snack-sdk/src/transports/index.ts
+++ b/packages/snack-sdk/src/transports/index.ts
@@ -1,5 +1,4 @@
 import TrafficMirroringTransport from './TrafficMirroringTransport';
-import TransportImplPubNub from './TransportImplPubNub';
 import TransportImplSocketIO from './TransportImplSocketIO';
 import { SnackTransport, SnackTransportOptions } from './types';
 
@@ -8,13 +7,9 @@ export * from './ConnectionMetricsEmitter';
 export { default as ConnectionMetricsEmitter } from './ConnectionMetricsEmitter';
 
 export function createTransport(options: SnackTransportOptions): SnackTransport {
-  return new TransportImplPubNub(options);
-}
-
-export function createSnackPubTransport(options: SnackTransportOptions): SnackTransport {
-  return new TrafficMirroringTransport(options);
-}
-
-export function createSnackPubOnlyTransport(options: SnackTransportOptions): SnackTransport {
   return new TransportImplSocketIO(options);
+}
+
+export function createTrafficMirroringTransport(options: SnackTransportOptions): SnackTransport {
+  return new TrafficMirroringTransport(options);
 }

--- a/runtime/src/Messaging.tsx
+++ b/runtime/src/Messaging.tsx
@@ -23,12 +23,10 @@ export const init = (deviceId: string, testTransport: string | null | undefined)
   let transportClass;
   if (Platform.OS === 'web') {
     transportClass = require('./transports/RuntimeTransportImplWebPlayer').default;
-  } else if (testTransport === 'snackpub') {
+  } else if (testTransport === 'trafficMirroring') {
     transportClass = require('./transports/RuntimeTrafficMirroringTransport').default;
-  } else if (testTransport === 'snackpubOnly') {
-    transportClass = require('./transports/RuntimeTransportImplSocketIO').default;
   } else {
-    transportClass = require('./transports/RuntimeTransportImplPubNub').default;
+    transportClass = require('./transports/RuntimeTransportImplSocketIO').default;
   }
   transport = new transportClass(device);
 };

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -70,7 +70,6 @@ type Props = AuthProps &
     isEmbedded?: boolean;
     files: SnackFiles;
     defaults: SnackDefaults;
-    testTransport: 'snackpub' | 'trafficMirroring';
   };
 
 type State = {
@@ -206,7 +205,7 @@ class Main extends React.Component<Props, State> {
       verbose,
       codeChangesDelay: sendCodeOnChangeEnabled ? 1000 : -1,
       createTransport: isWorker
-        ? createSnackWorkerTransport.bind(null, props.testTransport)
+        ? createSnackWorkerTransport.bind(null, props.query.testTransport ?? 'snackpub')
         : undefined,
       reloadTimeout: 10000,
       deviceId: getDeviceId(),
@@ -287,8 +286,8 @@ class Main extends React.Component<Props, State> {
       let webPreviewURL = state.session.webPreviewURL;
 
       let experienceURL = state.session.url;
-      if (['trafficMirroring'].includes(_props.testTransport)) {
-        experienceURL += `?testTransport=${_props.testTransport}`;
+      if (_props.query.testTransport) {
+        experienceURL += `?testTransport=${_props.query.testTransport}`;
       }
 
       if (state.isLocalWebPreview) {
@@ -849,11 +848,11 @@ class Main extends React.Component<Props, State> {
   };
 
   render() {
-    const { isEmbedded, testTransport } = this.props;
+    const { isEmbedded } = this.props;
 
     let experienceURL = this.state.session.url;
-    if (['trafficMirroring'].includes(testTransport)) {
-      experienceURL += `?testTransport=${testTransport}`;
+    if (this.props.query.testTransport) {
+      experienceURL += `?testTransport=${this.props.query.testTransport}`;
     }
 
     if (this.state.isPreview) {
@@ -957,7 +956,6 @@ class Main extends React.Component<Props, State> {
 const MainContainer = withPreferences(
   connect((state: any) => ({
     viewer: state.viewer,
-    testTransport: state.splitTestSettings.testTransport ?? 'snackpub',
   }))(withAuth(Main))
 );
 

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -70,7 +70,7 @@ type Props = AuthProps &
     isEmbedded?: boolean;
     files: SnackFiles;
     defaults: SnackDefaults;
-    testTransport: 'pubnub' | 'snackpub' | 'snackpubOnly';
+    testTransport: 'snackpub' | 'trafficMirroring';
   };
 
 type State = {
@@ -287,7 +287,7 @@ class Main extends React.Component<Props, State> {
       let webPreviewURL = state.session.webPreviewURL;
 
       let experienceURL = state.session.url;
-      if (['snackpub', 'snackpubOnly'].includes(_props.testTransport)) {
+      if (['trafficMirroring'].includes(_props.testTransport)) {
         experienceURL += `?testTransport=${_props.testTransport}`;
       }
 
@@ -852,7 +852,7 @@ class Main extends React.Component<Props, State> {
     const { isEmbedded, testTransport } = this.props;
 
     let experienceURL = this.state.session.url;
-    if (['snackpub', 'snackpubOnly'].includes(testTransport)) {
+    if (['trafficMirroring'].includes(testTransport)) {
       experienceURL += `?testTransport=${testTransport}`;
     }
 
@@ -957,7 +957,7 @@ class Main extends React.Component<Props, State> {
 const MainContainer = withPreferences(
   connect((state: any) => ({
     viewer: state.viewer,
-    testTransport: state.splitTestSettings.testTransport ?? 'pubnub',
+    testTransport: state.splitTestSettings.testTransport ?? 'snackpub',
   }))(withAuth(Main))
 );
 

--- a/website/src/client/types.tsx
+++ b/website/src/client/types.tsx
@@ -100,6 +100,7 @@ export type QueryInitParams = {
   iframeId?: string;
   waitForData?: 'boolean';
   saveToAccount?: 'true' | 'false';
+  testTransport?: 'snackpub' | 'trafficMirroring';
 };
 
 export type QueryStateParams = {

--- a/website/src/client/utils/snackTransports.tsx
+++ b/website/src/client/utils/snackTransports.tsx
@@ -8,7 +8,7 @@ import {
 import Analytics from './Analytics';
 
 export function createSnackWorkerTransport(
-  testTransport: 'pubnub' | 'snackpub' | 'snackpubOnly',
+  testTransport: 'snackpub' | 'trafficMirroring',
   options: SnackTransportOptions
 ) {
   let transport: SnackTransport | null = null;

--- a/website/src/client/workers/SnackTransport.worker.tsx
+++ b/website/src/client/workers/SnackTransport.worker.tsx
@@ -6,8 +6,7 @@ declare const self: WorkerGlobalScope;
 self.window = self; // Needed for pubnub to work
 
 const {
-  createSnackPubTransport,
-  createSnackPubOnlyTransport,
+  createTrafficMirroringTransport,
   createTransport,
   ConnectionMetricsEmitter,
 } = require('snack-sdk');
@@ -36,11 +35,8 @@ ConnectionMetricsEmitter.setUpdateListener((event: object) => {
 });
 
 function transportFactory(testTransport: string, data: any) {
-  if (testTransport === 'snackpub') {
-    return createSnackPubTransport(data);
-  }
-  if (testTransport === 'snackpubOnly') {
-    return createSnackPubOnlyTransport(data);
+  if (testTransport === 'trafficMirroring') {
+    return createTrafficMirroringTransport(data);
   }
   return createTransport(data);
 }

--- a/website/src/server/utils/getSplitTests.tsx
+++ b/website/src/server/utils/getSplitTests.tsx
@@ -39,7 +39,6 @@ export default async (ctx: Context) => {
       account: 0.25,
     }),
     authFlow: choose(['save1', 'save2']),
-    testTransport: 'snackpubOnly',
   };
 
   const newValues = {
@@ -47,14 +46,6 @@ export default async (ctx: Context) => {
     ...userDetails,
     ...existingSettings,
   };
-
-  const overrideTestTransport = ctx.request.query.testTransport;
-  if (
-    overrideTestTransport &&
-    ['pubnub', 'snackpub', 'snackpubOnly'].includes(overrideTestTransport)
-  ) {
-    newValues['testTransport'] = overrideTestTransport;
-  }
 
   ctx.res.setHeader('Set-Cookie', cookie.serialize(SNACK_COOKIE_NAME, JSON.stringify(newValues)));
   return newValues;


### PR DESCRIPTION
# Why

to help third party partners to migrate snackpub without further code changes, we should replace the original `createTransport()` underlying transport from pubnub to snackpub. 

# How

- replace the original `createTransport()` underlying transport from pubnub to snackpub. since it changes the semantics of the default transport, we should align the changes across snack-sdk and snack-runtime.
- [sdk] keeps only `createTransport()` and `createTrafficMirroringTransport()`. i.e. removes the `createSnackPubTransport()` and `createSnackPubOnlyTransport()`
- remove the testTransport a/b testing. now it's all snackpub by default. we could still use `?testTransport` to override transport. it's just not served from http cookie specified from server.
- the `testTransport` is now accepting `snackpub` or `trafficMirroring` 

# Test Plan

- ci passed
- `http://snack.expo.test/` - should not send pubnub long polling requests
- `http://snack.expo.test/?testTransport=trafficMirroring` - should send pubnub long polling requests
