### PR TITLE
[website] Fix test failing locally

### DIFF
--- a/website/jest/unit.setup.js
+++ b/website/jest/unit.setup.js
@@ -2,3 +2,13 @@ const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new Adapter() });
+
+// Node 21+ exposes a built-in `globalThis.navigator` whose `platform` reflects the host OS
+// (e.g. "MacIntel" on macOS). Source code that derives platform-specific behavior from
+// `navigator.platform` therefore produces host-dependent output in tests. Pin a fixed
+// non-Mac value so snapshots are stable across developer machines and CI.
+Object.defineProperty(globalThis, 'navigator', {
+  value: { platform: 'Linux x86_64', userAgent: 'jest' },
+  configurable: true,
+  writable: true,
+});


### PR DESCRIPTION
# Why

FileListEntry.test.tsx fails locally but passes on Linux CI. The test indirectly captures KeyMap.Meta's integer value, which KeybindingsManager.tsx derives from navigator.platform at module load. Jest's node test environment historically had no globalThis.navigator, so the snapshot was recorded with the non-Mac value. Node 21+ now exposes a built-in globalThis.navigator whose platform reflects the host OS, so on Macs the the snapshot mismatches.

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

Stub globalThis.navigator injest/unit.setup.js with a fixed non-Mac value so snapshot stays deterministic across hosts.

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

Tests pass.

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->