### PR TITLE
refactor(website): use icons for the Appetize device controls

### DIFF
--- a/website/src/client/components/DevicePreview/AppetizeDeviceControl.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeDeviceControl.tsx
@@ -13,14 +13,46 @@ type AppetizeActionProps = Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClic
 AppetizeDeviceControl.ReloadSnack = function AppetizeReloadSnack(props: AppetizeActionProps) {
   return (
     <button type="button" className={css(styles.button)} title="Reload Snack" {...props}>
-      Reload
+      <svg
+        width={16}
+        height={16}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2 10C2 10 4.00498 7.26822 5.63384 5.63824C7.26269 4.00827 9.5136 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21C7.89691 21 4.43511 18.2543 3.35177 14.5M2 10V4M2 10H8"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
     </button>
   );
 };
 AppetizeDeviceControl.ShakeDevice = function AppetizeShakeDevice(props: AppetizeActionProps) {
   return (
     <button type="button" className={css(styles.button)} title="Shake device (iOS only)" {...props}>
-      Shake
+      <svg
+        width={16}
+        height={16}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16.7243 19.5043L11.4274 20.9086C10.6467 21.1156 10.2564 21.2191 9.9098 21.1192C9.60492 21.0315 9.32367 20.8369 9.10642 20.5635C8.85942 20.2527 8.73495 19.7931 8.48603 18.8739L5.4637 7.713C5.21478 6.79379 5.09032 6.33417 5.14717 5.9428C5.19717 5.59853 5.34242 5.29091 5.56209 5.06402C5.81182 4.80607 6.20216 4.70258 6.98281 4.49561L12.2797 3.09125C13.0603 2.88427 13.4507 2.78077 13.7973 2.88062C14.1021 2.96843 14.3834 3.16298 14.6006 3.43639C14.8477 3.7472 14.9721 4.2068 15.221 5.12602L18.2434 16.2869C18.4923 17.2061 18.6168 17.6657 18.5599 18.0571C18.5099 18.4013 18.3646 18.709 18.145 18.9358C17.8953 19.1938 17.5049 19.2973 16.7243 19.5043Z"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path d="M2.42859 8.3175L5.8274 20.8686" stroke="currentColor" strokeLinecap="round" />
+        <path d="M1 10.7657L3.35302 19.455" stroke="currentColor" strokeLinecap="round" />
+        <path d="M18.1726 3.31982L21.5714 15.871" stroke="currentColor" strokeLinecap="round" />
+        <path d="M20.647 4.73328L23 13.4225" stroke="currentColor" strokeLinecap="round" />
+      </svg>
     </button>
   );
 };
