### PR TITLE
Add minAllowed CPU floor (150m) to snackager VPA

### DIFF
--- a/snackager/k8s/production/vertical-pod-autoscaler.yaml
+++ b/snackager/k8s/production/vertical-pod-autoscaler.yaml
@@ -12,6 +12,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: snackager
+      minAllowed:
+        cpu: 150m
       maxAllowed:
         cpu: 400m
         memory: 15Gi


### PR DESCRIPTION
Ensures the VPA never sets CPU requests below 150m for snackager pods in production, preventing under-provisioning during low-usage periods.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Changing the deployment file doesn 't work due to the VPA. 

# How

We change the minimum allowed by the VPA in order to be sure the cpu used is close as possible with the cpu we book/request.
<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Check with kubectl if the requests on resources spec has been applied properly.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
