### PR TITLE
chore(website): update proper env var for snack runtime

### DIFF
--- a/website/deploy/development/snack.env
+++ b/website/deploy/development/snack.env
@@ -13,4 +13,4 @@ LEGACY_SNACK_SERVER_URL=http://snack.expo.io.test
 SNACK_SERVER_URL=http://snack.expo.test
 SNACK_WEBPLAYER_URL=https://snack-web-player-staging.s3.us-west-1.amazonaws.com
 SNACK_WEBPLAYER_CDN=https://d1qt8af2b3kxj0.cloudfront.net
-SNACK_RUNTIME_EAS_ENDPOINT=staging-u.expo.dev/2dce2748-c51f-4865-bae0-392af794d60a
+SNACK_RUNTIME_ENDPOINT=staging-u.expo.dev/2dce2748-c51f-4865-bae0-392af794d60a

--- a/website/deploy/production/snack.env
+++ b/website/deploy/production/snack.env
@@ -11,4 +11,4 @@ SNACK_WEBPLAYER_URL=https://snack-web-player.s3.us-west-1.amazonaws.com
 SNACK_WEBPLAYER_CDN=https://dwmszb351h4q.cloudfront.net
 RUDDERSTACK_WRITE_KEY=1weTlMb720s5AkBTYwgCGORCHHg
 RUDDERSTACK_DATA_PLANE_URL=https://cdp.expo.dev
-SNACK_RUNTIME_EAS_ENDPOINT=u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824
+SNACK_RUNTIME_ENDPOINT=u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824

--- a/website/deploy/staging/snack.env
+++ b/website/deploy/staging/snack.env
@@ -11,4 +11,4 @@ SNACK_WEBPLAYER_URL=https://snack-web-player-staging.s3.us-west-1.amazonaws.com
 SNACK_WEBPLAYER_CDN=https://d1qt8af2b3kxj0.cloudfront.net
 RUDDERSTACK_DATA_PLANE_URL=https://cdp.expo.dev
 RUDDERSTACK_WRITE_KEY=1weTbQObpRMmIsWrdwEITRabLA2
-SNACK_RUNTIME_EAS_ENDPOINT=staging-u.expo.dev/2dce2748-c51f-4865-bae0-392af794d60a
+SNACK_RUNTIME_ENDPOINT=staging-u.expo.dev/2dce2748-c51f-4865-bae0-392af794d60a


### PR DESCRIPTION
# Why

This was renamed, but not in the `.env` files for web.

# How

- Updated

# Test Plan

TBD