### PR TITLE
chore(runtime): update deployment workflow for eas

### DIFF
--- a/.github/actions/setup-runtime/action.yml
+++ b/.github/actions/setup-runtime/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: Version of Node to use
     default: 18.x
 
-  expo-version:
-    description: Version of Expo CLI to use
+  eas-version:
+    description: Version of EAS CLI to use
     default: latest
 
 runs:
@@ -20,10 +20,10 @@ runs:
         cache: yarn
         cache-dependency-path: runtime/yarn.lock
 
-    - name: 🏗 Setup Expo
-      uses: expo/expo-github-action@v7
+    - name: 🏗 Setup EAS
+      uses: expo/expo-github-action@v8
       with:
-        expo-version: ${{ inputs.expo-version }}
+        eas-version: ${{ inputs.eas-version }}
 
     - name: 📦 Install monorepo dependencies
       run: yarn install --frozen-lockfile

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -69,6 +69,8 @@ jobs:
     environment:
       name: runtime-staging
       url: https://staging.expo.dev/@exponent/snack
+    env:
+      EXPO_PUBLIC_SNACK_ENV: staging
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -82,6 +84,15 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SNACK_RUNTIME_AWS_STAGING_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SNACK_RUNTIME_AWS_STAGING_SECRET }}
+
+      - name: 👷 Configure EAS Update for staging
+        if: ${{ contains('all native', github.event.inputs.platform) }}
+        run: |
+          eas init --id 2dce2748-c51f-4865-bae0-392af794d60a --force
+          eas update:configure
+        env:
+          EXPO_TOKEN: ${{ secrets.SNACK_RUNTIME_EXPO_STAGING }}
+          EXPO_STAGING: 'true'
 
       - name: 📱 Deploy native runtime
         if: ${{ contains('all native', github.event.inputs.platform) }}
@@ -109,6 +120,8 @@ jobs:
     environment:
       name: runtime-production
       url: https://expo.dev/@exponent/snack
+    env:
+      EXPO_PUBLIC_SNACK_ENV: production
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -122,6 +135,14 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SNACK_RUNTIME_AWS_PRODUCTION_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SNACK_RUNTIME_AWS_PRODUCTION_SECRET }}
+
+      - name: 👷 Configure EAS Update for production
+        if: ${{ contains('all native', github.event.inputs.platform) }}
+        run: |
+          eas init --id 933fd9c0-1666-11e7-afca-d980795c5824 --force
+          eas update:configure
+        env:
+          EXPO_TOKEN: ${{ secrets.SNACK_RUNTIME_EXPO_PRODUCTION }}
 
       - name: 📱 Deploy native runtime
         if: ${{ contains('all native', github.event.inputs.platform) }}

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -13,10 +13,10 @@
     "lint": "eslint .",
     "typescript": "tsc",
     "test": "jest",
-    "deploy:staging": "EXPO_PUBLIC_SNACK_ENV=staging EXPO_STAGING=1 expo-cli publish --clear",
-    "deploy:prod": "expo-cli publish --clear",
+    "deploy:staging": "EXPO_PUBLIC_SNACK_ENV=staging EXPO_STAGING=1 eas update --auto --branch staging",
+    "deploy:prod": "EXPO_PUBLIC_SNACK_ENV=production eas update --auto --branch production",
     "deploy:web:staging": "EXPO_PUBLIC_SNACK_ENV=staging node ./web/deploy-script.js",
-    "deploy:web:prod": "node ./web/deploy-script.js"
+    "deploy:web:prod": "EXPO_PUBLIC_SNACK_ENV=production node ./web/deploy-script.js"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.3",

--- a/runtime/web/deploy-script.js
+++ b/runtime/web/deploy-script.js
@@ -97,7 +97,9 @@ async function patchFaviconImportPath(options) {
 async function uploadWeb(options) {
   const sdkVersion = semver.major(expoVersion);
   const bucketName =
-    process.env.NODE_ENV === 'production' ? 'snack-web-player' : 'snack-web-player-staging';
+    process.env.EXPO_PUBLIC_SNACK_ENV === 'production'
+      ? 'snack-web-player'
+      : 'snack-web-player-staging';
 
   await spawnAsync(
     'yarn',


### PR DESCRIPTION
# Why

Starting from SDK 50, we are swapping to EAS Updates.

# How

- Updated github workflows to deploy to EAS Update
- Updated package scripts to deploy EAS Update

# Test Plan

TBD, staging.