@@ -28,7 +60,21 @@ AppetizeDeviceControl.ShakeDevice = function AppetizeShakeDevice(props: Appetize
 AppetizeDeviceControl.RotateDevice = function AppetizeRotateDevice(props: AppetizeActionProps) {
   return (
     <button type="button" className={css(styles.button)} title="Rotate device clockwise" {...props}>
-      Rotate
+      <svg
+        width={16}
+        height={16}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 20V18.6C4 15.2397 4 13.5595 4.65396 12.2761C5.2292 11.1471 6.14708 10.2292 7.27606 9.65396C8.55953 9 10.2397 9 13.6 9H20M20 9L15 14M20 9L15 4"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
     </button>
   );
 };
@@ -78,6 +124,7 @@ const styles = StyleSheet.create({
     flex: 0,
     alignItems: 'center',
     justifyContent: 'center',
+    margin: '0 16px',
   },
   button: {
     appearance: 'none',
@@ -86,15 +133,14 @@ const styles = StyleSheet.create({
     borderLeftWidth: 0,
     backgroundColor: c('content'),
     color: c('text'),
-    padding: 8,
+    padding: '8px 12px',
     margin: '16px 0',
     textAlign: 'center',
-    width: 112,
+    height: 34,
 
     ':first-child': {
       borderLeftWidth: 1,
       borderRadius: '3px 0 0 3px',
-      padding: '6px 12px',
     },
 
     ':last-child': {
@@ -105,7 +151,6 @@ const styles = StyleSheet.create({
     ':only-child': {
       borderLeftWidth: 1,
       borderRadius: '3px',
-      padding: '6px 12px',
     },
 
     ':hover': {

--- a/website/src/client/components/DevicePreview/AppetizeDeviceControl.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeDeviceControl.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, css } from 'aphrodite';
-import React, { PropsWithChildren } from 'react';
+import React, { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
 import { useAppetizeDevices } from '../../utils/Appetize';
 import { c } from '../ThemeProvider';
@@ -8,34 +8,42 @@ export function AppetizeDeviceControl({ children }: PropsWithChildren<object>) {
   return <div className={css(styles.container)}>{children}</div>;
 }
 
-AppetizeDeviceControl.ReloadSnack = ReloadSnack;
-AppetizeDeviceControl.SelectDevice = SelectDevice;
+type AppetizeActionProps = Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'disabled'>;
 
-type ReloadSnackProps = {
-  canReloadSnack: boolean;
-  onReloadSnack: () => void;
-};
-
-function ReloadSnack({ onReloadSnack, canReloadSnack }: ReloadSnackProps) {
+AppetizeDeviceControl.ReloadSnack = function AppetizeReloadSnack(props: AppetizeActionProps) {
   return (
-    <button
-      type="button"
-      className={css(styles.button)}
-      onClick={onReloadSnack}
-      disabled={!canReloadSnack}
-    >
-      Reload Snack
+    <button type="button" className={css(styles.button)} title="Reload Snack" {...props}>
+      Reload
     </button>
   );
-}
+};
+AppetizeDeviceControl.ShakeDevice = function AppetizeShakeDevice(props: AppetizeActionProps) {
+  return (
+    <button type="button" className={css(styles.button)} title="Shake device (iOS only)" {...props}>
+      Shake
+    </button>
+  );
+};
 
-type SelectDeviceProps = {
+AppetizeDeviceControl.RotateDevice = function AppetizeRotateDevice(props: AppetizeActionProps) {
+  return (
+    <button type="button" className={css(styles.button)} title="Rotate device clockwise" {...props}>
+      Rotate
+    </button>
+  );
+};
+
+type AppetizeSelectDeviceProps = {
   platform: 'android' | 'ios';
   selectedDevice?: string;
   onSelectDevice?: (device: string) => void;
 };
 
-function SelectDevice({ platform, onSelectDevice, selectedDevice }: SelectDeviceProps) {
+AppetizeDeviceControl.SelectDevice = function AppetizeSelectDevice({
+  platform,
+  onSelectDevice,
+  selectedDevice,
+}: AppetizeSelectDeviceProps) {
   const devices = useAppetizeDevices(platform);
 
   if (!selectedDevice) {
@@ -62,7 +70,7 @@ function SelectDevice({ platform, onSelectDevice, selectedDevice }: SelectDevice
       )}
     </select>
   );
-}
+};
 
 const styles = StyleSheet.create({
   container: {

--- a/website/src/client/components/DevicePreview/AppetizeFrame.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeFrame.tsx
@@ -139,13 +139,17 @@ export class AppetizeFrame extends Component<AppetizeFrameProps, AppetizeFrameSt
     }
   };
 
-  /** Restart Expo Go and reload the Snack, useful in cases of crashes without giving up on queue position */
-  private onReloadSnack = createAppetizeAction(this, 'reload', (session) => session.restartApp());
   /** Shake the device, iOS only unfortunately */
   private onShakeDevice = createAppetizeAction(this, 'shake', (session) => session.shake());
   /** Rotate the device to portrait or landscape */
   private onRotateDevice = createAppetizeAction(this, 'rotate', (session) =>
     session.rotate('right')
+  );
+
+  /** Restart Expo Go and reload the Snack, useful in cases of crashes without giving up on queue position */
+  private onReloadSnack = createAppetizeAction(this, 'reload', (session) =>
+    // Note(cedric): restart app doesn't resolve at the moment, so add a race condition of 5 sec
+    Promise.race([session.restartApp(), new Promise((resolve) => setTimeout(resolve, 5000))])
   );
 
   /** Use another device instance to preview Snack */
@@ -249,7 +253,7 @@ function createAppetizeAction(
     if (component.state.session && !component.state.deviceControlState) {
       component.setState({ deviceControlState: name });
 
-      action(component.state.session).finally(() =>
+      Promise.resolve(action(component.state.session)).finally(() =>
         component.setState({ deviceControlState: undefined })
       );
     }

--- a/website/src/client/components/DevicePreview/AppetizeFrame.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeFrame.tsx
@@ -86,6 +86,10 @@ export class AppetizeFrame extends Component<AppetizeFrameProps, AppetizeFrameSt
       this.resetAppetizeClient(config);
       this.props.onPopupUrl?.(resolveAppetizePopupUrl(config));
     }
+
+    if (this.state.deviceId && prevProps.platform !== this.props.platform) {
+      this.setState({ deviceId: undefined });
+    }
   }
 
   /** Initialize the Appetize SDK client */

--- a/website/src/client/components/DevicePreview/AppetizeFrame.tsx
+++ b/website/src/client/components/DevicePreview/AppetizeFrame.tsx
@@ -41,9 +41,8 @@ type AppetizeFrameProps = {
 type AppetizeFrameState = {
   session?: AppetizeSdkSession;
   deviceId?: string;
-  queuePosition?: number;
   sentQueueInfo?: boolean;
-  isReloadingSnack?: boolean;
+  deviceControlState?: string;
 };
 
 export class AppetizeFrame extends Component<AppetizeFrameProps, AppetizeFrameState> {
@@ -52,10 +51,12 @@ export class AppetizeFrame extends Component<AppetizeFrameProps, AppetizeFrameSt
   /** The iframe ref, to reopen as a popup */
   private iframe = createRef<HTMLIFrameElement>();
 
-  constructor(props: AppetizeFrameProps) {
-    super(props);
-    this.state = {}; // Note(cedric): this is somehow required...
-  }
+  state: AppetizeFrameState = {
+    session: undefined,
+    deviceId: undefined,
+    sentQueueInfo: false,
+    deviceControlState: undefined,
+  };
 
   componentDidMount() {
     // Load the Appetize client and setup initial bindings
@@ -138,35 +139,51 @@ export class AppetizeFrame extends Component<AppetizeFrameProps, AppetizeFrameSt
     }
   };
 
-  private onReloadSnack = () => {
-    if (this.state.session) {
-      this.setState({ isReloadingSnack: true });
-      this.state.session.restartApp().finally(() => this.setState({ isReloadingSnack: false }));
-    }
-  };
+  /** Restart Expo Go and reload the Snack, useful in cases of crashes without giving up on queue position */
+  private onReloadSnack = createAppetizeAction(this, 'reload', (session) => session.restartApp());
+  /** Shake the device, iOS only unfortunately */
+  private onShakeDevice = createAppetizeAction(this, 'shake', (session) => session.shake());
+  /** Rotate the device to portrait or landscape */
+  private onRotateDevice = createAppetizeAction(this, 'rotate', (session) =>
+    session.rotate('right')
+  );
 
+  /** Use another device instance to preview Snack */
   private onDeviceChange = (deviceId: string) => this.setState({ deviceId });
 
   render() {
+    const { platform, isEmbedded } = this.props;
+    const { session, deviceId, deviceControlState } = this.state;
+
+    const deviceControlDisabled = !session || !!deviceControlState;
+
     return (
       <>
-        <div className={css(this.props.isEmbedded ? styles.containerEmbedded : styles.container)}>
+        <div className={css(isEmbedded ? styles.containerEmbedded : styles.container)}>
           <iframe
             id="snack-appetize"
             ref={this.iframe}
-            className={css(styles.frame, this.props.isEmbedded && { padding: '8px 0' })}
+            className={css(styles.frame, isEmbedded && { padding: '8px 0' })}
           />
         </div>
 
-        {!this.props.isEmbedded && (
+        {!isEmbedded && (
           <AppetizeDeviceControl>
             <AppetizeDeviceControl.ReloadSnack
-              onReloadSnack={this.onReloadSnack}
-              canReloadSnack={!!this.state.session && !this.state.isReloadingSnack}
+              onClick={this.onReloadSnack}
+              disabled={deviceControlDisabled}
+            />
+            <AppetizeDeviceControl.ShakeDevice
+              onClick={this.onShakeDevice}
+              disabled={deviceControlDisabled || platform !== 'ios'}
+            />
+            <AppetizeDeviceControl.RotateDevice
+              onClick={this.onRotateDevice}
+              disabled={deviceControlDisabled}
             />
             <AppetizeDeviceControl.SelectDevice
-              platform={this.props.platform}
-              selectedDevice={this.state.deviceId}
+              platform={platform}
+              selectedDevice={deviceId}
               onSelectDevice={this.onDeviceChange}
             />
           </AppetizeDeviceControl>
@@ -221,6 +238,22 @@ function resolveAppetizePopupUrl(config: AppetizeSdkConfig) {
   url.searchParams.set('centered', config.centered!);
 
   return url.toString();
+}
+
+function createAppetizeAction(
+  component: InstanceType<typeof AppetizeFrame>,
+  name: string,
+  action: (session: AppetizeSdkSession) => Promise<any>
+) {
+  return () => {
+    if (component.state.session && !component.state.deviceControlState) {
+      component.setState({ deviceControlState: name });
+
+      action(component.state.session).finally(() =>
+        component.setState({ deviceControlState: undefined })
+      );
+    }
+  };
 }
 
 const styles = StyleSheet.create({

--- a/website/src/server/components/AppetizeScript.tsx
+++ b/website/src/server/components/AppetizeScript.tsx
@@ -93,6 +93,12 @@ declare global {
     /** @see https://docs.appetize.io/javascript-sdk/api-reference#restartapp */
     restartApp(): Promise<void>;
 
+    /** @see https://docs.appetize.io/javascript-sdk/api-reference#shake */
+    shake(): Promise<void>;
+
+    /** @see https://docs.appetize.io/javascript-sdk/api-reference#rotate */
+    rotate(direction: 'left' | 'right'): Promise<void>;
+
     /** @see https://docs.appetize.io/javascript-sdk/api-reference#end */
     end(): Promise<void>;
   }


### PR DESCRIPTION
# Why

This is the final stacked PR to finalize the new Appetize integration. See #558.

<details><summary>See screenshot</summary>

![screenshot](https://github.com/expo/snack/assets/1203991/2e5735a8-fe2b-4f1b-8e80-354cbd04f5ae)

</details>

# How

- Added "reload", "shake", and "rotate" device controls
- Added icons for each individual controls

# Test Plan

See staging.
