### PR TITLE
[website] reorder preview platform tabs

### DIFF
--- a/website/src/client/utils/PlatformOptions.ts
+++ b/website/src/client/utils/PlatformOptions.ts
@@ -8,8 +8,8 @@ export type PlatformOption = {
 export function all(): PlatformOption[] {
   return [
     { label: 'My Device', value: 'mydevice' },
-    { label: 'iOS', value: 'ios' },
     { label: 'Android', value: 'android' },
+    { label: 'iOS', value: 'ios' },
     { label: 'Web', value: 'web' },
   ];
 }


### PR DESCRIPTION
# Why

Refs:
* https://github.com/expo/expo/pull/26351#discussion_r1447872140

# How

Reorder preview platform tabs to match order specified in writing guidelines:
* https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-android-ios-and-web

# Test Plan

The chanage has been reviewed locally. All lint checks are passing.

# Preview

![Screenshot 2024-01-11 at 10 49 07](https://github.com/expo/snack/assets/719641/05c756ae-9d45-486c-be8e-71b99d4b829a)
