### PR TITLE
refactor(runtime): replace `cloudEnv` with `EXPO_PUBLIC_SNACK_ENV`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ snackpub/build
 
 # turborepo
 .turbo/
+
+# dotenv
+.env*
+!.env.example

--- a/runtime/.env.example
+++ b/runtime/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SNACK_ENV=staging
+# EXPO_PUBLIC_SNACK_ENV=production

--- a/runtime/app.config.js
+++ b/runtime/app.config.js
@@ -1,8 +1,0 @@
-export default ({ config }) => {
-  return {
-    ...config,
-    extra: {
-      cloudEnv: process.env.CLOUD_ENV,
-    },
-  };
-};

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -13,10 +13,10 @@
     "lint": "eslint .",
     "typescript": "tsc",
     "test": "jest",
-    "deploy:staging": "EXPO_STAGING=1 expo-cli publish --clear",
-    "deploy:prod": "CLOUD_ENV=production NODE_ENV=production expo-cli publish --clear",
-    "deploy:web:staging": "node ./web/deploy-script.js",
-    "deploy:web:prod": "CLOUD_ENV=production NODE_ENV=production node ./web/deploy-script.js"
+    "deploy:staging": "EXPO_PUBLIC_SNACK_ENV=staging EXPO_STAGING=1 expo-cli publish --clear",
+    "deploy:prod": "expo-cli publish --clear",
+    "deploy:web:staging": "EXPO_PUBLIC_SNACK_ENV=staging node ./web/deploy-script.js",
+    "deploy:web:prod": "node ./web/deploy-script.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.3",

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -1,7 +1,6 @@
 import './polyfill';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import Constants from 'expo-constants';
 import { activateKeepAwake } from 'expo-keep-awake';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
@@ -20,6 +19,7 @@ import { createVirtualModulePath } from 'snack-require-context';
 import { AppLoading } from './AppLoading';
 import BarCodeScannerView from './BarCodeScannerView';
 import * as Console from './Console';
+import { SNACK_API_URL } from './Constants';
 import * as Errors from './Errors';
 import * as Files from './Files';
 import LoadingView from './LoadingView';
@@ -34,9 +34,6 @@ import getDeviceIdAsync from './NativeModules/getDeviceIdAsync';
 import * as Profiling from './Profiling';
 import UpdateIndicator from './UpdateIndicator';
 import { parseTestTransportFromUrl } from './UrlUtils';
