### PR TITLE
refactor(runtime): drop `expo-constants` in favor of newer tools

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -13,10 +13,10 @@
     "lint": "eslint .",
     "typescript": "tsc",
     "test": "jest",
-    "deploy:staging": "EXPO_STAGING=1 expo-cli publish --clear",
-    "deploy:prod": "CLOUD_ENV=production NODE_ENV=production expo-cli publish --clear",
-    "deploy:web:staging": "node ./web/deploy-script.js",
-    "deploy:web:prod": "CLOUD_ENV=production NODE_ENV=production node ./web/deploy-script.js"
+    "deploy:staging": "SNACK_ENVIRONMENT=staging EXPO_STAGING=1 expo-cli publish --clear",
+    "deploy:prod": "NODE_ENV=production expo-cli publish --clear",
+    "deploy:web:staging": "SNACK_ENVIRONMENT=staging node ./web/deploy-script.js",
+    "deploy:web:prod": "NODE_ENV=production node ./web/deploy-script.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.3",

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -1,7 +1,6 @@
 import './polyfill';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import Constants from 'expo-constants';
 import { activateKeepAwake } from 'expo-keep-awake';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
@@ -20,6 +19,7 @@ import * as Analytics from './Analytics';
 import { AppLoading } from './AppLoading';
 import BarCodeScannerView from './BarCodeScannerView';
 import * as Console from './Console';
+import { selectEnvironment } from './Environment';
 import * as Errors from './Errors';
 import * as Files from './Files';
 import LoadingView from './LoadingView';
