### PR TITLE
fix(website): use proper secured settings for `snack-values` cookie

### DIFF
--- a/website/src/server/utils/getSplitTests.tsx
+++ b/website/src/server/utils/getSplitTests.tsx
@@ -47,6 +47,13 @@ export default async (ctx: Context) => {
     ...existingSettings,
   };
 
-  ctx.res.setHeader('Set-Cookie', cookie.serialize(SNACK_COOKIE_NAME, JSON.stringify(newValues)));
+  ctx.res.setHeader(
+    'Set-Cookie',
+    cookie.serialize(SNACK_COOKIE_NAME, JSON.stringify(newValues), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    })
+  );
   return newValues;
 };


### PR DESCRIPTION
# Why

Fixes ENG-12877

Update the security settings for `snack-values`, which only contains a few global properties for the UI.

# How

Added proper options for the cookie.

# Test Plan

See staging.