-
-const API_SERVER_URL_STAGING = 'https://staging.exp.host';
-const API_SERVER_URL_PROD = 'https://exp.host';
 
 type State = {
   initialLoad: boolean;
@@ -315,11 +312,7 @@ export default class App extends React.Component<object, State> {
   };
 
   _uploadPreviewToS3 = async (asset: string, height: number, width: number) => {
-    const url = `${
-      Constants.manifest?.extra?.cloudEnv !== 'production'
-        ? API_SERVER_URL_STAGING
-        : API_SERVER_URL_PROD
-    }/--/api/v2/snack/uploadPreview`;
+    const url = `${SNACK_API_URL}/--/api/v2/snack/uploadPreview`;
     const body = JSON.stringify({ asset, height, width });
     try {
       Logger.info('Uploading preview...', 'width', width, 'height', height);

--- a/runtime/src/Constants.ts
+++ b/runtime/src/Constants.ts
@@ -5,7 +5,7 @@ if (snackEnv === 'production' || snackEnv === 'staging') {
   console.log('Snack is running in', snackEnv, 'mode');
 } else {
   throw new Error(
-    `EXPO_PUBLIC_SNACK_ENV must be  must be "staging" or "production", received "${snackEnv}".`,
+    `EXPO_PUBLIC_SNACK_ENV must be  must be "staging" or "production", received "${snackEnv}".`
   );
 }
 

--- a/runtime/src/Constants.ts
+++ b/runtime/src/Constants.ts
@@ -1,0 +1,46 @@
+const snackEnv = process.env.EXPO_PUBLIC_SNACK_ENV ?? 'production';
+
+// Ensure the environment is valid
+if (snackEnv === 'production' || snackEnv === 'staging') {
+  console.log('Snack is running in', snackEnv, 'mode');
+} else {
+  throw new Error(
+    `EXPO_PUBLIC_SNACK_ENV must be  must be "staging" or "production", received "${snackEnv}".`,
+  );
+}
+
+/**
+ * The detected Snack environment based on the `EXPO_PUBLIC_SNACK_ENV` setting.
+ * This defaults to `production` if not set.
+ */
+export const SNACK_ENV = snackEnv;
+
+/** Get the value based on the detected Snack environment. */
+export function selectValueBySnackEnv<T extends any>(values: Record<typeof SNACK_ENV, T>): T {
+  return values[SNACK_ENV];
+}
+
+/** The Snack or Expo API endpoint. */
+export const SNACK_API_URL = selectValueBySnackEnv({
+  production: 'https://exp.host',
+  staging: 'https://staging.exp.host',
+});
+
+/**
+ * The Snackager Cloudfront endpoints to try before failing.
+ * Note, staging may fail randomly due to reduced capacity or general development work.
+ * Because of that, we try both staging and production before failing.
+ */
+export const SNACKAGER_API_URLS = selectValueBySnackEnv({
+  production: ['https://d37p21p3n8r8ug.cloudfront.net'],
+  staging: [
+    'https://ductmb1crhe2d.cloudfront.net', // staging
+    'https://d37p21p3n8r8ug.cloudfront.net', // production
+  ],
+});
+
+/** The SnackPub endpoint, used to establish socket connections with the Snack Website. */
+export const SNACKPUB_URL = selectValueBySnackEnv({
+  production: 'https://snackpub.expo.dev',
+  staging: 'https://staging-snackpub.expo.dev',
+});

--- a/runtime/src/Files.tsx
+++ b/runtime/src/Files.tsx
@@ -2,7 +2,6 @@
 // diffs etc. Does NOT deal with evaluating code, that happens in `Modules`.
 
 import { applyPatch } from 'diff';
-import Constants from 'expo-constants';
 
 type Message = {
   type: 'CODE';
@@ -24,23 +23,24 @@ type File = {
 
 const files: { [key: string]: File } = {};
 
+// TODO(cedric): replace this code with an initial fetch call to the server
 // Initialize by reading from `extra.code` in manifest if present
-const manifest = Constants.manifest;
+// const manifest = Constants.manifest;
 
-if (manifest?.extra?.code) {
-  const initialCode = manifest.extra.code;
-  Object.keys(initialCode).forEach((path) => {
-    const initialFile = initialCode[path];
-    const isAsset = initialFile.type === 'ASSET';
-    files[path] = {
-      isAsset,
-      s3Url: isAsset ? initialFile.contents : undefined,
-      s3Contents: undefined,
-      diff: undefined,
-      contents: !isAsset ? initialFile.contents : undefined,
-    };
-  });
-}
+// if (manifest?.extra?.code) {
+//   const initialCode = manifest.extra.code;
+//   Object.keys(initialCode).forEach((path) => {
+//     const initialFile = initialCode[path];
+//     const isAsset = initialFile.type === 'ASSET';
+//     files[path] = {
+//       isAsset,
+//       s3Url: isAsset ? initialFile.contents : undefined,
+//       s3Contents: undefined,
+//       diff: undefined,
+//       contents: !isAsset ? initialFile.contents : undefined,
+//     };
+//   });
+// }
 
 // Update files -- currently only handles updates from remote `message`s. Returns an array
 // containing paths of changed files.

--- a/runtime/src/transports/RuntimeTransportImplSocketIO.ts
+++ b/runtime/src/transports/RuntimeTransportImplSocketIO.ts
@@ -1,12 +1,9 @@
-import Constants from 'expo-constants';
 import { io } from 'socket.io-client';
 import type { Socket } from 'socket.io-client';
 
+import { SNACKPUB_URL } from '../Constants';
 import * as Logger from '../Logger';
 import type { Device, RuntimeMessagePayload, RuntimeTransport } from './RuntimeTransport';
-
-const SNACKPUB_URL_STAGING = 'https://staging-snackpub.expo.dev';
-const SNACKPUB_URL_PRODUCTION = 'https://snackpub.expo.dev';
 
 interface ServerToClientEvents {
   message: (data: { channel: string; sender: string } & RuntimeMessagePayload) => void;
@@ -30,11 +27,7 @@ export default class RuntimeTransportImplSocketIO implements RuntimeTransport {
   constructor(device: Device) {
     this.device = device;
     this.sender = JSON.stringify(device);
-    const snackpubURL =
-      Constants.manifest?.extra?.cloudEnv !== 'production'
-        ? SNACKPUB_URL_STAGING
-        : SNACKPUB_URL_PRODUCTION;
-    this.socket = io(snackpubURL, { transports: ['websocket'] });
+    this.socket = io(SNACKPUB_URL, { transports: ['websocket'] });
     this.socket.on('terminate', (reason) => {
       Logger.comm(`Terminating connection: ${reason}`);
       this.socket.disconnect();


### PR DESCRIPTION
# Why

This removes one of the last dependents on `expo-constants` within Snack. The last remaining one is the `Constants.statusBarHeight`.

# How

- Replaced `cloudEnv` with `EXPO_PUBLIC_SNACK_ENV`
- Added `.env.example` file

# Test Plan

Will be included in the full SDK 50 upgrade, and tested on Staging.
