### PR TITLE
refactor: upgrade to node to `18.17.1`

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -4,7 +4,7 @@ description: Prepare Runtime in GitHub Actions
 inputs:
   node-version:
     description: Version of Node to use
-    default: 16.x
+    default: 18.x
 
   expo-version:
     description: Version of Expo CLI to use

--- a/.github/actions/setup-snackager/action.yml
+++ b/.github/actions/setup-snackager/action.yml
@@ -28,3 +28,10 @@ runs:
     - name: 🛠 Build dependencies
       run: yarn turbo build --filter '{./snackager}^...'
       shell: bash
+
+    # Webpack 4 uses legacy hashing algorithm that is not supported by Node 18+
+    # This adds the workaround, AFTER Node is fully installed, avoiding "is not allowed" error
+    # See: https://stackoverflow.com/questions/72866798/node-openssl-legacy-provider-is-not-allowed-in-node-options
+    - name: 🐛 Add Webpack 4 workaround
+      run: echo "NODE_OPTIONS=\"--openssl-legacy-provider\"" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-snackager/action.yml
+++ b/.github/actions/setup-snackager/action.yml
@@ -4,7 +4,7 @@ description: Prepare Snackager in GitHub Actions
 inputs:
   node-version:
     description: Version of Node to use
-    default: 16.x
+    default: 18.x
 
 runs:
   using: composite

--- a/.github/actions/setup-snackager/action.yml
+++ b/.github/actions/setup-snackager/action.yml
@@ -28,10 +28,3 @@ runs:
     - name: 🛠 Build dependencies
       run: yarn turbo build --filter '{./snackager}^...'
       shell: bash
-
-    # Webpack 4 uses legacy hashing algorithm that is not supported by Node 18+
-    # This adds the workaround, AFTER Node is fully installed, avoiding "is not allowed" error
-    # See: https://stackoverflow.com/questions/72866798/node-openssl-legacy-provider-is-not-allowed-in-node-options
-    - name: 🐛 Add Webpack 4 workaround
-      run: echo "NODE_OPTIONS=\"--openssl-legacy-provider\"" >> $GITHUB_ENV
-      shell: bash

--- a/.github/actions/setup-snackpub/action.yml
+++ b/.github/actions/setup-snackpub/action.yml
@@ -4,7 +4,7 @@ description: Prepare Snackpub in GitHub Actions
 inputs:
   node-version:
     description: Version of Node to use
-    default: 16.x
+    default: 18.x
 
 runs:
   using: composite

--- a/.github/actions/setup-website/action.yml
+++ b/.github/actions/setup-website/action.yml
@@ -22,3 +22,10 @@ runs:
     - name: 🛠 Build dependencies
       run: yarn turbo build --filter '{./website}^...'
       shell: bash
+
+    # Webpack 4 uses legacy hashing algorithm that is not supported by Node 18+
+    # This adds the workaround, AFTER Node is fully installed, avoiding "is not allowed" error
+    # See: https://stackoverflow.com/questions/72866798/node-openssl-legacy-provider-is-not-allowed-in-node-options
+    - name: 🐛 Add Webpack 4 workaround
+      run: echo "NODE_OPTIONS=\"--openssl-legacy-provider\"" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-website/action.yml
+++ b/.github/actions/setup-website/action.yml
@@ -22,10 +22,3 @@ runs:
     - name: 🛠 Build dependencies
       run: yarn turbo build --filter '{./website}^...'
       shell: bash
-
-    # Webpack 4 uses legacy hashing algorithm that is not supported by Node 18+
-    # This adds the workaround, AFTER Node is fully installed, avoiding "is not allowed" error
-    # See: https://stackoverflow.com/questions/72866798/node-openssl-legacy-provider-is-not-allowed-in-node-options
-    - name: 🐛 Add Webpack 4 workaround
-      run: echo "NODE_OPTIONS=\"--openssl-legacy-provider\"" >> $GITHUB_ENV
-      shell: bash

--- a/.github/actions/setup-website/action.yml
+++ b/.github/actions/setup-website/action.yml
@@ -4,7 +4,7 @@ description: Prepare Website in GitHub Actions
 inputs:
   node-version:
     description: Version of Node to use
-    default: 16.x
+    default: 18.x
 
 runs:
   using: composite

--- a/.github/workflows/appetize-validation.yml
+++ b/.github/workflows/appetize-validation.yml
@@ -34,7 +34,7 @@ jobs:
           script: |
             const config = require('./website/src/client/configs/sdk')
             const versions = Object.keys(config.versions)
