### PR TITLE
chore(website): enable `config-check` on non-forks

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -85,26 +85,26 @@ jobs:
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json
         working-directory: ./
 
-  # Disabled due to random failures
-  # See: https://github.com/expo/snack/actions/runs/4584436218/jobs/8095917813?pr=408
-  # check-config:
-  #   if: ${{ github.event_name == 'pull_request' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: 🏗 Setup repository
-  #       uses: actions/checkout@v3
+  check-config:
+    if: ${{ github.event_name == 'pull_request' && github.repository == 'expo/snack' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repository
+        uses: actions/checkout@v3
 
-  #     - name: 🏗 Setup secrets
-  #       uses: ./.github/actions/setup-secrets
-  #       with:
-  #         git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
+      - name: 🏗 Setup secrets
+        uses: ./.github/actions/setup-secrets
+        with:
+          git-crypt-key: ${{ secrets.GIT_CRYPT_KEY }}
 
-  #     - name: 🏗 Setup Google Cloud SDK
-  #       uses: ./.github/actions/setup-google-cloud
+      - name: 🏗 Setup Google Cloud SDK
+        uses: ./.github/actions/setup-google-cloud
 
-  #     - run: kustomize build deploy/staging
+      - name: Check staging config
+        run: kustomize build deploy/staging
 
-  #     - run: kustomize build deploy/production
+      - name: Check production config
+        run: kustomize build deploy/production
 
   deploy-staging:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}


### PR DESCRIPTION
# Why

That was the culprit of #408 

# How

Added `github.repository` check, and mark the job as skipped when using forks.

# Test Plan

See #408