### PR TITLE
refactor(snack-content): use full sdk version in runtime url helpers

### DIFF
--- a/packages/snack-content/package.json
+++ b/packages/snack-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-content",
-  "version": "2.0.0-preview.1",
+  "version": "2.0.0-preview.2",
   "description": "Functions and types that describe the contents of Snack projects",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/snack-content/src/__tests__/urls-test.ts
+++ b/packages/snack-content/src/__tests__/urls-test.ts
@@ -5,32 +5,32 @@ const channel = 'AsZ12sasd11G';
 
 describe(createRuntimeUrl, () => {
   it('returns url with only "sdkVersion"', () => {
-    expect(createRuntimeUrl({ sdkVersion: 69 })).toMatchInlineSnapshot(
+    expect(createRuntimeUrl({ sdkVersion: '69.0.0' })).toMatchInlineSnapshot(
       `"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A69.0.0&channel-name=production"`,
     );
   });
 
   it(`returns url with "sdkVersion" and "snack"`, () => {
-    expect(createRuntimeUrl({ sdkVersion: 69, snack })).toMatchInlineSnapshot(
+    expect(createRuntimeUrl({ sdkVersion: '69.0.0', snack })).toMatchInlineSnapshot(
       `"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A69.0.0&channel-name=production&snack=xxxxxx"`,
     );
   });
 
   it(`returns url with "sdkVersion" and "channel"`, () => {
-    expect(createRuntimeUrl({ sdkVersion: 69, channel })).toMatchInlineSnapshot(
+    expect(createRuntimeUrl({ sdkVersion: '69.0.0', channel })).toMatchInlineSnapshot(
       `"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A69.0.0&channel-name=production&snack-channel=AsZ12sasd11G"`,
     );
   });
 
   it(`returns url with "sdkVersion", "snack", and "channel"`, () => {
-    expect(createRuntimeUrl({ sdkVersion: 69, snack, channel })).toMatchInlineSnapshot(
+    expect(createRuntimeUrl({ sdkVersion: '69.0.0', snack, channel })).toMatchInlineSnapshot(
       `"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A69.0.0&channel-name=production&snack=xxxxxx&snack-channel=AsZ12sasd11G"`,
     );
   });
 
   it(`returns url with "sdkVersion", "snack", and "channel" using custom "endpoint"`, () => {
     expect(
-      createRuntimeUrl({ sdkVersion: 69, snack, channel, endpoint: 'u-dev.expo.test/xxx' }),
+      createRuntimeUrl({ sdkVersion: '69.0.0', snack, channel, endpoint: 'u-dev.expo.test/xxx' }),
     ).toMatchInlineSnapshot(
       `"exp://u-dev.expo.test/xxx?runtime-version=exposdk%3A69.0.0&channel-name=production&snack=xxxxxx&snack-channel=AsZ12sasd11G"`,
     );
@@ -43,7 +43,7 @@ describe(parseRuntimeUrl, () => {
       .toMatchInlineSnapshot(`
       Object {
         "channel": undefined,
-        "sdkVersion": 69,
+        "sdkVersion": "69.0.0",
         "snack": undefined,
       }
     `);
@@ -54,7 +54,7 @@ describe(parseRuntimeUrl, () => {
       .toMatchInlineSnapshot(`
       Object {
         "channel": undefined,
-        "sdkVersion": 69,
+        "sdkVersion": "69.0.0",
         "snack": "snackid",
       }
     `);
@@ -68,7 +68,7 @@ describe(parseRuntimeUrl, () => {
     ).toMatchInlineSnapshot(`
       Object {
         "channel": "channelid",
-        "sdkVersion": 69,
+        "sdkVersion": "69.0.0",
         "snack": undefined,
       }
     `);
@@ -82,7 +82,7 @@ describe(parseRuntimeUrl, () => {
     ).toMatchInlineSnapshot(`
       Object {
         "channel": "channelid",
-        "sdkVersion": 69,
+        "sdkVersion": "69.0.0",
         "snack": "snackid",
       }
     `);

--- a/packages/snack-content/src/urls.ts
+++ b/packages/snack-content/src/urls.ts
@@ -1,6 +1,6 @@
 export type RuntimeUrlInfo = {
-  /** The (major) Expo SDK version that should be loaded */
-  sdkVersion: number;
+  /** The full Expo SDK version that should be loaded */
+  sdkVersion: string;
   /**
    * The unique Snack hash, referring to a saved Snack.
    * This value may conain `[a-zA-Z0-9-_]`, but may not start with `[-_]`.
@@ -35,7 +35,7 @@ export function createRuntimeUrl(options: RuntimeUrlInfo & RuntimeUrlOptions): s
   const parameters = new URLSearchParams();
 
   // Add the EAS Update references, `platform` is added by Expo Go
-  parameters.set('runtime-version', `exposdk:${options.sdkVersion}.0.0`);
+  parameters.set('runtime-version', `exposdk:${options.sdkVersion}`);
   parameters.set('channel-name', 'production');
 
   // Add the Snack reference
@@ -59,14 +59,14 @@ export function parseRuntimeUrl(uri: string | URL): RuntimeUrlInfo | null {
   const snack = url.searchParams.get('snack') ?? undefined;
   const channel = url.searchParams.get('snack-channel') ?? undefined;
   const runtimeVersion = url.searchParams.get('runtime-version');
-  const [, sdkVersion] = runtimeVersion?.match(/exposdk:([0-9]+)\.0\.0/) ?? [];
+  const [, sdkVersion] = runtimeVersion?.match(/exposdk:([0-9]+\.[0-9]+\.[0-9]+)/) ?? [];
 
   if (!sdkVersion) {
     return null;
   }
 
   return {
-    sdkVersion: parseInt(sdkVersion, 10),
+    sdkVersion,
     snack,
     channel,
   };

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -71,7 +71,7 @@
     "nullthrows": "^1.1.1",
     "pubnub": "^7.2.0",
     "semver": "^7.3.4",
-    "snack-content": "~2.0.0-preview.1",
+    "snack-content": "~2.0.0-preview.2",
     "socket.io-client": "~4.5.4",
     "ua-parser-js": "^0.7.22",
     "validate-npm-package-name": "^3.0.0"

--- a/packages/snack-sdk/src/utils.ts
+++ b/packages/snack-sdk/src/utils.ts
@@ -37,8 +37,7 @@ export function createChannel(channel?: string): string {
   return channel;
 }
 
-export function createURL(endpoint: string, version: SDKVersion, channel?: string, id?: string) {
-  const sdkVersion = parseInt(version.split('.')[0], 10);
+export function createURL(endpoint: string, sdkVersion: SDKVersion, channel?: string, id?: string) {
   return createRuntimeUrl({ endpoint, channel, sdkVersion, snack: id });
 }
 

--- a/website/package.json
+++ b/website/package.json
@@ -81,7 +81,7 @@
     "redux": "^4.0.1",
     "sanitize-html": "^1.20.0",
     "snack-babel-standalone": "^3.0.1",
-    "snack-content": "*",
+    "snack-content": "~2.0.0-preview.2",
     "snack-eslint-standalone": "^2.0.0",
     "snack-sdk": "*",
     "validate-npm-package-name": "^3.0.0"


### PR DESCRIPTION
# Why

After implementing this in orbit, this change didn't make sense.

# How

- Use the full SDK version in runtime URL helpers

# Test Plan

See tests
