### PR TITLE
[infra] Use best practices for resource limits

### DIFF
--- a/snackager/k8s/base/deployment.yaml
+++ b/snackager/k8s/base/deployment.yaml
@@ -40,8 +40,7 @@ spec:
             name: http
           resources:
             limits:
-              cpu: 210m
-              memory: 10Gi
+              memory: 5Gi
             requests:
               cpu: 105m
               memory: 5Gi

--- a/website/deploy/base/deployment.yaml
+++ b/website/deploy/base/deployment.yaml
@@ -32,8 +32,7 @@ spec:
             initialDelaySeconds: 1
           resources:
             limits:
-              cpu: 160m
-              memory: 728Mi
+              memory: 182Mi
             requests:
               cpu: 40m
               memory: 182Mi


### PR DESCRIPTION
# Why
This reflects some manual changes I made to reduce restarts of snackager.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

- Set memory limits equal to memory requests
- Unset CPU limits

Ref: https://cloud.google.com/architecture/best-practices-for-running-cost-effective-kubernetes-applications-on-gke#set_appropriate_resource_requests_and_limits

<!-- 
How did you build this feature or fix this bug and why? 
-->
