### PR TITLE
feature(website): add support for opening projects with Orbit

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,7 @@
     "classnames": "^2.2.6",
     "cookie": "^0.3.1",
     "core-js": "^3.6.5",
+    "custom-protocol-check": "^1.4.0",
     "date-fns": "^1.30.1",
     "docsearch.js": "^2.6.3",
     "es6-error": "^4.1.1",

--- a/website/src/client/auth/authManager.tsx
+++ b/website/src/client/auth/authManager.tsx
@@ -3,10 +3,19 @@ import ExtendableError from 'es6-error';
 import { getAuthStorageKey } from './config';
 import Storage from './storage';
 
+export enum Experiment {
+  Orbit = 'ORBIT',
+}
+
 export type UserData = {
   id: string;
   username: string;
   profilePhoto: string;
+  experiments: {
+    id: string;
+    enabled: boolean;
+    experiment: Experiment;
+  }[];
 };
 
 type Auth0TokenData = {
@@ -171,6 +180,11 @@ export default class AuthenticationManager {
             id
             username
             profilePhoto
+            experiments {
+              id
+              enabled
+              experiment
+            }
           }
         }`,
       },

--- a/website/src/client/components/DownloadOrbitDialog.tsx
+++ b/website/src/client/components/DownloadOrbitDialog.tsx
@@ -1,0 +1,37 @@
+import { StyleSheet, css } from 'aphrodite';
+import * as React from 'react';
+
+import withThemeName, { ThemeName } from './Preferences/withThemeName';
+
+type Props = {
+  theme: ThemeName;
+};
+
+class DownloadOrbitDialog extends React.Component<Props> {
+  render() {
+    return (
+      <div className={css(styles.container)}>
+        <p className={css(styles.text)}>
+          It seems that you don't have Orbit installed on your computer. To download the latest
+          release, please visit our{' '}
+          <a href="https://github.com/expo/orbit/releases" target="blank">
+            GitHub releases page
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+}
+
+export default withThemeName(DownloadOrbitDialog);
+
+const styles = StyleSheet.create({
+  container: {
+    margin: -12,
+    textAlign: 'left',
+  },
+  text: {
+    margin: 12,
+  },
+});

--- a/website/src/client/components/EditorToolbar.tsx
+++ b/website/src/client/components/EditorToolbar.tsx
@@ -27,6 +27,7 @@ type Props = {
   onShowModal: (modal: EditorModal) => void;
   onHideModal: () => void;
   onDownloadCode: () => Promise<void>;
+  onOpenWithOrbit: () => void;
   onPublishAsync: (options?: SaveOptions) => Promise<void>;
 };
 
@@ -48,6 +49,7 @@ export default function EditorToolbar(props: Props) {
     onShowModal,
     onHideModal,
     onDownloadCode,
+    onOpenWithOrbit,
     onPublishAsync,
   } = props;
   const { theme } = preferences;
@@ -103,6 +105,18 @@ export default function EditorToolbar(props: Props) {
               strokeWidth="1.667"
             />
             <rect x="8.333" y="1.667" width="5" height="2.5" rx=".833" stroke="none" />
+          </svg>
+        </IconButton>
+        <IconButton responsive title="Open with Orbit" onClick={onOpenWithOrbit}>
+          <svg width="20" height="20" viewBox="0 0 16 16">
+            <path
+              stroke="none"
+              d="M6.53747 12.9531C6.25915 12.0253 11.176 9.35779 13.6693 8.14001C13.5533 9.02918 13.4373 10.5176 11.9298 12.0253C10.5962 13.3591 6.88536 14.1129 6.53747 12.9531Z"
+            />
+            <path
+              stroke="none"
+              d="M5.84172 3.037C1.99171 4.79989 2.45941 8.66153 3.17452 10.3432C2.88459 10.4596 1.78288 10.5176 1.60898 10.2857C1.43507 10.0537 1.95691 9.53181 2.30481 9.29939L2.18883 8.83547C0.565336 9.64778 -0.19688 10.652 0.0434576 11.2135C0.217402 11.6199 2.18883 12.6628 8.85678 9.58934C15.5247 6.51589 16.2785 4.83465 15.9306 4.25476C15.6523 3.79084 13.708 4.00301 12.7996 4.19631L13.2634 4.71867C13.8432 4.60269 14.3071 4.60269 14.3071 4.89264C14.3071 5.36574 13.6693 5.78138 13.3214 5.99402C12.4323 4.29299 9.84249 1.20508 5.84172 3.037Z"
+            />
           </svg>
         </IconButton>
         <IconButton

--- a/website/src/client/components/EditorToolbar.tsx
+++ b/website/src/client/components/EditorToolbar.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, css } from 'aphrodite';
 import * as React from 'react';
 
+import { Experiment } from '../auth/authManager';
 import { SaveStatus, SaveHistory, Viewer, SaveOptions, SDKVersion } from '../types';
 import EditorTitle from './EditorTitle';
 import type { EditorModal } from './EditorViewProps';
@@ -57,6 +58,10 @@ export default function EditorToolbar(props: Props) {
   const isPublishing = saveStatus === 'publishing';
   const isPublished = saveStatus === 'published';
 
+  const showOrbitButton =
+    viewer?.experiments?.find(({ experiment }) => experiment === Experiment.Orbit)?.enabled ??
+    false;
+
   return (
     <ToolbarShell>
       <ToolbarTitleShell>
@@ -107,18 +112,20 @@ export default function EditorToolbar(props: Props) {
             <rect x="8.333" y="1.667" width="5" height="2.5" rx=".833" stroke="none" />
           </svg>
         </IconButton>
-        <IconButton responsive title="Open with Orbit" onClick={onOpenWithOrbit}>
-          <svg width="20" height="20" viewBox="0 0 16 16">
-            <path
-              stroke="none"
-              d="M6.53747 12.9531C6.25915 12.0253 11.176 9.35779 13.6693 8.14001C13.5533 9.02918 13.4373 10.5176 11.9298 12.0253C10.5962 13.3591 6.88536 14.1129 6.53747 12.9531Z"
-            />
-            <path
-              stroke="none"
-              d="M5.84172 3.037C1.99171 4.79989 2.45941 8.66153 3.17452 10.3432C2.88459 10.4596 1.78288 10.5176 1.60898 10.2857C1.43507 10.0537 1.95691 9.53181 2.30481 9.29939L2.18883 8.83547C0.565336 9.64778 -0.19688 10.652 0.0434576 11.2135C0.217402 11.6199 2.18883 12.6628 8.85678 9.58934C15.5247 6.51589 16.2785 4.83465 15.9306 4.25476C15.6523 3.79084 13.708 4.00301 12.7996 4.19631L13.2634 4.71867C13.8432 4.60269 14.3071 4.60269 14.3071 4.89264C14.3071 5.36574 13.6693 5.78138 13.3214 5.99402C12.4323 4.29299 9.84249 1.20508 5.84172 3.037Z"
-            />
-          </svg>
-        </IconButton>
+        {showOrbitButton ? (
+          <IconButton responsive title="Open with Orbit" onClick={onOpenWithOrbit}>
+            <svg width="20" height="20" viewBox="0 0 16 16">
+              <path
+                stroke="none"
+                d="M6.53747 12.9531C6.25915 12.0253 11.176 9.35779 13.6693 8.14001C13.5533 9.02918 13.4373 10.5176 11.9298 12.0253C10.5962 13.3591 6.88536 14.1129 6.53747 12.9531Z"
+              />
+              <path
+                stroke="none"
+                d="M5.84172 3.037C1.99171 4.79989 2.45941 8.66153 3.17452 10.3432C2.88459 10.4596 1.78288 10.5176 1.60898 10.2857C1.43507 10.0537 1.95691 9.53181 2.30481 9.29939L2.18883 8.83547C0.565336 9.64778 -0.19688 10.652 0.0434576 11.2135C0.217402 11.6199 2.18883 12.6628 8.85678 9.58934C15.5247 6.51589 16.2785 4.83465 15.9306 4.25476C15.6523 3.79084 13.708 4.00301 12.7996 4.19631L13.2634 4.71867C13.8432 4.60269 14.3071 4.60269 14.3071 4.89264C14.3071 5.36574 13.6693 5.78138 13.3214 5.99402C12.4323 4.29299 9.84249 1.20508 5.84172 3.037Z"
+              />
+            </svg>
+          </IconButton>
+        ) : null}
         <IconButton
           responsive
           title="Download as zip"

--- a/website/src/client/components/EditorView.tsx
+++ b/website/src/client/components/EditorView.tsx
@@ -8,6 +8,7 @@ import Analytics from '../utils/Analytics';
 import { isMobile } from '../utils/detectPlatform';
 import { isScript, isJson, isTest } from '../utils/fileUtilities';
 import lintFile from '../utils/lintFile';
+import { openExpoOrbitWithExperienceURL } from '../utils/orbit';
 import prettierCode from '../utils/prettierCode';
 import AssetViewer from './AssetViewer';
 import { withDependencyManager } from './DependencyManager';
@@ -15,6 +16,7 @@ import DeviceInstructionsModal, {
   ConnectionMethod,
 } from './DeviceInstructions/DeviceInstructionsModal';
 import DevicePreview from './DevicePreview/DevicePreview';
+import DownloadOrbitDialog from './DownloadOrbitDialog';
 import { EditorProps } from './Editor/EditorProps';
 import EditorFooter from './EditorFooter';
 import EditorPanels from './EditorPanels';
@@ -447,6 +449,11 @@ class EditorView extends React.Component<Props, State> {
                   onSubmitMetadata={this.props.onSubmitMetadata}
                   onDownloadCode={this.props.onDownloadAsync}
                   onPublishAsync={onPublishAsync}
+                  onOpenWithOrbit={() =>
+                    openExpoOrbitWithExperienceURL(experienceURL, () =>
+                      this._handleShowModal('install-orbit')
+                    )
+                  }
                 />
                 <div className={css(styles.editorAreaOuterWrapper)}>
                   <div className={css(styles.editorAreaOuter)}>
@@ -662,6 +669,12 @@ class EditorView extends React.Component<Props, State> {
                   setDeviceId={this.props.setDeviceId}
                   deviceId={deviceId}
                 />
+                <ModalDialog
+                  title="Expo Orbit"
+                  visible={currentModal === 'install-orbit'}
+                  onDismiss={this._handleHideModal}>
+                  <DownloadOrbitDialog />
+                </ModalDialog>
                 <ModalDialog
                   className={css(styles.embedModal)}
                   autoSize={false}

--- a/website/src/client/components/EditorViewProps.tsx
+++ b/website/src/client/components/EditorViewProps.tsx
@@ -23,7 +23,8 @@ export type EditorModal =
   | 'shortcuts'
   | 'previous-saves'
   | 'import-repo'
-  | 'import-production';
+  | 'import-production'
+  | 'install-orbit';
 
 export type EditorViewProps = {
   createdAt: string | undefined;

--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -1,0 +1,11 @@
+import customProtocolCheck from 'custom-protocol-check';
+
+export function openExpoOrbitWithExperienceURL(experienceURL: string, onFail?: () => void) {
+  const url = experienceURL?.replace('exp://', 'expo-orbit://');
+
+  if (!url) {
+    return;
+  }
+
+  customProtocolCheck(url, onFail);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6293,6 +6293,11 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+custom-protocol-check@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/custom-protocol-check/-/custom-protocol-check-1.4.0.tgz#87b579f6519d48adf55f539d774f7e026bae35e7"
+  integrity sha512-eMTyp8AKnE5eo+mKNqG3743eb5ZND5LhBgf9F8BN2tVdhSBnOCHH7me7iTcv0BUDhUW2dBQiHWLWMy776yZW1A==
+
 cycle@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
@@ -14173,10 +14178,34 @@ snack-babel-standalone@^2.2.2:
   resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
   integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
 
+snack-content@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/snack-content/-/snack-content-1.3.0.tgz#dfd9fd5dd9ca523bb5af6db3897e041c10d4280a"
+  integrity sha512-h5LymtR4Hvzgnb3gUyddq5ERgmRj9gsDUSXP/EJLgpVduH7nJiomzX25fiOUdWT8NwNHq0afusPK89RAQ+sizg==
+  dependencies:
+    semver "^7.3.4"
+
 snack-eslint-standalone@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.3.tgz#2c83a044d40244976bb4f11e741032a3c9162e1c"
   integrity sha512-7uJ9I3xHK5CV48ZXJRB+WAG3uyJBSRrhPAjPmzX4xbUCRCInok7znaW9u5J/vFxCAyyEcdeoWR+AfN0sgCCq8w==
+
+snack-sdk@*:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/snack-sdk/-/snack-sdk-4.0.1.tgz#ca0c653b05d7540cdb8c4fc0d3c5b273ba25e0d3"
+  integrity sha512-olhPtvRgMZfWHudPMqmwXg4sC7LkxV7KPYuOkuLFoj1R8HlrptTzsn2BQZkvom/R8QR3niy74d+GBBNtlwBDFQ==
+  dependencies:
+    diff "^4.0.2"
+    fetch-ponyfill "^7.0.0"
+    lodash "^4.17.20"
+    nanoid "^3.1.20"
+    nullthrows "^1.1.1"
+    pubnub "^7.2.0"
+    semver "^7.3.4"
+    snack-content "~1.3.0"
+    socket.io-client "~4.5.4"
+    ua-parser-js "^0.7.22"
+    validate-npm-package-name "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

As a part of the new Expo Orbit project, we need to add a button to the `EditorToolbar` in order to
 allow users to launch their projects with just one click using Expo Orbit.

# How

- Add "Open with Orbit" button to the `EditorToolbar` using the `expo-orbit://` custom schema
- Adds `custom-protocol-check` dependency to determine if Expo Orbit is installed or not and prompt user to install it if necessary
- Update AuthManager to query `experiments` to determine if we should display the Orbit button 

# Test Plan

### Case 1

The user HAS Obit installed and presses the "Open with Orbit" button  
 
https://github.com/expo/snack/assets/11707729/8146d57d-2f5a-4262-a7a4-31cd1b7f21c5


### Case 2
 
The user DOES NOT HAVE Obit installed, and presses the "Open with Orbit" button 


https://github.com/expo/snack/assets/11707729/2ea85073-56fb-4bb9-b102-c4a43552674f



