### PR TITLE
chore: publish SDK 49 versions

### DIFF
--- a/packages/snack-runtime/package.json
+++ b/packages/snack-runtime/package.json
@@ -36,8 +36,8 @@
     "escape-string-regexp": "^5.0.0",
     "path": "^0.12.7",
     "pubnub": "^7.2.0",
-    "snack-babel-standalone": "file:../snack-babel-standalone",
-    "snack-require-context": "file:../snack-require-context",
+    "snack-babel-standalone": "^3.0.0",
+    "snack-require-context": "^0.1.0",
     "socket.io-client": "~4.5.4",
     "source-map": "0.6.1"
   },

--- a/packages/snack-runtime/yarn.lock
+++ b/packages/snack-runtime/yarn.lock
@@ -8641,11 +8641,15 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-"snack-babel-standalone@file:../snack-babel-standalone":
+snack-babel-standalone@^3.0.0:
   version "3.0.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
+  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
 
-"snack-require-context@file:../snack-require-context":
+snack-require-context@^0.1.0:
   version "0.1.0"
+  resolved "https://registry.yarnpkg.com/snack-require-context/-/snack-require-context-0.1.0.tgz#dd48f6e2c6b7299b7d7f34c873220cb80a8a42a7"
+  integrity sha512-A3wTu9vHquHOP5I7T1WBfO51LuJaXA1htg4WurdmhePZr3CizS4XSwX5dh2fwc92U5R70W11AzoVvOg/Xqa+Nw==
 
 socket.io-client@~4.5.4:
   version "4.5.4"

--- a/runtime-shell/yarn.lock
+++ b/runtime-shell/yarn.lock
@@ -9275,11 +9275,15 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-"snack-babel-standalone@file:../packages/snack-babel-standalone":
+snack-babel-standalone@^3.0.0:
   version "3.0.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
+  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
 
-"snack-require-context@file:../packages/snack-require-context":
+snack-require-context@^0.1.0:
   version "0.1.0"
+  resolved "https://registry.yarnpkg.com/snack-require-context/-/snack-require-context-0.1.0.tgz#dd48f6e2c6b7299b7d7f34c873220cb80a8a42a7"
+  integrity sha512-A3wTu9vHquHOP5I7T1WBfO51LuJaXA1htg4WurdmhePZr3CizS4XSwX5dh2fwc92U5R70W11AzoVvOg/Xqa+Nw==
 
 "snack-runtime@file:../packages/snack-runtime":
   version "0.3.0-rc.3"
@@ -9292,8 +9296,8 @@ smart-buffer@^4.2.0:
     escape-string-regexp "^5.0.0"
     path "^0.12.7"
     pubnub "^7.2.0"
-    snack-babel-standalone "file:../../../../Library/Caches/Yarn/v6/npm-snack-runtime-0.3.0-rc.3-d8bc9475-3754-4be8-a1a1-aa0d39e13d7a-1695034525955/node_modules/snack-babel-standalone"
-    snack-require-context "file:../../../../Library/Caches/Yarn/v6/npm-snack-runtime-0.3.0-rc.3-d8bc9475-3754-4be8-a1a1-aa0d39e13d7a-1695034525955/node_modules/snack-require-context"
+    snack-babel-standalone "^3.0.0"
+    snack-require-context "^0.1.0"
     socket.io-client "~4.5.4"
     source-map "0.6.1"
 

--- a/website/package.json
+++ b/website/package.json
@@ -80,7 +80,7 @@
     "recast": "^0.20.3",
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
-    "snack-babel-standalone": "^2.2.2",
+    "snack-babel-standalone": "^3.0.0",
     "snack-content": "*",
     "snack-eslint-standalone": "^1.1.3",
     "snack-sdk": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,11 +4929,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -14748,10 +14743,10 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
-  integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
+snack-babel-standalone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
+  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
 
 snack-eslint-standalone@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
# Why

This releases all new package versions described in #463

# How

- Published versions
- Removed the `file:` in packages part of the monorepo and being published.

# Test Plan

TBD
