### PR TITLE
chore(ci): Google Cloud Workload Identity Federation

### DIFF
--- a/.github/actions/setup-google-cloud/action.yml
+++ b/.github/actions/setup-google-cloud/action.yml
@@ -2,53 +2,33 @@ name: Setup Google Cloud SDK
 description: Prepare Google Cloud SDK in GitHub Actions
 
 inputs:
-  project-id:
-    description: Google Cloud SDK project id
-    default: exponentjs
-
-  project-zone:
-    description: Google Cloud SDK compute zone
-    default: us-central1
-
-  project-cluster:
-    description: Google Cloud SDK container cluster
-    default: general-central
-
-  service-key:
-    description: Google Cloud SDK service_account_key
+  auth:
+    description: If it should authenticate with Google Cloud and the Kubernetes cluster
     default: ''
-
-  export-default-credentials:
-    type: boolean
-    description: If it should export the default credentials
-    default: true
+    required: false
 
 runs:
   using: composite
   steps:
-    - name: 🏗 Setup Google Cloud SDK with auth
-      if: ${{ inputs.service-key != '' }}
-      uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+    - name: 🏗 Authenticate to Google Cloud
+      if: ${{ inputs.auth != '' }}
+      uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c
       with:
-        project_id: ${{ inputs.project-id }}
-        service_account_key: ${{ inputs.service-key }}
-        export_default_credentials: ${{ inputs.export-default-credentials }}
+        project_id: exponentjs
+        workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
-    - name: 🏗 Setup Google Cloud SDK without auth
-      if: ${{ inputs.service-key == '' }}
-      uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
-
-    - name: 📦 Install Google Cloud SDK components
-      run: gcloud components install kubectl kustomize skaffold
-      shell: bash
+    - name: 📦 Setup Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200
+      with:
+        install_components: kubectl,kustomize,skaffold
 
     - name: ⚙️ Configure Google Cloud SDK
-      if: ${{ inputs.service-key != '' }}
+      if: ${{ inputs.auth != '' }}
       run: |
-        gcloud config set project ${{ inputs.project-id }}
-        gcloud config set compute/zone ${{ inputs.project-zone }}
-        gcloud config set run/region ${{ inputs.project-zone }}
-        gcloud config set container/cluster ${{ inputs.project-cluster }}
-        gcloud container clusters get-credentials ${{ inputs.project-cluster }}
+        gcloud config set project exponentjs
+        gcloud config set compute/zone us-central1
+        gcloud config set run/region us-central1
+        gcloud config set container/cluster general-central
+        gcloud container clusters get-credentials general-central
         gcloud auth configure-docker us-central1-docker.pkg.dev
       shell: bash

--- a/.github/workflows/snackager.yml
+++ b/.github/workflows/snackager.yml
@@ -86,6 +86,9 @@ jobs:
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -93,10 +96,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
@@ -106,6 +106,9 @@ jobs:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: snackager-staging
       url: https://staging.snackager.expo.io/status
@@ -116,10 +119,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json
@@ -152,6 +152,9 @@ jobs:
     if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: snackager-production
       url: https://snackager.expo.io/status
@@ -162,10 +165,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackager
         run: skaffold build --filename snackager/skaffold.yaml --file-output snackager/build.json

--- a/.github/workflows/snackpub.yml
+++ b/.github/workflows/snackpub.yml
@@ -60,6 +60,9 @@ jobs:
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -67,10 +70,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackpub
         run: skaffold build --filename snackpub/skaffold.yaml
@@ -80,6 +80,9 @@ jobs:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: snackpub-staging
     steps:
@@ -89,10 +92,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackpub
         run: skaffold build --filename snackpub/skaffold.yaml --file-output /tmp/build.json
@@ -121,6 +121,9 @@ jobs:
     if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: snackpub-production
     steps:
@@ -130,10 +133,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build snackpub
         run: skaffold build --filename snackpub/skaffold.yaml --file-output /tmp/build.json

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -64,6 +64,9 @@ jobs:
   build:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: 🏗 Setup repository
         uses: actions/checkout@v3
@@ -71,10 +74,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build website
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json
@@ -100,6 +100,9 @@ jobs:
     if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: website-staging
       url: https://staging-snack.expo.dev
@@ -110,10 +113,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build website
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json
@@ -146,6 +146,9 @@ jobs:
     if: ${{ github.event.inputs.deploy == 'production' && github.ref == 'refs/heads/main' }}
     needs: review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: website-production
       url: https://snack.expo.dev
@@ -156,10 +159,7 @@ jobs:
       - name: 🏗 Setup Google Cloud SDK
         uses: ./.github/actions/setup-google-cloud
         with:
-          project-id: exponentjs
-          project-zone: us-central1
-          project-cluster: general-central
-          service-key: ${{ secrets.SNACK_GCLOUD_KEY }}
+          auth: true
 
       - name: 🛠 Build website
         run: skaffold build --filename website/skaffold.yaml --file-output website/build.json


### PR DESCRIPTION
# Why

I hope this will let us remove the service account key from our GitHub Actions secrets.
<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# Test Plan

I was able to succesfully deploy snackager to staging, which suggests the other deployments will work too. https://github.com/expo/snack/actions/runs/8271897475/job/22632693926?pr=570
<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
