### PR TITLE
fix(website): allow mutating type definitions for libraries to workaround legacy typescript issues

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -97,7 +97,7 @@ jobs:
         run: kustomize build deploy/production
 
   deploy-staging:
-    if: ${{ (github.event.inputs.deploy == 'staging' && github.event_name != 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event.inputs.deploy == 'staging') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     needs: review
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# Why

This is a workaround for `react-native-safe-area-context` type definitions not being able to render properly.

The original error triggered:

![image](https://github.com/user-attachments/assets/1f83fd3f-2965-4d8c-b2cb-2a28cf145b5a)

Which is incorrect, as `SafeAreaView` is a correct type.

# How

- Force-mutate the loaded type definitions for `react-native-safe-area-context`

# Test Plan

See staging

![image](https://github.com/user-attachments/assets/5a64f119-c789-4b3e-817b-665c2e5f4a55)
