### PR TITLE
fix(snackager): avoid incorrect externals when bundling modules

### DIFF
--- a/snackager/src/bundler/makeConfig.ts
+++ b/snackager/src/bundler/makeConfig.ts
@@ -58,12 +58,11 @@ export default ({
       rules: [
         {
           test: /\.[cm]?(js|tsx?)$/,
-          parser: { requireEnsure: false },
-        },
-        {
-          test: /\.mjs/,
           type: 'javascript/auto',
-          resolve: { fullySpecified: false },
+          parser: {
+            requireEnsure: false,
+            fullySpecified: false,
+          },
         },
         {
           test: /\.[cm]?(js|tsx?)$/,


### PR DESCRIPTION
# Why

This should fix the wrong externals that [`@react-navigation/native@7.0.0-rc.12` is getting](https://github.com/expo/snack/actions/runs/9894635109/job/27332602658#step:4:215).

# How

- Combined legacy `.mjs` support with new `.mjs` and `.cjs` support.
- Marked modules as not fully specified (adds extensions to the imports)

# Test Plan

See staging and:

- `$ cd ./snackager`
- `$ yarn bundle @react-navigation/native@7.0.0-rc.12 | yarn bunyan`
- Should not output extraneous externals:
  <img width="362" alt="image" src="https://github.com/user-attachments/assets/5073c66c-f417-4b68-baa7-a4af6971c8c6">
