### PR TITLE
chore(website): only allow crawling the root Snack page

### DIFF
--- a/website/src/client/components/PageMetadata.tsx
+++ b/website/src/client/components/PageMetadata.tsx
@@ -44,6 +44,8 @@ export function getPageMetadata(props: Props) {
     { name: 'twitter:title', content: title },
     { name: 'twitter:description', content: description },
     { name: 'twitter:image', content: image },
+    // Crawlers (SEO)
+    { name: 'robots', content: !props.id ? 'all' : 'none' }, // Only allow indexing on root URL (no Snack loaded)
   ];
 
   return {


### PR DESCRIPTION
# Why

SEO request.

# How

- Only the root of snack (`https://snack.expo.dev`) is allowed to index.
- Any nested URL that loads a Snack, e.g. `https://snack.expo.dev/@<user>/<snack>`, is blocked from crawling.

# Test Plan

- Check if `<meta name="robots" content="all" />` is set on [staging-snack.expo.dev](https://staging-snack.expo.dev/).
- Check if `<meta name="robots" content="none" />` is set on all other URLs.