### PR TITLE
fix: vendor `expo-modules-core` from Snack Runtime

### DIFF
--- a/packages/snack-content/src/sdks/index.ts
+++ b/packages/snack-content/src/sdks/index.ts
@@ -99,6 +99,7 @@ const sdks: { [version: string]: SDKSpec } = {
       'expo-constants': '*',
       'expo-file-system': '*',
       'expo-updates': '*',
+      'expo-modules-core': '*',
       '@react-native-async-storage/async-storage': '*',
       'react-native-reanimated': '*',
       'expo-router': '*',

--- a/packages/snack-runtime/src/aliases/common.tsx
+++ b/packages/snack-runtime/src/aliases/common.tsx
@@ -17,6 +17,9 @@ const aliases: { [key: string]: any } = {
   'react-native-vector-icons': require('@expo/vector-icons'),
   '@expo/vector-icons': require('@expo/vector-icons'),
 
+  // Snackager can't bundle expo-modules-core, so we vendor it instead
+  'expo-modules-core': require('expo-modules-core'),
+
   // Packages that are used internally by the runtime
   'expo-constants': require('expo-constants'),
   'expo-file-system': require('expo-file-system'),

--- a/runtime/src/aliases/common.tsx
+++ b/runtime/src/aliases/common.tsx
@@ -23,6 +23,9 @@ const aliases: { [key: string]: any } = {
   'expo-updates': require('expo-updates'),
   '@react-native-async-storage/async-storage': require('@react-native-async-storage/async-storage'),
 
+  // Snackager can't bundle expo-modules-core, so we vendor it instead
+  'expo-modules-core': require('expo-modules-core'),
+
   // Renamed `@react-native-community` packages
   '@react-native-community/async-storage': require('@react-native-async-storage/async-storage'),
 

--- a/snackager/src/bundler/externals.ts
+++ b/snackager/src/bundler/externals.ts
@@ -12,6 +12,7 @@ const CORE_EXTERNALS = [
   'react-native-windows',
   'react-dom',
   'expo',
+  'expo-modules-core',
   '@unimodules/core',
   '@unimodules/react-native-adapter',
   'unimodules-permissions-interface',


### PR DESCRIPTION
# Why

Expo modules core is importing `crypto` in one of its files, which causes Snackager to panic. This vendors `expo-modules-core` and keeps it out of Snackager's list of problems.

# How

- Marked `expo-modules-core` as external in Snackager
- Alias `expo-modules-core` in Runtime
- Alias `expo-modules-core` in Snack Runtime (custom)

# Test Plan

`expo-symbols` seems to be compilable by Snackager now! https://github.com/expo/snack/actions/runs/8852447955/job/24311170804