### PR TITLE
chore(runtime): use right preset for `*.config.js` files

### DIFF
--- a/runtime/metro.config.js
+++ b/runtime/metro.config.js
@@ -2,7 +2,6 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const { boolish } = require('getenv');
 
-/* eslint-env node */
 const config = getDefaultConfig(__dirname);
 
 // Workaround for paths hosting web on a subdirectory (https://<s3-bucket>/v2/<expo-sdk-version>/)

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -89,6 +89,12 @@
     "extends": "universe/native",
     "ignorePatterns": [
       "vendor"
+    ],
+    "overrides": [
+      {
+        "files": ["*.config.js"],
+        "extends": "universe/node"
+      }
     ]
   },
   "jest": {


### PR DESCRIPTION
# Why

This sets the right preset for node-only files in the runtime.

# How

- Added missing `override` for `*.config.js` files.

# Test Plan

See CI.