### PR TITLE
chore(website): enable SDK 48 in dropdown

### DIFF
--- a/website/src/client/configs/sdk.tsx
+++ b/website/src/client/configs/sdk.tsx
@@ -9,7 +9,7 @@ import { SDKVersion } from 'snack-sdk';
 export const versions: Record<SDKVersion, boolean> = {
   '46.0.0': true,
   '47.0.0': true,
-  '48.0.0': false,
+  '48.0.0': true,
 };
 
 export const DEFAULT_SDK_VERSION: SDKVersion = defaultSdkVersion;


### PR DESCRIPTION
# Why

Enable users to select SDK 48 in the dropdown on Snack. We've deployed and tested SDK 48 to some extent, it should be mostly ready for normal usage.

# How

Enabled the flag.

# Test Plan

Minor change
