### PR TITLE
chore: bump website and snackager node versions to `16.20.1`

### DIFF
--- a/snackager/skaffold.yaml
+++ b/snackager/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: snackager/Dockerfile
         buildArgs:
-          node_version: 16.14.2
+          node_version: 16.20.1
           APP_VERSION: v{{.GITHUB_SHA}}
   tagPolicy:
     sha256: {}

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -13,7 +13,7 @@ build:
       docker:
         dockerfile: snackpub/Dockerfile
         buildArgs:
-          node_version: 16.14.2
+          node_version: 16.20.1
           DEPLOY_ENVIRONMENT: staging
   tagPolicy:
     sha256: {}

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -13,7 +13,7 @@ build:
       docker:
         dockerfile: snackpub/Dockerfile
         buildArgs:
-          node_version: 16.20.1
+          node_version: 16.14.2
           DEPLOY_ENVIRONMENT: staging
   tagPolicy:
     sha256: {}

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: website/Dockerfile
         buildArgs:
-          node_version: 16.14.2
+          node_version: 16.20.1
           LEGACY_SERVER_URL: https://staging.expo.io
           SERVER_URL: https://staging.expo.dev
           API_SERVER_URL: https://staging.exp.host
@@ -43,7 +43,7 @@ profiles:
           docker:
             dockerfile: website/Dockerfile
             buildArgs:
-              node_version: 16.14.2
+              node_version: 16.20.1
               LEGACY_SERVER_URL: https://expo.io
               SERVER_URL: https://expo.dev
               API_SERVER_URL: https://exp.host


### PR DESCRIPTION
# Why

Fixes [ENG-9178](https://linear.app/expo/issue/ENG-9178)

# How

- Bumped all docker node versions to from `16.14.2` to `16.20.1`.
 
# Test Plan

Deploying to staging.