### PR TITLE
refactor(snack-content): set SDK 51 as default

### DIFF
--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,7 +1,7 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '50.0.0';
+export const defaultSdkVersion: SDKVersion = '51.0.0';
 
 // Mostly used for tests
-export const oldestSdkVersion: SDKVersion = '48.0.0';
-export const newestSdkVersion: SDKVersion = '50.0.0';
+export const oldestSdkVersion: SDKVersion = '49.0.0';
+export const newestSdkVersion: SDKVersion = '51.0.0';


### PR DESCRIPTION
# Why

This should be the default when the blog post is released.

# How

- Configured SDK 51 as default through `snack-content`.

# Test Plan

See staging
