### PR TITLE
chore(runtime): Migrate from activateKeepAwake to activateKeepAwakeAsync

### DIFF
--- a/packages/snack-runtime/src/App.tsx
+++ b/packages/snack-runtime/src/App.tsx
@@ -1,7 +1,7 @@
 import './polyfill';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { activateKeepAwake } from 'expo-keep-awake';
+import { activateKeepAwakeAsync } from 'expo-keep-awake';
 import { StatusBar } from 'expo-status-bar';
 import * as React from 'react';
 import {
@@ -149,7 +149,7 @@ export default class App extends React.Component<Props, State> {
     this._listenForUpdates(deviceId);
 
     // Keep the device awake so the user doesn't have to keep waking it while coding
-    activateKeepAwake();
+    activateKeepAwakeAsync();
 
     // If we have an entry point file already, we can load now
     if (Files.get(Files.entry())) {

--- a/runtime/src/App.tsx
+++ b/runtime/src/App.tsx
@@ -1,7 +1,7 @@
 import './polyfill';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { activateKeepAwake } from 'expo-keep-awake';
+import { activateKeepAwakeAsync } from 'expo-keep-awake';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
 import * as React from 'react';
@@ -106,7 +106,7 @@ export default class App extends React.Component<object, State> {
     this._listenForUpdates(deviceId);
 
     // Keep the device awake so the user doesn't have to keep waking it while coding
-    activateKeepAwake();
+    activateKeepAwakeAsync();
 
     // If we have an entry point file already, we can load now
     if (Files.get(Files.entry())) {


### PR DESCRIPTION
# Why

When playing with some snacks, I was spotting this getting logged to the console - `Chrome:
`activateKeepAwake` is deprecated. Use `activateKeepAwakeAsync` instead.` so I thought it would be helpful if I open a PR to resolve the deprecation notice,

**Replication steps**: 

https://github.com/user-attachments/assets/99d56215-803b-440f-8c79-68ae8d5b349f

# How

This was a simple search and replace PR :)

# Test Plan

I was not able to fully test this, as I not able to get the local web-player running locally within the Expo Snack website :(
I tried running `runtime` and `runtime-shell` with port `19006`  and although they were running locally, noting was being rendered, and I was getting 404 errors for `http://snack.expo.test/index.bundle?platform=web&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.baseUrl=%2Fv2%2F51&transform.routerRoot=app`