### PR TITLE
fix(runtime): vendor `expo-modules-core` for SDK 49

### DIFF
--- a/runtime/app.config.js
+++ b/runtime/app.config.js
@@ -2,6 +2,7 @@ export default ({ config }) => {
   return {
     ...config,
     extra: {
+      ...config.extra,
       cloudEnv: process.env.CLOUD_ENV,
     },
   };

--- a/runtime/app.json
+++ b/runtime/app.json
@@ -21,12 +21,20 @@
     },
     "platforms": ["android", "ios", "web"],
     "assetBundlePatterns": ["**/*"],
-    "updates": {
-      "useClassicUpdates": true
-    },
     "web": {
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824"
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "933fd9c0-1666-11e7-afca-d980795c5824"
+      }
     }
   }
 }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -45,6 +45,7 @@
     "path": "^0.12.7",
     "prop-types": "^15.7.2",
     "pubnub": "^7.2.0",
+    "query-string": "^7.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.4",

--- a/runtime/src/UrlUtils.ts
+++ b/runtime/src/UrlUtils.ts
@@ -1,5 +1,30 @@
-export function parseExperienceURL(
-  experienceURL: string
+import { parse as parseQueryString } from 'query-string';
+
+/**
+ * Parse the query parameters of the URL to extract the channel, and optional test transport.
+ * Note, this is backported and should not be used in new code.
+ */
+export function parseExperienceURL(url: string) {
+  try {
+    const qs = parseQueryString(url.split('?')[1] || '');
+    if (qs['snack-channel']) {
+      return {
+        channel: qs['snack-channel'] as string,
+        testTransport: qs['testTransport'] as string | null,
+      };
+    }
+  } catch {
+    // Pass through
+  }
+
+  return null;
+}
+
+/**
+ * @deprecated This format of URLs is being phased out
+ */
+export function parseClassicExperienceURL(
+  experienceURL: string,
 ): { channel: string; testTransport: string | null } | null {
   const matches = experienceURL.match(/(\+|\/sdk\..*-)([^?]*)\??(.*$)/);
   if (!matches) {

--- a/runtime/src/aliases/common.tsx
+++ b/runtime/src/aliases/common.tsx
@@ -23,6 +23,9 @@ const aliases: { [key: string]: any } = {
   'expo-updates': require('expo-updates'),
   '@react-native-async-storage/async-storage': require('@react-native-async-storage/async-storage'),
 
+  // Snackager can't bundle expo-modules-core, so we vendor it instead
+  'expo-modules-core': require('expo-modules-core'),
+
   // Renamed `@react-native-community` packages
   '@react-native-community/async-storage': require('@react-native-async-storage/async-storage'),
 


### PR DESCRIPTION
# Why

Since we recently switched to vendoring Expo Modules Core, Snackager externalizes `expo-modules-core` now. This works well, and since older SDK packages are cached and served from cache, this also works on older SDK 49.

Unfortunately, one of our partners used a newer package on an older runtime, which triggered an error related to this. This fixes that.

# How

- Added `expo-modules-core` to runtime as vendored module

# Test Plan

TBD