### PR TITLE
fix: prevent workflows from auto-canceling when triggered from other sources

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,7 +1,7 @@
 name: Packages
 
 concurrency:
-  group: packages-${{ github.ref }}
+  group: packages-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -5,7 +5,7 @@ defaults:
     working-directory: runtime
 
 concurrency:
-  group: runtime-${{ github.ref }}
+  group: runtime-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -5,7 +5,7 @@ defaults:
     working-directory: snackager
 
 concurrency:
-  group: snackager-${{ github.ref }}
+  group: snackager-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -5,7 +5,7 @@ defaults:
     working-directory: snackpub
 
 concurrency:
-  group: snackpub-${{ github.ref }}
+  group: snackpub-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,7 +5,7 @@ defaults:
     working-directory: website
 
 concurrency:
-  group: website-${{ github.ref }}
+  group: website-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
# Why

Before this change, a manual deployment could cancel the workflow running on `main`. 

# How

This prevents that by adding `github.event_name` to the concurrency check.

# Test Plan

Workflow change only.