### PR TITLE
refactor(website): default to SDK 49

### DIFF
--- a/packages/snack-content/package.json
+++ b/packages/snack-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-content",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Functions and types that describe the contents of Snack projects",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,6 +1,6 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '48.0.0';
+export const defaultSdkVersion: SDKVersion = '49.0.0';
 
 // Mostly used for tests
 export const oldestSdkVersion: SDKVersion = '47.0.0';

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "The Expo Snack SDK",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -71,7 +71,7 @@
     "nullthrows": "^1.1.1",
     "pubnub": "^7.2.0",
     "semver": "^7.3.4",
-    "snack-content": "~1.5.0",
+    "snack-content": "~1.6.0",
     "socket.io-client": "~4.5.4",
     "ua-parser-js": "^0.7.22",
     "validate-npm-package-name": "^3.0.0"

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -198,7 +198,7 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~2.9.0",
+    "wantedVersion": "~2.12.0",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.48.0.0-10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://exp.host/@snack/sdk.49.0.0-10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__integration-tests__/__snapshots__/git.test.ts.snap
@@ -223,7 +223,7 @@ Array [
         },
         "description": "test2 @ Jan 1, 2020",
         "name": "test2",
-        "sdkVersion": "48.0.0",
+        "sdkVersion": "49.0.0",
       },
     },
     "headers": Object {
@@ -261,7 +261,7 @@ Array [
         },
         "description": "test3 @ Jan 1, 2020",
         "name": "test3",
-        "sdkVersion": "48.0.0",
+        "sdkVersion": "49.0.0",
       },
     },
     "headers": Object {
@@ -295,7 +295,7 @@ Array [
         },
         "description": "some-example @ Jan 1, 2020",
         "name": "some-example",
-        "sdkVersion": "48.0.0",
+        "sdkVersion": "49.0.0",
       },
     },
     "headers": Object {


### PR DESCRIPTION
# Why

We are preparing for SDK 50, this was a left over of the previous SDK release cycle.

# How

- Updated `snack-content` to default to SDK 49

# Test Plan

See staging
