### PR TITLE
chore(snack-content): default to Expo SDK 54 when creating new snacks

### DIFF
--- a/packages/snack-content/src/defaults.ts
+++ b/packages/snack-content/src/defaults.ts
@@ -1,6 +1,6 @@
 import { SDKVersion } from './types';
 
-export const defaultSdkVersion: SDKVersion = '53.0.0';
+export const defaultSdkVersion: SDKVersion = '54.0.0';
 
 // Mostly used for tests
 export const oldestSdkVersion: SDKVersion = '50.0.0';

--- a/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/dependencies-test.ts.snap
@@ -12,7 +12,7 @@ Object {
   },
   "expo-font": Object {
     "version": "8.1.0",
-    "wantedVersion": "~13.3.1",
+    "wantedVersion": "~14.0.7",
   },
   "react-native-paper": Object {
     "handle": "snackager-1/react-native-paper@3.10.1",
@@ -108,27 +108,27 @@ Object {
       "@react-navigation/stack",
       "@react-navigation/drawer",
     ],
-    "wantedVersion": "~2.24.0",
+    "wantedVersion": "~2.28.0",
   },
   "react-native-reanimated": Object {
     "dependents": Array [
       "@react-navigation/drawer",
     ],
-    "wantedVersion": "~3.17.4",
+    "wantedVersion": "~4.1.0",
   },
   "react-native-safe-area-context": Object {
     "dependents": Array [
       "@react-navigation/stack",
       "@react-navigation/drawer",
     ],
-    "wantedVersion": "5.4.0",
+    "wantedVersion": "~5.6.0",
   },
   "react-native-screens": Object {
     "dependents": Array [
       "@react-navigation/stack",
       "@react-navigation/drawer",
     ],
-    "wantedVersion": "~4.10.0",
+    "wantedVersion": "~4.16.0",
   },
 }
 `;
@@ -136,8 +136,8 @@ Object {
 exports[`dependencies resolves * after enabling 1`] = `
 Object {
   "expo-constants": Object {
-    "version": "~17.1.5",
-    "wantedVersion": "~17.1.5",
+    "version": "~18.0.7",
+    "wantedVersion": "~18.0.7",
   },
 }
 `;
@@ -145,8 +145,8 @@ Object {
 exports[`dependencies resolves * to wanted version 1`] = `
 Object {
   "expo-constants": Object {
-    "version": "~17.1.5",
-    "wantedVersion": "~17.1.5",
+    "version": "~18.0.7",
+    "wantedVersion": "~18.0.7",
   },
 }
 `;
@@ -176,7 +176,7 @@ Object {
   },
   "expo-font": Object {
     "version": "~10.0.4",
-    "wantedVersion": "~13.3.1",
+    "wantedVersion": "~14.0.7",
   },
   "react-native-paper": Object {
     "handle": "snackager-1/react-native-paper@3.10.1",
@@ -198,7 +198,7 @@ Object {
       "react-native-gesture-handler": "1.6.0",
     },
     "version": "1.6.0",
-    "wantedVersion": "~2.24.0",
+    "wantedVersion": "~2.28.0",
   },
 }
 `;
@@ -206,9 +206,9 @@ Object {
 exports[`dependencies updates preloaded module version when changing SDK version 1`] = `
 Object {
   "expo-av": Object {
-    "error": [Error: Failed to resolve dependency 'expo-av@~15.1.4' (Package 'expo-av@~15.1.4' not found in the registry)],
-    "version": "~15.1.4",
-    "wantedVersion": "~15.1.4",
+    "error": [Error: Failed to resolve dependency 'expo-av@~16.0.6' (Package 'expo-av@~16.0.6' not found in the registry)],
+    "version": "~16.0.6",
+    "wantedVersion": "~16.0.6",
   },
 }
 `;
@@ -216,9 +216,9 @@ Object {
 exports[`dependencies updates preloaded module version when changing SDK version 2`] = `
 Object {
   "expo-av": Object {
-    "error": [Error: Failed to resolve dependency 'expo-av@~15.1.4' (Package 'expo-av@~15.1.4' not found in the registry)],
-    "version": "~16.0.6",
-    "wantedVersion": "~16.0.6",
+    "error": [Error: Failed to resolve dependency 'expo-av@~16.0.6' (Package 'expo-av@~16.0.6' not found in the registry)],
+    "version": "~13.10.5",
+    "wantedVersion": "~13.10.5",
   },
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -4,7 +4,7 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
 Object {
   "data": Blob {
     "config": Array [
-      "{\\"session\\":{\\"url\\":\\"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A53.0.0&channel-name=production&snack-channel=10spnBnPxi\\"}}",
+      "{\\"session\\":{\\"url\\":\\"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A54.0.0&channel-name=production&snack-channel=10spnBnPxi\\"}}",
     ],
   },
   "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",

--- a/packages/snack-sdk/src/__tests__/dependencies-test.ts
+++ b/packages/snack-sdk/src/__tests__/dependencies-test.ts
@@ -5,7 +5,7 @@ import Snack from './snack-sdk';
 
 // A set of SDK versions to test against.
 // When upgrading SDK version, make sure to update this list.
-const sdkVersions: { [key: string]: SDKVersion } = {
+const sdkVersions: Record<'prev' | 'current' | 'next', SDKVersion> = {
   prev: oldestSdkVersion,
   current: defaultSdkVersion,
   next: newestSdkVersion,
@@ -248,7 +248,7 @@ describe('dependencies', () => {
     });
     const state1 = await snack.getStateAsync();
     expect(state1.dependencies).toMatchSnapshot();
-    snack.setSDKVersion(sdkVersions.next);
+    snack.setSDKVersion(sdkVersions.prev);
     const state2 = await snack.getStateAsync();
     expect(state2.dependencies).toMatchSnapshot();
     expect(state1).not.toMatchObject(state2);

--- a/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
@@ -223,7 +223,7 @@ exports[`git imports repository with no sdkVersion 1`] = `
         },
         "description": "test2 @ Jan 1, 2020",
         "name": "test2",
-        "sdkVersion": "53.0.0",
+        "sdkVersion": "54.0.0",
       },
     },
     "headers": {
@@ -261,7 +261,7 @@ exports[`git imports repository with too old sdkVersion 1`] = `
         },
         "description": "test3 @ Jan 1, 2020",
         "name": "test3",
-        "sdkVersion": "53.0.0",
+        "sdkVersion": "54.0.0",
       },
     },
     "headers": {
@@ -295,7 +295,7 @@ exports[`git imports repository without app.json 1`] = `
         },
         "description": "some-example @ Jan 1, 2020",
         "name": "some-example",
-        "sdkVersion": "53.0.0",
+        "sdkVersion": "54.0.0",
       },
     },
     "headers": {


### PR DESCRIPTION
# Why

It has been long enough.

# How

Changed default SDK to `54.0.0`

# Test Plan

See tests and staging