### PR TITLE
[infra] Use new Cloud Memorystore host.

### DIFF
--- a/snackager/k8s/production/external-secret-env.yaml
+++ b/snackager/k8s/production/external-secret-env.yaml
@@ -14,4 +14,4 @@ spec:
   dataFrom:
   - extract:
       key: production__snack__snackager__env
-      version: "1"
+      version: "2"

--- a/snackager/scripts/port-forward-redis
+++ b/snackager/scripts/port-forward-redis
@@ -39,7 +39,7 @@ case "$environment" in
     snackager_cache_memorystore_ip="10.81.199.227"
     ;;
   production)
-    snackager_cache_memorystore_ip="10.144.221.51"
+    snackager_cache_memorystore_ip="10.241.107.196"
     ;;
   *)
     echo "Error: unknown environment: $environment" >&2


### PR DESCRIPTION
# Why

We're upgrading our Redis infrastructure.

# How

- Updated the host IP in the `port-forward-redis` script.
- Updated the secret version for snackager env.
