### PR TITLE
fix(snackager): ensure git is installed and avoid importing files over 10mb

### DIFF
--- a/snackager/Dockerfile
+++ b/snackager/Dockerfile
@@ -64,6 +64,9 @@ RUN yarn turbo build --filter "{./snackager}..." && \
 FROM base
 WORKDIR /app
 
+# Install system dependencies
+RUN apk --no-cache add git openssh-client
+
 # Copy deployment-ready repository
 COPY --from=deploy /app .
 

--- a/snackager/src/utils/convertRepoToSnack.ts
+++ b/snackager/src/utils/convertRepoToSnack.ts
@@ -146,6 +146,12 @@ async function generateFilesObj(dirname: string): Promise<GitSnackFiles> {
 
         const filePath = path.join(dirname, fileName);
 
+        // Skip files larger than 10MB
+        const stat = fs.statSync(filePath);
+        if (stat.size > 10 * 1024 * 1024) {
+          return;
+        }
+
         if (isAsset(filePath)) {
           const formData = new FormData();
           formData.append('asset', fs.createReadStream(filePath), fileName);

--- a/website/src/client/components/Import/ImportRepoModal.tsx
+++ b/website/src/client/components/Import/ImportRepoModal.tsx
@@ -149,12 +149,21 @@ export default class ImportRepoModal extends React.PureComponent<Props, State> {
           <ProgressIndicator duration={45000} className={css(styles.progress)} />
         ) : null}
         <form onSubmit={this._handleImportRepoClick}>
-          <p className={!isError ? css(styles.paragraph) : css(styles.errorParagraph)}>
-            {!isError
-              ? 'Import an Expo project from a Public Git repository.'
-              : 'An error occurred during import. This could be because the data provided was invalid, or because the repository referenced is not a properly formatted Expo project.'}
-          </p>
-          {isError && <p className={css(styles.errorParagraph)}>{error}</p>}
+          {!isError ? (
+            <p className={css(styles.paragraph)}>
+              Import an Expo project from a public git repository. Note, files over 10MB are not
+              imported.
+            </p>
+          ) : (
+            <>
+              <p className={css(styles.errorParagraph)}>
+                An error occurred during import. This could be because the data provided was
+                invalid, or because the repository referenced is not a properly formatted Expo
+                project.
+              </p>
+              <p className={css(styles.errorParagraph)}>{error}</p>
+            </>
+          )}
           {advanced ? (
             <>
               <h4 className={css(styles.subtitle)}>Repository URL</h4>


### PR DESCRIPTION
# Why

Git imports seems to fail now.

# How

- Ensure git is available in Snackager
- Ensure files are lower than `10 * 1024 * 1024` bytes, otherwise skip file

# Test Plan

See staging