### PR TITLE
feature(website): Enable Orbit button on Windows and Linux

### DIFF
--- a/website/src/client/utils/orbit.ts
+++ b/website/src/client/utils/orbit.ts
@@ -80,17 +80,15 @@ export function useOrbit() {
   );
 
   useEffect(() => {
-    if (isRunningMacOS) {
-      fetchLocalOrbitServer('status')
-        .then((r) => {
-          setIsRunning(!!r?.version);
-        })
-        .catch(() => {});
-    }
-  }, [isRunningMacOS]);
+    fetchLocalOrbitServer('status')
+      .then((r) => {
+        setIsRunning(!!r?.version);
+      })
+      .catch(() => {});
+  }, []);
 
   return {
-    isEnabled: isRunningMacOS,
+    isEnabled: isRunningMacOS || isRunning,
     openWithExperienceURL,
   };
 }


### PR DESCRIPTION
# Why

With the Orbit [Windows Preview 1](https://github.com/expo/orbit/releases/tag/expo-orbit-v2.0.0-preview.1) now available, users can run Orbit on Windows and soon will be able to run it on Linux as well.  

# How

Update the `useOrbit` logic to: on macOS always display the "Open with Orbit" button and other other platforms check if Orbit is running and then display the button

# Test Plan

On Windows with Orbit running in the background

<img width="1662" alt="image" src="https://github.com/expo/snack/assets/11707729/246b667d-6000-4bd0-8e7c-fc3f3cf4123a">


On Windows with Orbit closed 

<img width="1519" alt="image" src="https://github.com/expo/snack/assets/11707729/1ff2c2cd-a094-46e4-ac7e-1e81aeab741e">