@@ -317,11 +317,11 @@ export default class App extends React.Component<object, State> {
   };
 
   _uploadPreviewToS3 = async (asset: string, height: number, width: number) => {
-    const url = `${
-      Constants.manifest?.extra?.cloudEnv !== 'production'
-        ? API_SERVER_URL_STAGING
-        : API_SERVER_URL_PROD
-    }/--/api/v2/snack/uploadPreview`;
+    const host = selectEnvironment({
+      staging: API_SERVER_URL_STAGING,
+      production: API_SERVER_URL_PROD,
+    });
+    const url = `${host}/--/api/v2/snack/uploadPreview`;
     const body = JSON.stringify({ asset, height, width });
     try {
       Logger.info('Uploading preview...', 'width', width, 'height', height);

--- a/runtime/src/BarCodeScannerView.native.tsx
+++ b/runtime/src/BarCodeScannerView.native.tsx
@@ -1,7 +1,6 @@
 import { BarCodeScanner, BarCodeScannedCallback } from 'expo-barcode-scanner';
-import Constants from 'expo-constants';
 import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, SafeAreaView } from 'react-native';
 
 import LoadingView from './LoadingView';
 
@@ -44,7 +43,7 @@ export default class BarCodeScannerView extends React.Component<Props, State> {
 
     if (hasCameraPermission) {
       return (
-        <View style={styles.container}>
+        <SafeAreaView style={styles.container}>
           <Text style={styles.initialURL}>{`Launch URL: ${initialURL}`}</Text>
           <Text style={styles.paragraph}>
             Open up https://snack.expo.dev and scan the QR code to get started!
@@ -54,7 +53,7 @@ export default class BarCodeScannerView extends React.Component<Props, State> {
           </Text>
           {/* @ts-ignore Property 'style' does not exist on type */}
           <BarCodeScanner style={styles.camera} onBarCodeScanned={onBarCodeScanned} />
-        </View>
+        </SafeAreaView>
       );
     }
 
@@ -72,7 +71,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingTop: Constants.statusBarHeight,
     backgroundColor: '#ecf0f1',
   },
   initialURL: {

--- a/runtime/src/BarCodeScannerView.tsx
+++ b/runtime/src/BarCodeScannerView.tsx
@@ -1,7 +1,6 @@
 import type { BarCodeEvent } from 'expo-barcode-scanner';
-import Constants from 'expo-constants';
 import * as React from 'react';
-import { View, TextInput, StyleSheet } from 'react-native';
+import { TextInput, StyleSheet, SafeAreaView } from 'react-native';
 
 type Props = {
   onBarCodeScanned: (event: Pick<BarCodeEvent, 'type' | 'data'>) => any;
@@ -10,13 +9,13 @@ type Props = {
 
 export default function BarCodeScannerView({ onBarCodeScanned }: Props) {
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <TextInput
         style={styles.input}
         onSubmitEditing={(e) => onBarCodeScanned({ data: e.nativeEvent.text, type: 'url' })}
         placeholder="Enter URL to load"
       />
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -24,7 +23,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingTop: Constants.statusBarHeight,
     backgroundColor: '#ecf0f1',
   },
   input: {

--- a/runtime/src/Environment.ts
+++ b/runtime/src/Environment.ts
@@ -1,0 +1,7 @@
+/** The current environment based on the `SNACK_ENVIRONMENT` environment variable */
+export const environment = process.env.SNACK_ENVIRONMENT === 'staging' ? 'staging' : 'production';
+
+/** Select a value based on the current environment, similar to `Platform.select({})` */
+export function selectEnvironment<T>(values: Record<typeof environment, T>): T {
+  return values[environment];
+}

--- a/runtime/src/Errors.tsx
+++ b/runtime/src/Errors.tsx
@@ -1,8 +1,7 @@
 // Currently only one error is saved at a time for display
 
-import Constants from 'expo-constants';
 import * as React from 'react';
-import { View, ScrollView, Text, StyleSheet, Platform } from 'react-native';
+import { View, ScrollView, Text, StyleSheet, Platform, SafeAreaView } from 'react-native';
 
 import * as Files from './Files';
 import * as Logger from './Logger';
@@ -194,7 +193,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   _renderOverlay(error: Error) {
     return (
-      <View style={styles.overlay}>
+      <SafeAreaView style={styles.overlay}>
         <View style={styles.header}>
           <Text style={styles.title}>
             <Text style={styles.titleBold}>Did you know: </Text>
@@ -205,7 +204,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
           {this._renderErrorMessage(error)}
           {this._renderStackTrace(error)}
         </ScrollView>
-      </View>
+      </SafeAreaView>
     );
   }
 
@@ -268,7 +267,7 @@ const styles = StyleSheet.create({
   },
   overlay: {
     position: 'absolute',
-    top: 28 + Constants.statusBarHeight,
+    top: 28,
     bottom: 28,
     left: 28,
     right: 28,

--- a/runtime/src/Modules.tsx
+++ b/runtime/src/Modules.tsx
@@ -23,6 +23,7 @@ import { SourceMapConsumer, RawSourceMap } from 'source-map';
 
 import ReanimatedPlugin from '../vendor/reanimated-plugin';
 import System from '../vendor/system.src';
+import { selectEnvironment } from './Environment';
 import * as Files from './Files';
 import * as Logger from './Logger';
 import AssetRegistry from './NativeModules/AssetRegistry';
@@ -312,10 +313,10 @@ const fetchPipeline = async (load: Load) => {
           );
         } else {
           // In development, try fetching from staging cloudfront first
-          const cloudFrontUrls =
-            Constants.manifest?.extra?.cloudEnv !== 'production'
-              ? [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD]
-              : [SNACKAGER_CDN_PROD];
+          const cloudFrontUrls = selectEnvironment({
+            staging: [SNACKAGER_CDN_STAGING, SNACKAGER_CDN_PROD],
+            production: [SNACKAGER_CDN_PROD],
+          });
           for (const url of cloudFrontUrls) {
             const fetchFrom = `${url}/${handle}-${Platform.OS}/bundle.js`;
 

--- a/runtime/src/transports/RuntimeTransportImplSocketIO.ts
+++ b/runtime/src/transports/RuntimeTransportImplSocketIO.ts
@@ -1,7 +1,7 @@
-import Constants from 'expo-constants';
 import { io } from 'socket.io-client';
 import type { Socket } from 'socket.io-client';
 
+import { selectEnvironment } from '../Environment';
 import * as Logger from '../Logger';
 import type { Device, RuntimeMessagePayload, RuntimeTransport } from './RuntimeTransport';
 
@@ -30,10 +30,10 @@ export default class RuntimeTransportImplSocketIO implements RuntimeTransport {
   constructor(device: Device) {
     this.device = device;
     this.sender = JSON.stringify(device);
-    const snackpubURL =
-      Constants.manifest?.extra?.cloudEnv !== 'production'
-        ? SNACKPUB_URL_STAGING
-        : SNACKPUB_URL_PRODUCTION;
+    const snackpubURL = selectEnvironment({
+      staging: SNACKPUB_URL_STAGING,
+      production: SNACKPUB_URL_PRODUCTION,
+    });
     this.socket = io(snackpubURL, { transports: ['websocket'] });
     this.socket.on('terminate', (reason) => {
       Logger.comm(`Terminating connection: ${reason}`);


### PR DESCRIPTION
# Why

We've used `expo-constants` a lot, mostly to check if we need to ping the staging environment or production and a not-so-great alternative to `<SafeAreaView>`.

# How

- Added `src/Environments.ts` helper, similarly to `Platform.select`, to get hosts to ping
- Replaced `Constants.statusBar` with `<SafeAreaView>`

# Test Plan

TBD