-            
+
             core.info(`Resolved supported website SDKs`)
             for (const version of versions) {
               core.info(`  - ${version} ${version === config.DEFAULT_SDK_VERSION ? '(default)' : ''}`)
@@ -56,21 +56,21 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
-          
+          node-version: 18.x
+
       - name: 📋 Download Appetize information
         # Redirect output because the endpoint returns the public and private app keys
         run: curl --silent --fail -o appetize.json https://$TOKEN@api.appetize.io/v1/apps/$APP > /dev/null
         env:
           TOKEN: ${{ secrets[format('APPETIZE_{0}_TOKEN', matrix.appetize)] }}
           APP: ${{ secrets[format('APPETIZE_{0}_{1}', matrix.appetize, matrix.platform)] }}
-    
+
       - name: 📋 Download SDK information
         run: curl --silent -o versions.json https://exp.host/--/api/v2/versions
 
       - name: 🧶 Install semver
         run: yarn add semver
-      
+
       - name: Validate version
         uses: actions/github-script@v6
         with:
@@ -80,7 +80,7 @@ jobs:
             const { sdkVersions } = require('./versions.json')
             const platform = '${{ matrix.platform }}'.toLowerCase()
             const appetize = '${{ matrix.appetize }}'.toLowerCase()
-            
+
             const website = JSON.parse('${{ needs.website.outputs.config }}')
             const websiteSdk = sdkVersions[website.default]
             const websiteVersion = (websiteSdk || {})[`${platform}ClientVersion`]

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -53,7 +53,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
 
       - name: 📦 Install monorepo dependencies

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -69,6 +69,9 @@ jobs:
 
       - name: 🧪 Test snackager
         run: yarn test --ci --maxWorkers 1 --testPathIgnorePatterns=__integration-tests__
+        env:
+          # Enable Webpack 4 with newer Node versions
+          NODE_OPTIONS: --openssl-legacy-provider
 
   e2e:
     # Takes a long time, best to only run this on PRs
@@ -88,6 +91,9 @@ jobs:
 
       - name: 🧪 Test snackager
         run: yarn test --ci --maxWorkers 1 --testPathPattern=__integration-tests__
+        env:
+          # Enable Webpack 4 with newer Node versions
+          NODE_OPTIONS: --openssl-legacy-provider
 
   build:
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -69,9 +69,6 @@ jobs:
 
       - name: 🧪 Test snackager
         run: yarn test --ci --maxWorkers 1 --testPathIgnorePatterns=__integration-tests__
-        env:
-          # Enable Webpack 4 with newer Node versions
-          NODE_OPTIONS: --openssl-legacy-provider
 
   e2e:
     # Takes a long time, best to only run this on PRs
@@ -91,9 +88,6 @@ jobs:
 
       - name: 🧪 Test snackager
         run: yarn test --ci --maxWorkers 1 --testPathPattern=__integration-tests__
-        env:
-          # Enable Webpack 4 with newer Node versions
-          NODE_OPTIONS: --openssl-legacy-provider
 
   build:
     if: ${{ github.event_name == 'pull_request' }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Expo",
   "license": "MIT",
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.1"
   },
   "scripts": {
     "start": "turbo build --filter '{./packages/snack-term}...' && yarn --cwd ./packages/snack-term start",

--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -33,7 +33,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.1"
   },
   "scripts": {
     "test": "echo 'No tests yet'",

--- a/packages/snack-content/package.json
+++ b/packages/snack-content/package.json
@@ -27,7 +27,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "16.14.0"
+    "node": "18.17.1"
   },
   "dependencies": {
     "semver": "^7.3.4"

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -53,6 +53,6 @@
     "snack-babel-standalone": ">=2.2.2"
   },
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.1"
   }
 }

