### PR TITLE
[website] fix device dialog store buttons and segmented buttons appearance

### DIFF
--- a/website/src/client/components/shared/Button.tsx
+++ b/website/src/client/components/shared/Button.tsx
@@ -87,7 +87,6 @@ const styles = StyleSheet.create({
 
   normal: {
     color: c('text'),
-    backgroundColor: c('secondary'),
     border: `1px solid ${c('border')}`,
   },
 

--- a/website/src/client/components/shared/SegmentedButton.tsx
+++ b/website/src/client/components/shared/SegmentedButton.tsx
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
   },
 
   selected: {
-    color: c('selected-text'),
+    color: c('text'),
     backgroundColor: c('selected'),
     ':hover': {
       backgroundColor: c('selected'),


### PR DESCRIPTION
# Why

Fixes ENG-9448

# How

Add small style tweaks to ensure that components are correctly displayed, no matter of selected theme.

# Test Plan

The changes have been reviewed by running Snack stack locally.

# Preview

<img width="390" src="https://github.com/expo/snack/assets/719641/bf2e0b38-93ca-4481-8943-d9b53c784905" align="left">
<img width="390" src="https://github.com/expo/snack/assets/719641/ed6ebf53-0823-44cb-8466-dcdef03d5428">
