### PR TITLE
fix(snack-babel-standalone): expose `traverse` for eslint

### DIFF
--- a/packages/snack-babel-standalone/package.json
+++ b/packages/snack-babel-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-babel-standalone",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Babel for Snack Runtime and Website",
   "main": "./build/runtime.js",
   "types": "./types/runtime.d.ts",

--- a/packages/snack-babel-standalone/src/entries/eslint.ts
+++ b/packages/snack-babel-standalone/src/entries/eslint.ts
@@ -17,7 +17,7 @@ export const version = babelVersion;
 // The tokTypes is an internal in babel, specifically for the `@babel/eslint-parser`.
 // See: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b08e4746a2f6321aa20410c00bc615662351f984/types/babel__core/index.d.ts#L724-L725
 // @ts-expect-error Module '"@babel/core"' has no exported member 'tokTypes'.
-export { types, tokTypes } from '@babel/core';
+export { traverse, types, tokTypes } from '@babel/core';
 
 // Babel core's parse sync is used in the `@babel/eslint-parser`.
 // See: https://github.com/babel/babel/blob/v7.14.2/eslint/babel-eslint-parser/src/index.js#L4

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -43,14 +43,14 @@
     "jest": "^28.1.3",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "patch-package": "^6.4.7",
-    "snack-babel-standalone": "^2.2.2",
+    "snack-babel-standalone": "^3.0.0",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0"
   },
   "peerDependencies": {
-    "snack-babel-standalone": ">=2.2.2"
+    "snack-babel-standalone": "^3.0.0"
   },
   "volta": {
     "node": "18.17.1"

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-eslint-standalone",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "ESLint for Snack Website",
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
@@ -43,7 +43,7 @@
     "jest": "^28.1.3",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "patch-package": "^6.4.7",
-    "snack-babel-standalone": "file:../snack-babel-standalone",
+    "snack-babel-standalone": "^3.0.1",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",

--- a/packages/snack-eslint-standalone/package.json
+++ b/packages/snack-eslint-standalone/package.json
@@ -43,14 +43,14 @@
     "jest": "^28.1.3",
     "node-polyfill-webpack-plugin": "^2.0.0",
     "patch-package": "^6.4.7",
-    "snack-babel-standalone": "^3.0.0",
+    "snack-babel-standalone": "file:../snack-babel-standalone",
     "typescript": "^4.7.4",
     "webpack": "^5.73.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.10.0"
   },
   "peerDependencies": {
-    "snack-babel-standalone": "^3.0.0"
+    "snack-babel-standalone": "^3.0.1"
   },
   "volta": {
     "node": "18.17.1"

--- a/packages/snack-eslint-standalone/yarn.lock
+++ b/packages/snack-eslint-standalone/yarn.lock
@@ -4584,10 +4584,8 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-snack-babel-standalone@^3.0.0:
+"snack-babel-standalone@file:../snack-babel-standalone":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
-  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
 
 source-map-support@0.5.13:
   version "0.5.13"

--- a/packages/snack-eslint-standalone/yarn.lock
+++ b/packages/snack-eslint-standalone/yarn.lock
@@ -4584,8 +4584,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-"snack-babel-standalone@file:../snack-babel-standalone":
-  version "3.0.0"
+snack-babel-standalone@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.1.tgz#c619711c4e2e59b44846b28dbbdfdaaed76495c4"
+  integrity sha512-sqmBEX7kuW1ZwgviIYi06ILnVhDHCxiZk/DDrISejxUUyFnu3zXQxrYAwtWksj3v7VlGyC2TsALXQN3GhDi0Hg==
 
 source-map-support@0.5.13:
   version "0.5.13"

--- a/packages/snack-eslint-standalone/yarn.lock
+++ b/packages/snack-eslint-standalone/yarn.lock
@@ -4584,10 +4584,10 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-snack-babel-standalone@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-2.2.2.tgz#2154855c482c112036261171ed32f7892102be60"
-  integrity sha512-kYYfIsktDfJeYrByF184YO/x55U7rPzfXThsownEGCNBn8d1xZ8AD7NyuLS5aA1n2rk9yKQ1CZxIRHwoNkootQ==
+snack-babel-standalone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
+  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
 
 source-map-support@0.5.13:
   version "0.5.13"

--- a/website/package.json
+++ b/website/package.json
@@ -80,9 +80,9 @@
     "recast": "^0.20.3",
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
-    "snack-babel-standalone": "^3.0.0",
+    "snack-babel-standalone": "^3.0.1",
     "snack-content": "*",
-    "snack-eslint-standalone": "^1.1.3",
+    "snack-eslint-standalone": "^2.0.0",
     "snack-sdk": "*",
     "validate-npm-package-name": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14743,15 +14743,11 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snack-babel-standalone@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.0.tgz#dfd99ffc306439054862303755a8d4700733af6e"
-  integrity sha512-RFUjiT6wMiC3hjiekvmt66pzY//tEbCVbc8J8uxQ6KXTnWOcn/b0FoeEKX8DlzglHCf0KcCFtFgCf1LTfh61Cg==
+"snack-babel-standalone@file:packages/snack-babel-standalone":
+  version "3.0.1"
 
-snack-eslint-standalone@^1.1.3:
+"snack-eslint-standalone@file:packages/snack-eslint-standalone":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-1.1.3.tgz#2c83a044d40244976bb4f11e741032a3c9162e1c"
-  integrity sha512-7uJ9I3xHK5CV48ZXJRB+WAG3uyJBSRrhPAjPmzX4xbUCRCInok7znaW9u5J/vFxCAyyEcdeoWR+AfN0sgCCq8w==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14743,11 +14743,15 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-"snack-babel-standalone@file:packages/snack-babel-standalone":
+snack-babel-standalone@^3.0.1:
   version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snack-babel-standalone/-/snack-babel-standalone-3.0.1.tgz#c619711c4e2e59b44846b28dbbdfdaaed76495c4"
+  integrity sha512-sqmBEX7kuW1ZwgviIYi06ILnVhDHCxiZk/DDrISejxUUyFnu3zXQxrYAwtWksj3v7VlGyC2TsALXQN3GhDi0Hg==
 
-"snack-eslint-standalone@file:packages/snack-eslint-standalone":
-  version "1.1.3"
+snack-eslint-standalone@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/snack-eslint-standalone/-/snack-eslint-standalone-2.0.0.tgz#99157a29b05eb4849ddaae1dde1c25363f43d899"
+  integrity sha512-v4XwV1UTnhgSTAjimLzBgdoG4xJKkwONRaEMFw1N34J1Eu5Mkujck73h+mXcdQ8HYDotrTltevzo17tvMhEu4w==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
# Why

This fixes an issue with `snack-eslint-standalone` and `snack-babel-standalone`.

# How

- Bumped up `snack-babel-standalone` in `snack-eslint-standalone`
- Resolved all testing issues
- Validated in website locally

# Packages

- Published `snack-babel-standalone@3.0.1`
- Published `snack-eslint-standalone@2.0.0`

# Test Plan

- `$ yarn`
- `$ yarn start`
- Open [website locally](http://snack.expo.test)
- Should not give ESLint errors