--- a/packages/snack-proxies/package.json
+++ b/packages/snack-proxies/package.json
@@ -12,7 +12,7 @@
     "build": "tsc"
   },
   "volta": {
-    "node": "12.16.2"
+    "node": "18.17.1"
   },
   "dependencies": {
     "chalk": "^4.1.0",

--- a/packages/snack-require-context/package.json
+++ b/packages/snack-require-context/package.json
@@ -37,7 +37,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.1"
   },
   "scripts": {
     "test": "jest",

--- a/packages/snack-runtime/package.json
+++ b/packages/snack-runtime/package.json
@@ -20,7 +20,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.1"
   },
   "scripts": {
     "test": "jest",

--- a/packages/snack-sdk-legacy/package.json
+++ b/packages/snack-sdk-legacy/package.json
@@ -30,7 +30,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "12.18.4"
+    "node": "18.17.1"
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -33,7 +33,7 @@
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
   "volta": {
-    "node": "12.22.11"
+    "node": "18.17.1"
   },
   "devDependencies": {
     "@expo/spawn-async": "^1.5.0",

--- a/packages/snack-term/package.json
+++ b/packages/snack-term/package.json
@@ -10,7 +10,7 @@
     "build": "tsc"
   },
   "volta": {
-    "node": "12.16.2"
+    "node": "18.17.1"
   },
   "dependencies": {
     "@expo/spawn-async": "^1.5.0",

--- a/snackager/Dockerfile
+++ b/snackager/Dockerfile
@@ -12,8 +12,22 @@ RUN apk --no-cache add jq && \
   turbo prune --docker --scope=snack-modules-packager
 
 
+# --- Base - Prepare all environment variables for development/production
+FROM node:${node_version}-alpine as base
+
+# Enable Webpack 4 with newer Node versions
+ENV NODE_OPTIONS --openssl-legacy-provider
+
+# Prepare environment variables
+ARG APP_VERSION
+ENV APP_VERSION ${APP_VERSION}
+
+# Install system dependencies
+RUN npm install --global npm@^6
+
+
 # --- Development - Prepare Snackager for development
-FROM node:${node_version}-alpine as development
+FROM base as development
 WORKDIR /app
 
 # Copy "package.json"-only repository
@@ -33,16 +47,11 @@ CMD ["yarn", "start"]
 
 
 # --- Deploy - Prepare Snackager for production
-FROM node:${node_version}-alpine as deploy
+FROM base as deploy
 WORKDIR /app
 
 # Install system dependencies
-RUN apk --no-cache add git openssh-client && \
-  npm install --global npm@^6
-
-# Prepare environment variables
-ARG APP_VERSION
-ENV APP_VERSION ${APP_VERSION}
+RUN apk --no-cache add git openssh-client
 
 # Copy built repository
 COPY --from=development /app .
@@ -52,12 +61,8 @@ RUN yarn turbo build --filter "{./snackager}..." && \
 
 
 # --- Production - Run Snackager in production
-FROM node:${node_version}-alpine
+FROM base
 WORKDIR /app
-
-# Prepare environment variables
-ARG APP_VERSION
-ENV APP_VERSION ${APP_VERSION}
 
 # Copy deployment-ready repository
 COPY --from=deploy /app .

--- a/snackager/package.json
+++ b/snackager/package.json
@@ -83,7 +83,7 @@
     "lint": "tsc --noEmit && eslint ./src"
   },
   "volta": {
-    "node": "16.14.2",
+    "node": "18.17.1",
     "npm": "6.14.16",
     "yarn": "1.22.4"
   }

--- a/snackager/skaffold.yaml
+++ b/snackager/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: snackager/Dockerfile
         buildArgs:
-          node_version: 16.20.1
+          node_version: 18.17.1
           APP_VERSION: v{{.GITHUB_SHA}}
   tagPolicy:
     sha256: {}

--- a/snackpub/skaffold.yaml
+++ b/snackpub/skaffold.yaml
@@ -13,7 +13,7 @@ build:
       docker:
         dockerfile: snackpub/Dockerfile
         buildArgs:
-          node_version: 16.14.2
+          node_version: 18.17.1
           DEPLOY_ENVIRONMENT: staging
   tagPolicy:
     sha256: {}

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -15,6 +15,9 @@ RUN apk --no-cache add jq && \
 # --- Base - Prepare all environment variables for development/production
 FROM node:${node_version}-alpine as base
 
+# Enable Webpack 4 with newer Node versions
+ENV NODE_OPTIONS --openssl-legacy-provider
+
 # Prepare environment variables
 ARG API_SERVER_URL
 ENV API_SERVER_URL ${API_SERVER_URL}

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
   "author": "Expo",
   "license": "MIT",
   "volta": {
-    "node": "16.14.2",
+    "node": "18.17.1",
     "npm": "6.14.16"
   },
   "dependencies": {

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -12,7 +12,7 @@ build:
       docker:
         dockerfile: website/Dockerfile
         buildArgs:
-          node_version: 16.20.1
+          node_version: 18.17.1
           LEGACY_SERVER_URL: https://staging.expo.io
           SERVER_URL: https://staging.expo.dev
           API_SERVER_URL: https://staging.exp.host
@@ -43,7 +43,7 @@ profiles:
           docker:
             dockerfile: website/Dockerfile
             buildArgs:
-              node_version: 16.20.1
+              node_version: 18.17.1
               LEGACY_SERVER_URL: https://expo.io
               SERVER_URL: https://expo.dev
               API_SERVER_URL: https://exp.host


### PR DESCRIPTION
# Why

Upgrade from EOL to supported LTS node.

# How

- Updated all workflows to Node `18.17.1` (current `18.x`)
- Updated all Volta definitions to `18.17.1`
- Updated all skaffold configs to `18.17.1`

# Test Plan

See staging.
