### PR TITLE
[sdk] fix code diff limit for snackpub transport

### DIFF
--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+### 🐛 Bug fixes
+
+- Fixed `undefined` importing file when its size exceeds 32768. ([#360](https://github.com/expo/snack/pull/423) by [@kudo](https://github.com/kudo))
+
 ## 4.0.0 - 2023-04-21
 
 ### 🛠 Breaking changes

--- a/packages/snack-sdk/src/transports/TransportImplBase.ts
+++ b/packages/snack-sdk/src/transports/TransportImplBase.ts
@@ -17,6 +17,9 @@ export default abstract class TransportImplBase implements SnackTransport {
   private connectionsCount: number = 0;
   protected readonly logSuffix: string;
 
+  // Limit for code size in diff message
+  protected static readonly CODE_SIZE_LIMIT_FOR_DIFF = 32768;
+
   constructor(options: SnackTransportOptions) {
     const { apiURL, channel, verbose } = options;
     this.channel = channel ?? '';
@@ -29,7 +32,7 @@ export default abstract class TransportImplBase implements SnackTransport {
         callback: this.onCodeMessageReady,
         apiURL,
         logger: this.logger,
-        maxDiffPlaceholder: 'X'.repeat(32768),
+        maxDiffPlaceholder: 'X'.repeat(TransportImplBase.CODE_SIZE_LIMIT_FOR_DIFF),
       });
     } else {
       this.codeMessageBuilder = new CodeMessageBuilder({

--- a/packages/snack-sdk/src/transports/TransportImplPubNub.ts
+++ b/packages/snack-sdk/src/transports/TransportImplPubNub.ts
@@ -89,13 +89,13 @@ export default class TransportImplPubNub extends TransportImplBase {
     for (const path in codeMessage.diff) {
       approxSize += path.length + codeMessage.diff[path].length;
     }
-    if (approxSize >= 32768) {
+    if (approxSize >= TransportImplBase.CODE_SIZE_LIMIT_FOR_DIFF) {
       return false;
     }
 
     // Calculate exact size and check whether it exceeds the limit
     const size = calcPubNubCodeMessageSize(this.channel, codeMessage);
-    return size < 32768;
+    return size < TransportImplBase.CODE_SIZE_LIMIT_FOR_DIFF;
   }
 
   private onPubNubPresence = (event: PubNub.PresenceEvent) => {

--- a/packages/snack-sdk/src/transports/TransportImplSocketIO.ts
+++ b/packages/snack-sdk/src/transports/TransportImplSocketIO.ts
@@ -94,16 +94,13 @@ export default class TransportImplSocketIO extends TransportImplBase {
   }
 
   protected onVerifyCodeMessageSize(codeMessage: ProtocolCodeMessage): boolean {
-    // https://socket.io/docs/v4/server-options/#maxhttpbuffersize
-    const MAX_SIZE = 1e6;
-
     // Calculate unencoded size (quickly) and if that exceeds the limit
     // then don't bother calculating the exact size (which is more expensive)
     let approxSize = 0;
     for (const path in codeMessage.diff) {
       approxSize += path.length + codeMessage.diff[path].length;
     }
-    return approxSize < MAX_SIZE;
+    return approxSize < TransportImplBase.CODE_SIZE_LIMIT_FOR_DIFF;
   }
 
   private onMessage = (data: {


### PR DESCRIPTION
# Why

We have 32768 limit for code diff for PubNub transport and the `32768` limit is hardcoded in different places. I didn't implement similar logic in socketio transport, so it will actually transfer `'X'.repeat(32768)` as the file content in transport. 

# How

- implement 32768 limit on TransportImplSocketIO
- centralize the 32768 limit

# Test Plan

- working example: https://staging-snack.expo.dev/@kudochien/long-snack (since i've deployed the pr to staging)
- not working example: https://snack.expo.dev/@kudochien/long-snack
