### PR TITLE
Return 4xx instead of 500 for client errors in bundle endpoint

### DIFF
--- a/snackager/src/__tests__/bundle.test.ts
+++ b/snackager/src/__tests__/bundle.test.ts
@@ -1,0 +1,78 @@
+import supertest from 'supertest';
+
+import createApp from '../app';
+import { PackageNotFoundError, UnbundleablePackageError } from '../errors';
+import * as servePackageModule from '../utils/servePackage';
+
+jest.mock('../utils/servePackage');
+
+const mockedServePackage = servePackageModule.default as jest.MockedFunction<
+  typeof servePackageModule.default
+>;
+
+function request(): supertest.SuperTest<supertest.Test> {
+  return supertest(createApp());
+}
+
+describe('/bundle/', () => {
+  it('returns 404 for PackageNotFoundError', async () => {
+    mockedServePackage.mockRejectedValue(
+      new PackageNotFoundError('Package "nonexistent" not found in the registry'),
+    );
+
+    const response = await request().get('/bundle/nonexistent@1.0.0?platforms=ios');
+
+    expect(response.status).toBe(404);
+    expect(response.text).toContain('not found in the registry');
+    expect(response.text).toContain('Verify the package name and version');
+  });
+
+  it('returns 422 for UnbundleablePackageError', async () => {
+    mockedServePackage.mockRejectedValue(
+      new UnbundleablePackageError(
+        'Cannot resolve module crypto after installing it as a dependency',
+      ),
+    );
+
+    const response = await request().get('/bundle/bcrypt@5.1.1?platforms=ios');
+
+    expect(response.status).toBe(422);
+    expect(response.text).toContain('Cannot resolve module crypto');
+    expect(response.text).toContain('cannot be bundled for the Snack runtime');
+  });
+
+  it('returns 500 for unexpected errors', async () => {
+    mockedServePackage.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+    const response = await request().get('/bundle/some-package@1.0.0?platforms=ios');
+
+    expect(response.status).toBe(500);
+    expect(response.text).toContain('ENOENT');
+  });
+
+  it('does not report PackageNotFoundError to Sentry', async () => {
+    const raven = require('raven');
+    jest.spyOn(raven, 'captureException');
+
+    mockedServePackage.mockRejectedValue(
+      new PackageNotFoundError('Package "nonexistent" not found in the registry'),
+    );
+
+    await request().get('/bundle/nonexistent@1.0.0?platforms=ios');
+
+    expect(raven.captureException).not.toHaveBeenCalled();
+  });
+
+  it('does not report UnbundleablePackageError to Sentry', async () => {
+    const raven = require('raven');
+    jest.spyOn(raven, 'captureException');
+
+    mockedServePackage.mockRejectedValue(
+      new UnbundleablePackageError('Cannot resolve module crypto'),
+    );
+
+    await request().get('/bundle/bcrypt@5.1.1?platforms=ios');
+
+    expect(raven.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/snackager/src/bundle.ts
+++ b/snackager/src/bundle.ts
@@ -3,6 +3,7 @@ import querystring from 'querystring';
 import raven from 'raven';
 
 import config from './config';
+import { PackageNotFoundError, UnbundleablePackageError } from './errors';
 import parseRequest, { BundleRequest } from './utils/parseRequest';
 import servePackage from './utils/servePackage';
 
@@ -23,10 +24,22 @@ export default async function bundle(req: Request, res: Response): Promise<void>
     res.status(200);
     res.end(JSON.stringify(result));
   } catch (e) {
-    if (config.sentry) {
-      raven.captureException(e);
+    if (e instanceof PackageNotFoundError) {
+      res.status(404);
+      res.end(
+        `${e.message}. The package name may be misspelled, the version may not exist, or the package may have been unpublished. Verify the package name and version on the npm registry.`,
+      );
+    } else if (e instanceof UnbundleablePackageError) {
+      res.status(422);
+      res.end(
+        `${e.message}. This package cannot be bundled for the Snack runtime because it depends on modules that are unavailable in the browser or on native platforms. Try using a different package that supports the target platforms.`,
+      );
+    } else {
+      if (config.sentry) {
+        raven.captureException(e);
+      }
+      res.status(500);
+      res.end(e.message);
     }
-    res.status(500);
-    res.end(e.message);
   }
 }

--- a/snackager/src/errors.ts
+++ b/snackager/src/errors.ts
@@ -1,0 +1,11 @@
+export class PackageNotFoundError extends Error {
+  static {
+    this.prototype.name = 'PackageNotFoundError';
+  }
+}
+
+export class UnbundleablePackageError extends Error {
+  static {
+    this.prototype.name = 'UnbundleablePackageError';
+  }
+}

--- a/snackager/src/utils/fetchMetadata.ts
+++ b/snackager/src/utils/fetchMetadata.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 
 import config from '../config';
+import { PackageNotFoundError } from '../errors';
 import { RedisClient } from '../external/redis';
 import logger from '../logger';
 import { Metadata } from '../types';
@@ -83,14 +84,13 @@ export default async function fetchMetadata(
       return json;
     } catch (e) {
       logger.error({ ...logMetadata, qualified, e }, `error in parsing: ${e.toString()}`);
-      throw new Error(`Failed to parse the response for '${qualified}'`);
+      throw new Error(`Failed to parse the response for "${qualified}"`);
     }
   } catch (e) {
     logger.error({ ...logMetadata, qualified, e }, `error in fetching: ${e.toString()}`);
-    throw new Error(
-      e.name === 'NotFoundError'
-        ? `Package '${qualified}' not found in the registry`
-        : `Failed to fetch '${qualified}' from the registry`,
-    );
+    if (e.name === 'NotFoundError') {
+      throw new PackageNotFoundError(`Package "${qualified}" not found in the registry`);
+    }
+    throw new Error(`Failed to fetch "${qualified}" from the registry`);
   }
 }


### PR DESCRIPTION
Stacked on #675.

## Why
All errors from the `/bundle/` endpoint returned HTTP 500, including permanent failures like "package not found" (404 from npm) and "package can't be bundled" (invalid modules, unresolvable dependencies). These expected client errors inflated 5xx rates and created unnecessary Sentry noise. They should be 4xx to signal "don't retry" and to separate them from real server errors in metrics.

## How
Two new error classes, `PackageNotFoundError` and `UnbundleablePackageError`, are thrown from the appropriate sites in `fetchMetadata` and `packageBundle`. In `bundle.ts`, `PackageNotFoundError` maps to 404 and `UnbundleablePackageError` maps to 422, with descriptive response bodies explaining the error and how to work around it. Only 500s are reported to Sentry. `fetchBundle` stores `errorName` in Redis alongside cached errors so that `UnbundleablePackageError` is preserved across the cache boundary. Log levels in `servePackage` and `fetchBundle` are downgraded to warn for client errors.

## Test Plan
`yarn test` passes (74 tests). New unit tests in `src/__tests__/bundle.test.ts` mock `servePackage` to throw each error class and verify the status code, response body, and Sentry behavior.

Manually tested against local Redis with `NODE_OPTIONS=--openssl-legacy-provider`:
- 404 cold fetch: `this-package-does-not-exist-xyz@1.0.0` returns 404 with a descriptive message. Repeated requests also return 404 since registry 404s are not cached.
- 422 cold fetch: `bcrypt@5.1.1` returns 200 pending because bundling is async. After the bundler fails with "Cannot resolve module crypto after installing it as a dependency", the `UnbundleablePackageError` and `errorName` are stored in the Redis hash. The subsequent request re-throws the error and returns 422.
- 400: `react-native@0.73.0` returns 400 (existing `parseRequest` behavior, unchanged).