### PR TITLE
[snackpub] integrate http liveness/readiness probe

### DIFF
--- a/snackpub/k8s/base/deployment.yaml
+++ b/snackpub/k8s/base/deployment.yaml
@@ -24,10 +24,12 @@ spec:
               memory: 512Mi
               cpu: 300m
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /status/live
               port: 3013
             periodSeconds: 20
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /status/ready
               port: 3013
             periodSeconds: 20


### PR DESCRIPTION
# Why

originally we have the http readiness endpoint from #405, but cloudrun does not well support the readinessProbe. after k8s migration, we can now integrate the http readiness check.

# How

integrate http based liveness/readiness probes rather than tcp checks

# Test Plan

review and let's see if that works after staging deployment