### PR TITLE
feature(website): Update AuthenticationManager to get user data from the GraphQL API

### DIFF
--- a/website/src/client/components/DevicePreview/AppetizeFrame.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeFrame.tsx
@@ -65,7 +65,7 @@ type State = {
 
 class AppetizeFrame extends React.PureComponent<Props, State> {
   private static getAppetizeURL(props: Props, autoplay: boolean) {
-    const { experienceURL, platform, isEmbedded, payerCode, viewer, theme, devices } = props;
+    const { experienceURL, platform, isEmbedded, payerCode, theme, devices } = props;
 
     return constructAppetizeURL({
       type: isEmbedded ? 'embedded' : 'website',
@@ -74,7 +74,7 @@ class AppetizeFrame extends React.PureComponent<Props, State> {
       platform,
       previewQueue: isEmbedded ? 'secondary' : 'main',
       deviceColor: theme === 'dark' ? 'white' : 'black',
-      payerCode: viewer?.user_metadata?.appetize_code ?? payerCode,
+      payerCode,
       devices,
     });
   }
@@ -84,11 +84,7 @@ class AppetizeFrame extends React.PureComponent<Props, State> {
     if (
       props.platform !== state.platform ||
       props.sdkVersion !== state.sdkVersion ||
-      props.theme !== state.theme ||
-      (props.viewer !== state.viewer &&
-        props.viewer &&
-        props.viewer.user_metadata &&
-        props.viewer.user_metadata.appetize_code)
+      props.theme !== state.theme
     ) {
       const autoplay = state.payerCodeFormStatus.type === 'submitted';
       return {

--- a/website/src/client/components/Publish/ModalSuccessfulPublish.tsx
+++ b/website/src/client/components/Publish/ModalSuccessfulPublish.tsx
@@ -29,7 +29,7 @@ class ModalSuccessfulPublish extends React.PureComponent<Props> {
   };
 
   render() {
-    const picture = this.props.viewer?.picture;
+    const picture = this.props.viewer?.profilePhoto;
 
     return (
       <ModalDialog visible={this.props.visible} onDismiss={this.props.onDismiss}>

--- a/website/src/client/components/UserMenu.tsx
+++ b/website/src/client/components/UserMenu.tsx
@@ -65,7 +65,7 @@ class UserMenu extends React.Component<Props, State> {
     return (
       <div className={css(styles.container)}>
         <button ref={this._avatar} className={css(styles.button)}>
-          <Avatar source={viewer?.picture ? viewer.picture : null} size={26} />
+          <Avatar source={viewer?.profilePhoto ? viewer.profilePhoto : null} size={26} />
         </button>
         <ContextMenu
           ref={this._menu}

--- a/website/src/client/types.tsx
+++ b/website/src/client/types.tsx
@@ -13,6 +13,7 @@ import {
   SDKVersion,
 } from 'snack-sdk';
 
+import { UserData } from './auth/authManager';
 import { AppetizeDeviceAndroid, AppetizeDeviceIos } from './components/DevicePreview/AppetizeFrame';
 import { ThemeName } from './components/Preferences/withThemeName';
 
@@ -65,14 +66,7 @@ export type RouterData =
       defaults: SnackDefaults;
     };
 
-export type Viewer = {
-  username: string;
-  nickname: string;
-  picture?: string;
-  user_metadata?: {
-    appetize_code: string;
-  };
-};
+export type Viewer = UserData;
 
 export type Platform = 'android' | 'ios' | 'web' | 'mydevice';
 


### PR DESCRIPTION
# Why

In order to support fetching more complex data involving user fields, we should use the GraphQL API instead of `api/v2`. Necessary for querying things like:

```
{
  me {
    id
    username 
    userExperiments {
      id
      enabled
      experiment
    }
  }
}
```

In a follow-up PR we should add something like `graphql-tag` to have more robust support for the GraphQL queries 

# How

Replace the existing `userInfo` request with an equivalent query using the GraphQL API

# Test Plan

Run the website locally and ensure user data is loaded correctly 
<img width="1028" alt="image" src="https://github.com/expo/snack/assets/11707729/3c5661a4-031c-4d76-9e6f-43a5b09684ad">
