### PR TITLE
fix(website): allow log/error panel to open

### DIFF
--- a/website/src/client/components/EditorView.tsx
+++ b/website/src/client/components/EditorView.tsx
@@ -790,6 +790,8 @@ export default withPreferences(
 
 const styles = StyleSheet.create({
   panelContainer: {
+    display: 'flex',
+    flexDirection: 'column',
     width: '100%',
     height: '100%',
   },


### PR DESCRIPTION
# Why

Fixes #567 

# How

- Auto shrink the editor when opening the log/error panel

# Test Plan

See staging
