### PR TITLE
[snackpub] reduce production k8s replicas

### DIFF
--- a/snackpub/k8s/production/deployment-replicas.yaml
+++ b/snackpub/k8s/production/deployment-replicas.yaml
@@ -3,4 +3,4 @@ kind: Deployment
 metadata:
   name: snackpub
 spec:
-  replicas: 5
+  replicas: 3


### PR DESCRIPTION
# Why

reduce the replicas to the previous number which worked great.

# How

reduce the replicas to 3

# Test Plan

as previous experiments, three replicas should be good enough for snackpub
