### PR TITLE
fix(website): update sidebar shortcut key combo to `⌘/ Ctrl + B`

### DIFF
--- a/website/src/client/components/KeyboardShortcuts.tsx
+++ b/website/src/client/components/KeyboardShortcuts.tsx
@@ -16,7 +16,7 @@ export const Shortcuts = {
   },
   tree: {
     description: 'Toggle sidebar',
-    combo: [KeyMap.Meta, KeyMap.Backslash],
+    combo: [KeyMap.Meta, KeyMap.B],
   },
   panels: {
     description: 'Toggle error and log panels',

--- a/website/src/client/components/shared/KeybindingsManager.tsx
+++ b/website/src/client/components/shared/KeybindingsManager.tsx
@@ -8,6 +8,7 @@ type Props<T extends { combo: number[] }> = {
 const isMac = 'navigator' in global && /Mac/i.test(navigator.platform);
 
 export const KeyMap = {
+  B: 66,
   C: 67,
   D: 68,
   F: 70,
@@ -23,7 +24,6 @@ export const KeyMap = {
   Alt: 18,
   Cmd: 91,
   Tilde: 192,
-  Backslash: 220,
   Meta: isMac ? 91 : 17,
 };
 


### PR DESCRIPTION
# Why

Align the toggling of sidebar shortcut with `Cmd/Ctrl + B` for consistency and familiar experience with other code editors.

# How

Modified KeyMap.

# Test Plan

Verify in staging.
