### PR TITLE
chore(website): Update Orbit deep link route

### DIFF
--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -66,7 +66,7 @@ export function useOrbit() {
         return;
       }
 
-      const deeplink = `expo-orbit://snack/${experienceURL.replace('exp://', '')}`;
+      const deeplink = `expo-orbit://snack/?url=${encodeURIComponent(experienceURL)}`;
       if (isRunning) {
         const response = await fetchLocalOrbitServer('open', { url: deeplink });
         if (response?.ok) {

--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -66,7 +66,7 @@ export function useOrbit() {
         return;
       }
 
-      const deeplink = `expo-orbit://snack/?url=${encodeURIComponent(experienceURL)}`;
+      const deeplink = `expo-orbit:///snack/?url=${encodeURIComponent(experienceURL)}`;
       if (isRunning) {
         const response = await fetchLocalOrbitServer('open', { url: deeplink });
         if (response?.ok) {

--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -66,14 +66,15 @@ export function useOrbit() {
         return;
       }
 
+      const deeplink = `expo-orbit://snack/${experienceURL.replace('exp://', '')}`;
       if (isRunning) {
-        const response = await fetchLocalOrbitServer('open', { url: experienceURL });
+        const response = await fetchLocalOrbitServer('open', { url: deeplink });
         if (response?.ok) {
           return;
         }
       }
 
-      customProtocolCheck(experienceURL.replace('exp://', 'expo-orbit://'), onFail);
+      customProtocolCheck(deeplink, onFail);
     },
     [isRunning]
   );


### PR DESCRIPTION
# Why

With the new `experienceURL` format Orbit can no longer distinguish an Expo Update from an Snack just by checking the URL, because of that we should use the `/snack` route which is specific for snacks

Closes ENG-11059

# How

Update Orbit deep link route to use `/snack`

# Test Plan

Run snack locally and launch Orbit from the button 

https://github.com/expo/snack/assets/11707729/b4f631c6-ae79-4791-8252-2185997d0e8a