### PR TITLE
refactor(runtime): drop `cloudEnv` in favor of `EXPO_PUBLIC_SNACK_ENV`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ npm-debug.log
 yarn-error.log
 package-lock.json
 
+# dotenv
+.env
+!.env.example
+
 # IDEs
 .idea
 

--- a/packages/snack-runtime/src/Constants.ts
+++ b/packages/snack-runtime/src/Constants.ts
@@ -13,9 +13,7 @@ if (!['staging', 'production'].includes(SNACK_ENV)) {
 }
 
 /** Get the value based on the detected Snack environment. */
-export function getSnackEnvironmentValue<T extends any>(
-  values: Record<typeof SNACK_ENV, T>,
-): T {
+export function getSnackEnvironmentValue<T extends any>(values: Record<typeof SNACK_ENV, T>): T {
   return values[SNACK_ENV];
 }
 

--- a/packages/snack-runtime/src/Constants.ts
+++ b/packages/snack-runtime/src/Constants.ts
@@ -1,24 +1,22 @@
-import Constants from 'expo-constants';
-
 /**
  * The detected Snack environment based on the `manifest.extra.cloudEnv` setting.
  * This defaults to `production` if not set.
  */
-export const SNACK_ENVIRONMENT: 'staging' | 'production' =
-  Constants.manifest?.extra?.cloudEnv ?? 'production';
+export const SNACK_ENV: 'staging' | 'production' =
+  (process.env.EXPO_PUBLIC_SNACK_ENV as any) ?? 'production';
 
-// Ensure the environment is valid
-if (!['staging', 'production'].includes(SNACK_ENVIRONMENT)) {
+// Ensure the `SNACK_ENV` is valid
+if (!['staging', 'production'].includes(SNACK_ENV)) {
   throw new Error(
-    `Invalid Snack environment set through "manifest.extra.cloudEnv", must be "staging" or "production", received "${SNACK_ENVIRONMENT}".`,
+    `Invalid Snack environment set through "EXPO_PUBLIC_SNACK_ENV", must be "staging" or "production", received "${SNACK_ENV}".`,
   );
 }
 
 /** Get the value based on the detected Snack environment. */
 export function getSnackEnvironmentValue<T extends any>(
-  values: Record<typeof SNACK_ENVIRONMENT, T>,
+  values: Record<typeof SNACK_ENV, T>,
 ): T {
-  return values[SNACK_ENVIRONMENT];
+  return values[SNACK_ENV];
 }
 
 /** The Snack or Expo API endpoint. */

--- a/runtime-shell/.env.example
+++ b/runtime-shell/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SNACK_ENV=staging
+# EXPO_PUBLIC_SNACK_ENV=production

--- a/runtime-shell/metro.config.js
+++ b/runtime-shell/metro.config.js
@@ -6,11 +6,11 @@ const { boolish } = require('getenv');
 const config = getDefaultConfig(__dirname);
 
 // Workaround for paths hosting web on a subdirectory (https://<s3-bucket>/v2/<expo-sdk-version>/)
-// if (boolish('SNACK_EXPORT_WEB', false)) {
-//   const expoVersion = require('expo/package.json').version;
-//   const semver = require('semver');
+if (boolish('SNACK_EXPORT_WEB', false)) {
+  const expoVersion = require('expo/package.json').version;
+  const semver = require('semver');
 
-//   config.transformer.publicPath = `/v2/${semver.major(expoVersion)}/assets`;
-// }
+  config.transformer.publicPath = `/v2/${semver.major(expoVersion)}/assets`;
+}
 
 module.exports = config;

--- a/runtime-shell/metro.config.js
+++ b/runtime-shell/metro.config.js
@@ -6,11 +6,11 @@ const { boolish } = require('getenv');
 const config = getDefaultConfig(__dirname);
 
 // Workaround for paths hosting web on a subdirectory (https://<s3-bucket>/v2/<expo-sdk-version>/)
-if (boolish('SNACK_EXPORT_WEB', false)) {
-  const expoVersion = require('expo/package.json').version;
-  const semver = require('semver');
+// if (boolish('SNACK_EXPORT_WEB', false)) {
+//   const expoVersion = require('expo/package.json').version;
+//   const semver = require('semver');
 
-  config.transformer.publicPath = `/v2/${semver.major(expoVersion)}/assets`;
-}
+//   config.transformer.publicPath = `/v2/${semver.major(expoVersion)}/assets`;
+// }
 
 module.exports = config;

--- a/runtime-shell/package.json
+++ b/runtime-shell/package.json
@@ -7,16 +7,16 @@
   "main": "index.js",
   "owner": "exponent",
   "scripts": {
-    "start": "CLOUD_ENV=staging expo start",
-    "web": "CLOUD_ENV=staging expo start --web",
+    "start": "EXPO_PUBLIC_SNACK_ENV=staging expo start",
+    "web": "EXPO_PUBLIC_SNACK_ENV=staging expo start --web",
     "postinstall": "patch-package",
     "lint": "eslint .",
     "typescript": "tsc",
     "test": "jest",
-    "deploy:staging": "CLOUD_ENV=staging EXPO_STAGING=1 expo-cli publish --clear",
-    "deploy:prod": "NODE_ENV=production expo-cli publish --clear",
-    "deploy:web:staging": "CLOUD_ENV=staging node ./web/deploy-script.js",
-    "deploy:web:prod": "NODE_ENV=production node ./web/deploy-script.js"
+    "deploy:staging": "EXPO_PUBLIC_SNACK_ENV=staging EXPO_STAGING=1 expo-cli publish --clear",
+    "deploy:prod": "EXPO_PUBLIC_SNACK_ENV=production expo-cli publish --clear",
+    "deploy:web:staging": "EXPO_PUBLIC_SNACK_ENV=staging node ./web/deploy-script.js",
+    "deploy:web:prod": "EXPO_PUBLIC_SNACK_ENV=production node ./web/deploy-script.js"
   },
   "dependencies": {
     "@react-navigation/drawer": "^6.6.2",

--- a/runtime/.env.example
+++ b/runtime/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SNACK_ENV=staging
+# EXPO_PUBLIC_SNACK_ENV=production

--- a/runtime/app.config.js
+++ b/runtime/app.config.js
@@ -1,8 +1,0 @@
-export default ({ config }) => {
-  return {
-    ...config,
-    extra: {
-      cloudEnv: process.env.CLOUD_ENV,
-    },
-  };
-};

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -14,9 +14,9 @@
     "typescript": "tsc",
     "test": "jest",
     "deploy:staging": "EXPO_STAGING=1 expo-cli publish --clear",
-    "deploy:prod": "CLOUD_ENV=production NODE_ENV=production expo-cli publish --clear",
+    "deploy:prod": "EXPO_PUBLIC_SNACK_ENV=production NODE_ENV=production expo-cli publish --clear",
     "deploy:web:staging": "node ./web/deploy-script.js",
-    "deploy:web:prod": "CLOUD_ENV=production NODE_ENV=production node ./web/deploy-script.js"
+    "deploy:web:prod": "EXPO_PUBLIC_SNACK_ENV=production NODE_ENV=production node ./web/deploy-script.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.3",

--- a/runtime/src/Constants.ts
+++ b/runtime/src/Constants.ts
@@ -1,24 +1,22 @@
-import Constants from 'expo-constants';
-
 /**
  * The detected Snack environment based on the `manifest.extra.cloudEnv` setting.
  * This defaults to `production` if not set.
  */
-export const SNACK_ENVIRONMENT: 'staging' | 'production' =
-  (Constants.manifest as any)?.extra?.cloudEnv ?? 'production';
+export const SNACK_ENV: 'staging' | 'production' =
+  (process.env.EXPO_PUBLIC_SNACK_ENV as any) ?? 'production';
 
-// Ensure the environment is valid
-if (!['staging', 'production'].includes(SNACK_ENVIRONMENT)) {
+// Ensure the `SNACK_ENV` is valid
+if (!['staging', 'production'].includes(SNACK_ENV)) {
   throw new Error(
-    `Invalid Snack environment set through "manifest.extra.cloudEnv", must be "staging" or "production", received "${SNACK_ENVIRONMENT}".`,
+    `Invalid Snack environment set through "EXPO_PUBLIC_SNACK_ENV", must be "staging" or "production", received "${SNACK_ENV}".`,
   );
 }
 
 /** Get the value based on the detected Snack environment. */
 export function getSnackEnvironmentValue<T extends any>(
-  values: Record<typeof SNACK_ENVIRONMENT, T>,
+  values: Record<typeof SNACK_ENV, T>,
 ): T {
-  return values[SNACK_ENVIRONMENT];
+  return values[SNACK_ENV];
 }
 
 /** The Snack or Expo API endpoint. */

--- a/runtime/src/Constants.ts
+++ b/runtime/src/Constants.ts
@@ -13,9 +13,7 @@ if (!['staging', 'production'].includes(SNACK_ENV)) {
 }
 
 /** Get the value based on the detected Snack environment. */
-export function getSnackEnvironmentValue<T extends any>(
-  values: Record<typeof SNACK_ENV, T>,
-): T {
+export function getSnackEnvironmentValue<T extends any>(values: Record<typeof SNACK_ENV, T>): T {
   return values[SNACK_ENV];
 }
 


### PR DESCRIPTION
# Why

Part of [ENG-11039](https://linear.app/expo/issue/ENG-11039/[runtime]-update-supported-snack-url)

Now that we have proper environment variables support, the old system blocks more than it helps.

# How

This replaces `require('expo-constants').manifest.extra.cloudEnv` with just `process.env.EXPO_PUBLIC_SNACK_ENV`.

# Test Plan

This will be part of the SDK 50 release.