### PR TITLE
chore(website): temporary lock website `snack-sdk` version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -82,7 +82,7 @@
     "snack-babel-standalone": "^2.2.2",
     "snack-content": "*",
     "snack-eslint-standalone": "^1.1.3",
-    "snack-sdk": "*",
+    "snack-sdk": "4.1.0-rc.0",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14173,10 +14173,34 @@ snack-babel-standalone@^2.2.2:
   resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
   integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
 
+snack-content@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/snack-content/-/snack-content-1.3.0.tgz#dfd9fd5dd9ca523bb5af6db3897e041c10d4280a"
+  integrity sha512-h5LymtR4Hvzgnb3gUyddq5ERgmRj9gsDUSXP/EJLgpVduH7nJiomzX25fiOUdWT8NwNHq0afusPK89RAQ+sizg==
+  dependencies:
+    semver "^7.3.4"
+
 snack-eslint-standalone@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.3.tgz#2c83a044d40244976bb4f11e741032a3c9162e1c"
   integrity sha512-7uJ9I3xHK5CV48ZXJRB+WAG3uyJBSRrhPAjPmzX4xbUCRCInok7znaW9u5J/vFxCAyyEcdeoWR+AfN0sgCCq8w==
+
+snack-sdk@*:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-4.0.1.tgz#ca0c653b05d7540cdb8c4fc0d3c5b273ba25e0d3"
+  integrity sha512-olhPtvRgMZfWHudPMqmwXg4sC7LkxV7KPYuOkuLFoj1R8HlrptTzsn2BQZkvom/R8QR3niy74d+GBBNtlwBDFQ==
+  dependencies:
+    diff "^4.0.2"
+    fetch-ponyfill "^7.0.0"
+    lodash "^4.17.20"
+    nanoid "^3.1.20"
+    nullthrows "^1.1.1"
+    pubnub "^7.2.0"
+    semver "^7.3.4"
+    snack-content "~1.3.0"
+    socket.io-client "~4.5.4"
+    ua-parser-js "^0.7.22"
+    validate-npm-package-name "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

It seems that yarn workspaces isn't playing nice with `-rc` releases. Let's lock it on this version until we have the stable one.

# How

- Locked `"snack-sdk": "4.1.0-rc.0"` in Snack Website
