### PR TITLE
chore: improve monorepo tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # npm dependencies
 **/node_modules/
+!node_modules/.cache/turbo
 
 # Compiled JavaScript
 packages/**/build

--- a/.github/actions/setup-snackager/action.yml
+++ b/.github/actions/setup-snackager/action.yml
@@ -15,6 +15,19 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: yarn
 
+    # Cache the build files when coupled within the monorepo
+    - name: 🏗 Setup caching
+      uses: actions/cache@v3
+      if: ${{ !matrix.monorepo-detached }}
+      with:
+        key: turbo-snackager-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          turbo-snackager-${{ runner.os }}
+          turbo-snackager
+        path: |
+          node_modules/.cache/turbo
+          packages/*/.turbo
+
     # npm v7+ doesn't work well with our monorepo
     - name: 🐛 Downgrade npm to v6
       run: npm install --global npm@^6
@@ -25,17 +38,6 @@ runs:
       run: yarn install --frozen-lockfile --ignore-scripts
       shell: bash
 
-    # Snackager relies on snack-content, which relies on snack-sdk
-    - name: 👷 Build snack-content
-      run: yarn workspace snack-content build
-      shell: bash
-
-    # Snackager relies on snack-content
-    - name: 👷 Build snack-sdk
-      run: yarn workspace snack-sdk build
-      shell: bash
-
-    # Snackager relies on snack-require-context
-    - name: 👷 Build snack-require-context
-      run: yarn workspace snack-require-context build
+    - name: 🛠 Build packages
+      run: yarn turbo build -- --filter "{./snackager}..."
       shell: bash

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -67,31 +67,40 @@ jobs:
             node_modules/.cache/turbo
             packages/*/.turbo
 
-      - name: 📦 Install monorepo dependencies
+      - name: 📦 Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: 🚨 Lint package
+        if: ${{ !matrix.monorepo-detached }}
+        run: yarn turbo lint -- --filter "./packages/${{ matrix.package }}" -- --max-warnings 0
+
+      - name: 🧪 Test package
+        if: ${{ !matrix.monorepo-detached }}
+        run: yarn turbo test -- --filter "./packages/${{ matrix.package }}" -- --ci --maxWorkers 1
+
+      - name: 🛠 Build package
+        if: ${{ !matrix.monorepo-detached }}
+        run: yarn turbo build -- --filter "{./packages/${{ matrix.package }}}..."
+
       # When decoupled from the monorepo, make sure to install the local packages
-      - name: 📦 Install local dependencies
+      - name: 📦 Install detached dependencies
         if: ${{ matrix.monorepo-detached }}
         run: yarn install --frozen-lockfile
         working-directory: packages/${{ matrix.package }}
 
-      # When coupled within the monorepo, build the package and all its dependents
-      - name: 🛠 Build dependent packages
-        if: ${{ !matrix.monorepo-detached }}
-        run: yarn turbo build --filter "{./packages/${{ matrix.package }}}..."
-
-      - name: 🚨 Lint package
+      - name: 🚨 Lint detached package
+        if: ${{ matrix.monorepo-detached }}
         run: yarn lint --max-warnings 0
         working-directory: packages/${{ matrix.package }}
 
-      - name: 🧪 Test package
+      - name: 🧪 Test detached package
+        if: ${{ matrix.monorepo-detached }}
         run: yarn test --ci --maxWorkers 1
         working-directory: packages/${{ matrix.package }}
 
       # When decoupled from the monorepo, make sure the package is built
       # Since there are no dependents, do this step last to fail faster
