### PR TITLE
Fix snackpub deployments

### DIFF
--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -141,7 +141,7 @@ jobs:
           fields: message,commit,author,job,took
 
   deploy-production:
-    if: ${{ github.event.inputs.deploy == 'production' }}
+    if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
     needs: review
     runs-on: ubuntu-latest
     environment:
@@ -169,6 +169,10 @@ jobs:
         env:
           ENVIRONMENT: production
           SKAFFOLD_PUSH_IMAGE: 'true'
+
+      - name: 🚀 Deploy snackpub to cloud run
+        run: ./scripts/deploy.sh -e production
+        working-directory: snackpub
 
       - name: 🚀 Deploy snackpub to k8s
         run: skaffold deploy --status-check --build-artifacts /tmp/build.json

--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -110,7 +110,7 @@ jobs:
           service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
 
       - name: 🛠 Build snackpub
-        run: skaffold build --filename snackpub/skaffold.yaml --file-output ~/tmp/build.json
+        run: skaffold build --filename snackpub/skaffold.yaml --file-output /tmp/build.json
         working-directory: ./
         env:
           SKAFFOLD_PUSH_IMAGE: 'true'
@@ -124,7 +124,7 @@ jobs:
         working-directory: snackpub
 
       - name: 🚀 Deploy snackpub to k8s
-        run: skaffold deploy --status-check --build-artifacts /tmp/workspace/build.json
+        run: skaffold deploy --status-check --build-artifacts /tmp/build.json
         working-directory: snackpub
         env:
           ENVIRONMENT: staging
@@ -164,7 +164,7 @@ jobs:
           service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
 
       - name: 🛠 Build snackpub
-        run: skaffold build --filename snackpub/skaffold.yaml --file-output ~/tmp/build.json
+        run: skaffold build --filename snackpub/skaffold.yaml --file-output /tmp/build.json
         working-directory: ./
         env:
           ENVIRONMENT: production
@@ -175,7 +175,7 @@ jobs:
         working-directory: snackpub
 
       - name: 🚀 Deploy snackpub to k8s
-        run: skaffold deploy --status-check --build-artifacts /tmp/workspace/build.json
+        run: skaffold deploy --status-check --build-artifacts /tmp/build.json
         working-directory: snackpub
         env:
           ENVIRONMENT: production

--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -141,7 +141,7 @@ jobs:
           fields: message,commit,author,job,took
 
   deploy-production:
-    if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event.inputs.deploy == 'production' }}
     needs: review
     runs-on: ubuntu-latest
     environment:
@@ -169,10 +169,6 @@ jobs:
         env:
           ENVIRONMENT: production
           SKAFFOLD_PUSH_IMAGE: 'true'
-
-      - name: 🚀 Deploy snackpub to cloud run
-        run: ./scripts/deploy.sh -e production
-        working-directory: snackpub
 
       - name: 🚀 Deploy snackpub to k8s
         run: skaffold deploy --status-check --build-artifacts /tmp/build.json

--- a/snackpub/k8s/base/kustomization.yaml
+++ b/snackpub/k8s/base/kustomization.yaml
@@ -4,5 +4,4 @@ commonLabels:
   app: snackpub
 resources:
   - deployment.yaml
-  - pdb.yaml
   - service.yaml

--- a/snackpub/k8s/base/pdb.yaml
+++ b/snackpub/k8s/base/pdb.yaml
@@ -1,8 +1,0 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: snackpub
-spec:
-  minAvailable: 50%
-  selector:
-    matchLabels: {}

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -46,8 +46,7 @@ profiles:
       - env: CI=true
     deploy:
       kubectl: {}
-      # kubeContext: gke_exponentjs_us-central1_general-central
-      kubeContext: general-central
+      kubeContext: gke_exponentjs_us-central1_general-central
   - name: main
     activation:
       - env: GITHUB_REF=refs/heads/main

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -18,7 +18,7 @@ build:
   tagPolicy:
     sha256: {}
   local:
-    push: false
+    push: true
 manifests:
   kustomize:
     paths:

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -18,7 +18,7 @@ build:
   tagPolicy:
     sha256: {}
   local:
-    push: true
+    push: false
 manifests:
   kustomize:
     paths:


### PR DESCRIPTION
# Why

Snackpub deployments are currently broken.

# How

- Fix `skaffold` commands in GHA.
- Fix cluster name.
- Removed pdb from k8s config.

# Test Plan

Manually triggered successful deployments for [staging](https://github.com/expo/snack/actions/runs/5579453245/jobs/10195050524) and [production](https://github.com/expo/snack/actions/runs/5579549858/jobs/10195298956).
