### PR TITLE
[website] remove snackpub analytics

### DIFF
--- a/website/src/client/utils/snackTransports.tsx
+++ b/website/src/client/utils/snackTransports.tsx
@@ -5,8 +5,6 @@ import {
   SnackTransportListener,
 } from 'snack-sdk';
 
-import Analytics from './Analytics';
-
 export function createSnackWorkerTransport(
   testTransport: 'snackpub' | 'trafficMirroring',
   options: SnackTransportOptions
@@ -26,10 +24,6 @@ export function createSnackWorkerTransport(
       if (!transportListener) {
         transportListener = (event: any) => {
           const message = event.data;
-          if (message?.type === 'transportConnectionUpdates' && message?.payload?.name) {
-            Analytics.getInstance().logEvent(message.payload.name, message.payload);
-            return;
-          }
           listener(message);
         };
       }

--- a/website/src/client/workers/SnackTransport.worker.tsx
+++ b/website/src/client/workers/SnackTransport.worker.tsx
@@ -5,11 +5,7 @@ declare const self: WorkerGlobalScope;
 // @ts-ignore
 self.window = self; // Needed for pubnub to work
 
-const {
-  createTrafficMirroringTransport,
-  createTransport,
-  ConnectionMetricsEmitter,
-} = require('snack-sdk');
+const { createTrafficMirroringTransport, createTransport } = require('snack-sdk');
 
 let transport: SnackTransport | undefined = undefined;
 const transportCallback = (event: SnackTransportEvent) => postMessage(event);
@@ -29,10 +25,6 @@ onmessage = (event) => {
     }
   }
 };
-
-ConnectionMetricsEmitter.setUpdateListener((event: object) => {
-  postMessage({ type: 'transportConnectionUpdates', payload: event });
-});
 
 function transportFactory(testTransport: string, data: any) {
   if (testTransport === 'trafficMirroring') {


### PR DESCRIPTION
# Why

snackpub was fully rolled out to production and we don't need the measurement anymore. this could save the big query cost a little bit.

# How

revert partial code from #380 on website

# Test Plan

ci passed
