### PR TITLE
fix(runtime): use `transformer.publicPath` with deploy workaround for asset paths on web

### DIFF
--- a/runtime/metro.config.js
+++ b/runtime/metro.config.js
@@ -1,4 +1,16 @@
 // Learn more https://docs.expo.dev/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
+const { boolish } = require('getenv');
 
-module.exports = getDefaultConfig(__dirname);
+/* eslint-env node */
+const config = getDefaultConfig(__dirname);
+
+// Workaround for paths hosting web on a subdirectory (https://<s3-bucket>/v2/<expo-sdk-version>/)
+if (boolish('SNACK_EXPORT_WEB', false)) {
+  const expoVersion = require('expo/package.json').version;
+  const semver = require('semver');
+
+  config.transformer.publicPath = `/v2/${semver.major(expoVersion)}/assets`;
+}
+
+module.exports = config;

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -75,6 +75,7 @@
     "babel-preset-expo": "^9.3.0",
     "eslint": "^8.20.0",
     "eslint-config-universe": "^11.2.0",
+    "getenv": "^1.0.0",
     "jest": "^29.2.1",
     "jest-expo": "^47.0.1",
     "patch-package": "^6.4.7",


### PR DESCRIPTION
# Why

When importing assets from packages bundled with the Snack Runtime, the assets are expected to be hosted at the root of the domain. This adds the `transformer.publicPath` to tell the web export where to look up the assets.

# How

- Added `transformer.publicPath` config option based on an env flag
- Updated `web/deploy-script.js` to enable this env flag, and move assets to the proper folders for S3 upload

# Test Plan

See staging.