### PR TITLE
fix: bundle `react-native-pager-view` inside the runtime to avoid Snackager errors

### DIFF
--- a/packages/snack-content/src/sdks/index.ts
+++ b/packages/snack-content/src/sdks/index.ts
@@ -97,6 +97,7 @@ const sdks: { [version: string]: SDKSpec } = {
       'expo-router/html': '*',
       'expo-router/head': '*',
       'expo-router/entry': '*',
+      'react-native-pager-view': '*',
     },
     deprecatedModules: {},
   },

--- a/runtime-shell/package.json
+++ b/runtime-shell/package.json
@@ -40,6 +40,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.71.8",
     "react-native-gesture-handler": "~2.9.0",
+    "react-native-pager-view": "6.1.2",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",

--- a/runtime-shell/src/App.tsx
+++ b/runtime-shell/src/App.tsx
@@ -1,4 +1,5 @@
 import { reloadAsync } from 'expo-updates';
+import { Platform } from 'react-native';
 import {
   type SnackConfig,
   defaultSnackModules,
@@ -17,6 +18,14 @@ const config: SnackConfig = {
     'expo-router/html': require('expo-router/html'),
     'expo-router/head': require('expo-router/head'),
     'expo-router/entry': () => {}, // noop
+    // Platform specific modules
+    ...Platform.select({
+      web: {},
+      native: {
+        // Does not work in Snackager, likely due to Webpack / Codegen
+        'react-native-pager-view': require('react-native-pager-view'),
+      },
+    }),
   },
   experimental: {
     expoRouterEntry: require('./NativeModules/ExpoRouter').ExpoRouterApp,

--- a/runtime-shell/src/App.tsx
+++ b/runtime-shell/src/App.tsx
@@ -7,9 +7,18 @@ import {
   SnackRuntime,
 } from 'snack-runtime';
 
+const platformModules: SnackConfig['modules'] = Platform.select({
+  default: {},
+  native: {
+    // Does not work in Snackager, likely due to Webpack / Codegen
+    'react-native-pager-view': require('react-native-pager-view'),
+  },
+});
+
 const config: SnackConfig = {
   modules: {
     ...defaultSnackModules,
+    ...platformModules,
     // Only works when vendored into the runtime (expo-router@1.5.3)
     'expo-router': require('expo-router'),
     'expo-router/stack': require('expo-router/stack'),
@@ -18,14 +27,6 @@ const config: SnackConfig = {
     'expo-router/html': require('expo-router/html'),
     'expo-router/head': require('expo-router/head'),
     'expo-router/entry': () => {}, // noop
-    // Platform specific modules
-    ...Platform.select({
-      web: {},
-      native: {
-        // Does not work in Snackager, likely due to Webpack / Codegen
-        'react-native-pager-view': require('react-native-pager-view'),
-      },
-    }),
   },
   experimental: {
     expoRouterEntry: require('./NativeModules/ExpoRouter').ExpoRouterApp,

--- a/runtime-shell/yarn.lock
+++ b/runtime-shell/yarn.lock
@@ -8846,6 +8846,11 @@ react-native-gradle-plugin@^0.71.18:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.19.tgz#3379e28341fcd189bc1f4691cefc84c1a4d7d232"
   integrity sha512-1dVk9NwhoyKHCSxcrM6vY6cxmojeATsBobDicX0ZKr7DgUF2cBQRTKsimQFvzH8XhOVXyH8p4HyDSZNIFI8OlQ==
 
+react-native-pager-view@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.1.2.tgz#3522079b9a9d6634ca5e8d153bc0b4d660254552"
+  integrity sha512-qs2KSFc+7N7B+UZ6SG2sTvCkppagm5fVyRclv1KFKc7lDtrhXLzN59tXJw575LDP/dRJoXsNwqUAhZJdws6ABQ==
+
 react-native-reanimated@~2.14.4:
   version "2.14.4"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz#3fa3da4e7b99f5dfb28f86bcf24d9d1024d38836"
@@ -9584,7 +9589,7 @@ snack-require-context@^0.1.0:
   integrity sha512-A3wTu9vHquHOP5I7T1WBfO51LuJaXA1htg4WurdmhePZr3CizS4XSwX5dh2fwc92U5R70W11AzoVvOg/Xqa+Nw==
 
 "snack-runtime@file:../packages/snack-runtime":
-  version "0.3.0-rc.1"
+  version "0.3.0-rc.3"
   dependencies:
     "@babel/polyfill" "^7.8.3"
     "@react-native-async-storage/async-storage" "1.17.11"
@@ -9592,6 +9597,7 @@ snack-require-context@^0.1.0:
     canvaskit-wasm "0.38.0"
     diff "^5.0.0"
     escape-string-regexp "^5.0.0"
+    path "^0.12.7"
     pubnub "^7.2.0"
     snack-babel-standalone "^2.2.2"
     snack-require-context "^0.1.0"

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -49,6 +49,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.71.8",
     "react-native-gesture-handler": "~2.9.0",
+    "react-native-pager-view": "6.1.2",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",

--- a/runtime/src/aliases/index.tsx
+++ b/runtime/src/aliases/index.tsx
@@ -20,6 +20,9 @@ const aliases: { [key: string]: any } = {
   'react-native/Libraries/Core/Devtools/getDevServer': require('react-native/Libraries/Core/Devtools/getDevServer'), // Used by @sentry/react-native@3.4.2
   'react-native/Libraries/Utilities/PolyfillFunctions': require('react-native/Libraries/Utilities/PolyfillFunctions'), // Used by @sentry/react-native@3.4.2
   'react-native/Libraries/Utilities/codegenNativeCommands': require('react-native/Libraries/Utilities/codegenNativeCommands'), // Used by react-native-webview@11.23.0
+
+  // Does not work in Snackager, likely due to Webpack / Codegen
+  'react-native-pager-view': require('react-native-pager-view'),
 };
 
 export default aliases;

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -11658,6 +11658,11 @@ react-native-gradle-plugin@^0.71.18:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.18.tgz#20ef199bc85be32e45bb6cc069ec2e7dcb1a74a6"
   integrity sha512-7F6bD7B8Xsn3JllxcwHhFcsl9aHIig47+3eN4IHFNqfLhZr++3ElDrcqfMzugM+niWbaMi7bJ0kAkAL8eCpdWg==
 
+react-native-pager-view@6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.1.2.tgz#3522079b9a9d6634ca5e8d153bc0b4d660254552"
+  integrity sha512-qs2KSFc+7N7B+UZ6SG2sTvCkppagm5fVyRclv1KFKc7lDtrhXLzN59tXJw575LDP/dRJoXsNwqUAhZJdws6ABQ==
+
 react-native-reanimated@~2.14.4:
   version "2.14.4"
   resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz#3fa3da4e7b99f5dfb28f86bcf24d9d1024d38836"
@@ -12619,7 +12624,7 @@ snack-babel-standalone@^2.2.0:
   integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
 
 "snack-require-context@file:../packages/snack-require-context":
-  version "0.0.0"
+  version "0.1.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

This is one of the important React Navigation libraries, and should work in Snack.

# How

- Vendored `react-native-pager-view` inside the runtimes.

# Test Plan

See if this works on staging:

https://staging-snack.expo.dev/?platform=android&name=header%20button&dependencies=%40expo%2Fvector-icons%40*%2C%40react-native-community%2Fmasked-view%40*%2Creact-native-gesture-handler%40*%2Creact-native-pager-view%40*%2Creact-native-paper%40%5E4.7.2%2Creact-native-reanimated%40*%2Creact-native-safe-area-context%40*%2Creact-native-screens%40*%2Creact-native-tab-view%40%5E3.0.0%2C%40react-navigation%2Fbottom-tabs%406.3.1%2C%40react-navigation%2Fdrawer%406.4.1%2C%40react-navigation%2Felements%401.3.3%2C%40react-navigation%2Fmaterial-bottom-tabs%406.2.1%2C%40react-navigation%2Fmaterial-top-tabs%406.2.1%2C%40react-navigation%2Fnative-stack%406.6.1%2C%40react-navigation%2Fnative%406.0.10%2C%40react-navigation%2Fstack%406.2.1&hideQueryParams=true&sourceUrl=https%3A%2F%2Freactnavigation.org%2Fexamples%2F6.x%2Fsimple-header-button.js