### PR TITLE
   chore(website): Enable Orbit to all macOS users

### DIFF
--- a/website/src/client/components/EditorToolbar.tsx
+++ b/website/src/client/components/EditorToolbar.tsx
@@ -58,9 +58,7 @@ export default function EditorToolbar(props: Props) {
   const isPublishing = saveStatus === 'publishing';
   const isPublished = saveStatus === 'published';
 
-  const { isEnabled: showOrbitButton, openWithExperienceURL: onOpenWithOrbit } = useOrbit({
-    experiments: viewer?.experiments,
-  });
+  const { isEnabled: showOrbitButton, openWithExperienceURL: onOpenWithOrbit } = useOrbit();
 
   return (
     <ToolbarShell>

--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -2,7 +2,6 @@ import customProtocolCheck from 'custom-protocol-check';
 import { useCallback, useEffect, useState } from 'react';
 
 import { isMacOS } from './detectPlatform';
-import { Experiment, UserData } from '../auth/authManager';
 
 const ORBIT_SERVER_PORTS = [35783, 47909, 44171, 50799];
 
@@ -57,16 +56,9 @@ async function fetchLocalOrbitServer<T extends keyof LocalServerRoutes>(
   return undefined;
 }
 
-interface UseOrbitParams {
-  experiments?: UserData['experiments'];
-}
-
-export function useOrbit({ experiments }: UseOrbitParams = {}) {
+export function useOrbit() {
   const [isRunning, setIsRunning] = useState(false);
   const isRunningMacOS = isMacOS(navigator?.userAgent);
-
-  const hasEnabledOrbitExperiment =
-    experiments?.find(({ experiment }) => experiment === Experiment.Orbit)?.enabled ?? false;
 
   const openWithExperienceURL = useCallback(
     async (experienceURL: string, onFail?: () => void) => {
@@ -97,7 +89,7 @@ export function useOrbit({ experiments }: UseOrbitParams = {}) {
   }, [isRunningMacOS]);
 
   return {
-    isEnabled: hasEnabledOrbitExperiment || isRunning,
+    isEnabled: isRunningMacOS,
     openWithExperienceURL,
   };
 }


### PR DESCRIPTION
# Why

With the official release of Orbit, it should no longer be considered an experiment and should be visible to all users

# How

Update useOrbit hook to make the Orbit button always visible 

# Test Plan

"Open with Orbit" button should be now visible to all accounts
