### PR TITLE
fix(runtime): improve virtual module invalidation

### DIFF
--- a/packages/snack-require-context/src/utils/context.ts
+++ b/packages/snack-require-context/src/utils/context.ts
@@ -91,7 +91,7 @@ export function resolveContextFiles(request: SnackRequireContextRequest, files: 
     contextFiles
       .map((snackPath) => [`./${snackPath.replace(relativePathReplace, '')}`, snackPath])
       .filter(([relativePath]) => request.matching.test(relativePath))
-  );
+  ) as Record<string, string>;
 }
 
 /**

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -439,18 +439,20 @@ export default class App extends React.Component<object, State> {
     let rootElement: React.ReactElement | undefined;
     try {
       const rootModuleUri = 'module://' + Files.entry();
-      if (changedPaths.length > 0) {
-        await Modules.flush({ changedPaths, changedUris: [rootModuleUri] });
-      }
 
       // Handle Expo Router root with a Snack compatible components
       if (isExpoRouterEntry(Files.get(Files.entry())?.contents)) {
+        // Flush without flushing the root component
+        await Modules.flush({ changedPaths, changedUris: [] });
+
         const ctx = await Modules.load(createVirtualModulePath({ directory: 'module://app' }));
         Logger.info('Updating Expo Router root element');
         rootElement = React.createElement(ExpoRouterApp, { ctx });
       }
       // Handle normal default exports
       else {
+        // Flush with the root component
+        await Modules.flush({ changedPaths, changedUris: [rootModuleUri] });
         const hasRootModuleUri = await Modules.has(rootModuleUri);
         if (!hasRootModuleUri) {
           const rootDefaultExport = (await Modules.load(rootModuleUri)).default;


### PR DESCRIPTION
# Why

This fixes a couple of things around the newer `require.context` implementation for Expo Router.

# How

- Keep track of each dependent of a virtual module, invalidate only those virtual modules when dependent was changed.
- Invalidate all virtual modules whenever a new file was added
- Only flush the root component when not using `expo-router`

# Test Plan

See staging.