### PR TITLE
chore: force-overwrite Appetize binary for empty `appVersionName`

### DIFF
--- a/.github/workflows/appetize.yml
+++ b/.github/workflows/appetize.yml
@@ -141,7 +141,16 @@ jobs:
         if: ${{ steps.appetize.outputs.oldVersion != matrix.androidVersion }}
         # This step MUST NOT output anything, the endpoint returns the public and private app keys
         run: |
-          curl --silent --fail --http1.1 https://api.appetize.io/v1/apps/$APP -H "X-API-KEY: $TOKEN" -F "file=@exponent-android.apk" -F "platform=android" > /dev/null
+          curl --silent --fail -X POST https://api.appetize.io/v1/apps/$APP -H "X-API-KEY: $TOKEN" \
+            -F "file=@exponent-android.apk" \
+            -F "platform=android" \
+            -F "note=Expo Go for SDK ${{ matrix.sdkVersion }}" \
+            -F "buttonText=Launch Snack" \
+            -F "preLaunchButtonBackgroundColor=#000000" \
+            -F "preLaunchButtonBackgroundOpacity=1" \
+            -F "postSessionButtonText=Launch Snack" \
+            -F "postSessionButtonBackgroundColor=#000000" \
+            -F "postSessionButtonBackgroundOpacity=1" > /dev/null
           rm -rf exponent-android.apk appetize.json
         env:
           TOKEN: ${{ secrets[matrix.appetizeTokenName] }}
@@ -197,7 +206,16 @@ jobs:
         if: ${{ steps.appetize.outputs.oldVersion != matrix.iosVersion }}
         # This step MUST NOT output anything, the endpoint returns the public and private app keys
         run: |
-          curl --silent --fail --http1.1 https://api.appetize.io/v1/apps/$APP -H "X-API-KEY: $TOKEN" -F "file=@exponent-ios.zip" -F "platform=ios" > /dev/null
+          curl --silent --fail -X POST https://api.appetize.io/v1/apps/$APP -H "X-API-KEY: $TOKEN" \
+            -F "file=@exponent-ios.zip" \
+            -F "platform=ios" \
+            -F "note=Expo Go for SDK ${{ matrix.sdkVersion }}" \
+            -F "buttonText=Launch Snack" \
+            -F "preLaunchButtonBackgroundColor=#000000" \
+            -F "preLaunchButtonBackgroundOpacity=1" \
+            -F "postSessionButtonText=Launch Snack" \
+            -F "postSessionButtonBackgroundColor=#000000" \
+            -F "postSessionButtonBackgroundOpacity=1" > /dev/null
           rm -rf exponent-ios.zip appetize.json
         env:
           TOKEN: ${{ secrets[matrix.appetizeTokenName] }}


### PR DESCRIPTION
# Why

This indicates the app binary is broken, and should be overwritten.

# How

- Changed the authentication mechanism to documented API: https://docs.appetize.io/rest-api/update-existing-app
- Force-overwrite the app binary when no `appVersionName` is present
- Also update additional properties to make upgrading easier

# Test Plan

See CI