-      - name: 🛠 Build package
+      - name: 🛠 Build detached package
         if: ${{ matrix.monorepo-detached }}
         run: yarn build
         working-directory: packages/${{ matrix.package }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -12,6 +12,7 @@ on:
       - packages/**
       - .eslint*
       - .prettier*
+      - turbo.json
       - yarn.lock
   push:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - packages/**
       - .eslint*
       - .prettier*
+      - turbo.json
       - yarn.lock
 
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -54,6 +54,19 @@ jobs:
           node-version: 16.x
           cache: yarn
 
+      # Cache the build files when coupled within the monorepo
+      - name: 🏗 Setup caching
+        uses: actions/cache@v3
+        if: ${{ !matrix.monorepo-detached }}
+        with:
+          key: turbo-${{ matrix.package }}-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ matrix.package }}-${{ runner.os }}
+            turbo-${{ matrix.package }}
+          path: |
+            node_modules/.cache/turbo
+            packages/*/.turbo
+
       - name: 📦 Install monorepo dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,7 +1,7 @@
 name: Packages
 
 concurrency:
-  group: packages-${{ github.ref }}
+  group: packages-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 on:
@@ -39,11 +39,11 @@ jobs:
           - snack-term
         include:
           - package: snack-babel-standalone
-            local-install: true
+            monorepo-detached: true
           - package: snack-eslint-standalone
-            local-install: true
+            monorepo-detached: true
           - package: snack-runtime
-            local-install: true
+            monorepo-detached: true
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -59,12 +59,14 @@ jobs:
 
       # When decoupled from the monorepo, make sure to install the local packages
       - name: 📦 Install local dependencies
-        if: ${{ matrix.local-install }}
+        if: ${{ matrix.monorepo-detached }}
         run: yarn install --frozen-lockfile
         working-directory: packages/${{ matrix.package }}
 
-      - name: 🛠 Build core packages
-        run: yarn build
+      # When coupled within the monorepo, build the package and all its dependents
+      - name: 🛠 Build dependent packages
+        if: ${{ !matrix.monorepo-detached }}
+        run: yarn turbo build --filter "{./packages/${{ matrix.package }}}..."
 
       - name: 🚨 Lint package
         run: yarn lint --max-warnings 0
@@ -74,6 +76,9 @@ jobs:
         run: yarn test --ci --maxWorkers 1
         working-directory: packages/${{ matrix.package }}
 
+      # When decoupled from the monorepo, make sure the package is built
+      # Since there are no dependents, do this step last to fail faster
       - name: 🛠 Build package
+        if: ${{ matrix.monorepo-detached }}
         run: yarn build
         working-directory: packages/${{ matrix.package }}

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -27,9 +27,11 @@ on:
       - .github/workflows/snackager.yml
       - snackager/**
       - packages/snack-content/**
+      - packages/snack-require-context/**
       - packages/snack-sdk/**
       - .eslint*
       - .prettier*
+      - turbo.json
       - yarn.lock
   push:
     branches: [main]
@@ -40,9 +42,11 @@ on:
       - .github/workflows/snackager.yml
       - snackager/**
       - packages/snack-content/**
+      - packages/snack-require-context/**
       - packages/snack-sdk/**
       - .eslint*
       - .prettier*
+      - turbo.json
       - yarn.lock
 
 jobs:
@@ -61,13 +65,13 @@ jobs:
         uses: ./.github/actions/setup-snackager
 
       - name: 🚨 Lint snackager
-        run: yarn lint --max-warnings 0
+        run: yarn turbo lint -- --filter "./snackager" -- --max-warnings 0
 
       - name: 🧪 Unit test snackager
-        run: yarn test --ci --maxWorkers 1 --testPathIgnorePatterns=__integration-tests__
+        run: yarn turbo test -- --filter "./snackager" -- --ci --maxWorkers 1 --testPathIgnorePatterns=__integration-tests__
 
       - name: 🧪 E2E test snackager
-        run: yarn test --ci --maxWorkers 1 --testPathPattern=__integration-tests__
+        run: yarn turbo test -- --filter "./snackager" -- --ci --maxWorkers 1 --testPathPattern=__integration-tests__
         # Takes a long time, best to only run this on PRs
         if: ${{ github.event_name == 'pull_request' }}
 
@@ -90,6 +94,9 @@ jobs:
           project-zone: us-central1
           project-cluster: general-central
           service-key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: 🏗 Setup snackager
+        uses: ./.github/actions/setup-snackager
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
@@ -118,6 +125,9 @@ jobs:
           project-zone: us-central1
           project-cluster: general-central
           service-key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: 🏗 Setup snackager
+        uses: ./.github/actions/setup-snackager
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
@@ -173,6 +183,9 @@ jobs:
           project-zone: us-central1
           project-cluster: general-central
           service-key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: 🏗 Setup snackager
+        uses: ./.github/actions/setup-snackager
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ package-lock.json
 
 # snackpub
 snackpub/build
+
+# turbo
+.turbo/

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "env-cmd": "^10.1.0",
     "eslint": "^8.12.0",
     "eslint-config-universe": "^10.0.0",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "turborepo": "^0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "node": "16.14.2"
   },
   "scripts": {
-    "build": "cd packages/snack-content && yarn build && cd .. && cd snack-sdk && yarn build && cd .. && cd snack-require-context && yarn build",
-    "start": "cd packages/snack-term && yarn start && cd .."
+    "start": "turbo build --filter '{./packages/snack-term}...' && yarn --cwd ./packages/snack-term start",
+    "lint": "turbo lint --filter './packages/*'",
+    "test": "turbo test --filter './packages/*'",
+    "build": "turbo build --filter './packages/*'"
   },
   "workspaces": {
     "packages": [
@@ -30,6 +32,6 @@
     "eslint": "^8.12.0",
     "eslint-config-universe": "^10.0.0",
     "prettier": "^2.6.2",
-    "turborepo": "^0.0.1"
+    "turbo": "^1.10.13"
   }
 }

--- a/snackager/Dockerfile
+++ b/snackager/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add git openssh-client
 
 # Workspace files
 WORKDIR /app
-COPY package.json yarn.lock .prettierrc ./
+COPY package.json yarn.lock .prettierrc turbo.json node_modules/.cache/turbo ./
 
 # Workspace packages
 WORKDIR /app
@@ -25,9 +25,9 @@ COPY snackager/.eslint* ./
 # Install dependencies
 RUN yarn install --frozen-lockfile --production=false
 
-# Build core packages
+# Build Snackager
 WORKDIR /app
-RUN yarn build
+RUN yarn turbo build -- --filter "./snackager"
 
 # Snackager
 WORKDIR /app/snackager
@@ -40,7 +40,7 @@ ARG APP_VERSION
 ENV APP_VERSION ${APP_VERSION}
 
 # Build Snackager
-RUN yarn build
+RUN yarn turbo build -- --filter "./snackager"
 
 # Minimize node_modules
 RUN yarn install --frozen-lockfile --offline --production

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "start": {
+      "cache": false,
+      "dependsOn": ["build"],
+      "persistent": true
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "inputs": ["**/*.{js,jsx,json,ts,tsx}"]
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [
+        "build/**"
+      ]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15267,6 +15267,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turborepo@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/turborepo/-/turborepo-0.0.1.tgz#0f86976a6246108387777542ba7a585b1dcf4f94"
+  integrity sha512-x+4Q9iy252nr6zuU/TvQIF4na8OVLe2pBTwTJKA/aTPzdR4W8q0uhEj/U69G09IznNDjMg8jXG2nm9gan4KQ1g==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15267,10 +15267,47 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-turborepo@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/turborepo/-/turborepo-0.0.1.tgz#0f86976a6246108387777542ba7a585b1dcf4f94"
-  integrity sha512-x+4Q9iy252nr6zuU/TvQIF4na8OVLe2pBTwTJKA/aTPzdR4W8q0uhEj/U69G09IznNDjMg8jXG2nm9gan4KQ1g==
+turbo-darwin-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.13.tgz#7abc33838bf74c7e7ba2955cb6acc40342d6964c"
+  integrity sha512-vmngGfa2dlYvX7UFVncsNDMuT4X2KPyPJ2Jj+xvf5nvQnZR/3IeDEGleGVuMi/hRzdinoxwXqgk9flEmAYp0Xw==
+
+turbo-darwin-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.13.tgz#89f2d14a28789e5eaf276a17fecd4116d61fd16d"
+  integrity sha512-eMoJC+k7gIS4i2qL6rKmrIQGP6Wr9nN4odzzgHFngLTMimok2cGLK3qbJs5O5F/XAtEeRAmuxeRnzQwTl/iuAw==
+
+turbo-linux-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.13.tgz#803e2b351984ec81034dc4b6935cdfb0a7d7d572"
+  integrity sha512-0CyYmnKTs6kcx7+JRH3nPEqCnzWduM0hj8GP/aodhaIkLNSAGAa+RiYZz6C7IXN+xUVh5rrWTnU2f1SkIy7Gdg==
+
+turbo-linux-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.13.tgz#92439a927ec98801be1be266016736be5730e40c"
+  integrity sha512-0iBKviSGQQlh2OjZgBsGjkPXoxvRIxrrLLbLObwJo3sOjIH0loGmVIimGS5E323soMfi/o+sidjk2wU1kFfD7Q==
+
+turbo-windows-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.13.tgz#870815cdcb20f2480296c208778f9127be61eec6"
+  integrity sha512-S5XySRfW2AmnTeY1IT+Jdr6Goq7mxWganVFfrmqU+qqq3Om/nr0GkcUX+KTIo9mPrN0D3p5QViBRzulwB5iuUQ==
+
+turbo-windows-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.13.tgz#2da38b71b1716732541dfc5bd7475dc0903921f8"
+  integrity sha512-nKol6+CyiExJIuoIc3exUQPIBjP9nIq5SkMJgJuxsot2hkgGrafAg/izVDRDrRduQcXj2s8LdtxJHvvnbI8hEQ==
+
+turbo@^1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.13.tgz#8050bcd09f8a20d5a626f41e86cd8760e49a0df6"
+  integrity sha512-vOF5IPytgQPIsgGtT0n2uGZizR2N3kKuPIn4b5p5DdeLoI0BV7uNiydT7eSzdkPRpdXNnO8UwS658VaI4+YSzQ==
+  optionalDependencies:
+    turbo-darwin-64 "1.10.13"
+    turbo-darwin-arm64 "1.10.13"
+    turbo-linux-64 "1.10.13"
+    turbo-linux-arm64 "1.10.13"
+    turbo-windows-64 "1.10.13"
+    turbo-windows-arm64 "1.10.13"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
# Why

With more packages being added, we should have proper tooling to support monorepos.

# How

- Added basic configuration for `start`, `lint`, `test`, and `build` focusing _only_ on packages.
- Updated workflow to optimize each package CI time

# Test Plan

See if this PR passes.