### PR TITLE
[snack-sdk][website][snackager] Migrate API server hostname

### DIFF
--- a/docs/hosts-ports.md
+++ b/docs/hosts-ports.md
@@ -8,5 +8,4 @@ The following hosts and ports are used by Snack.
 | localhost:3012 (snackager.expo.test) | staging-snackager.eascdn.net | snackager.eascdn.net | Snackager bundler service. |
 | localhost:3000 | staging.exp.host | exp.host | The Expo API server. |
 | localhost:3001 | staging.expo.dev | expo.dev | The Expo website. |
-| localhost:3020 | - | - | Proxy server that forwards and logs all requests to the local or staging Expo API server. Located in `./packages/snack-proxies`. |
 | localhost:3022 | - | - | Proxy server that forwards and logs all requests to the local or staging Snackager service. Located in `./packages/snack-proxies`. |

--- a/docs/snack-sdk.md
+++ b/docs/snack-sdk.md
@@ -419,7 +419,7 @@ Once a Snack has been saved, it can be downloaded as a Zip file. The `getDownloa
 
 ```ts
 const url = snack.getDownloadURLAsync();
-console.log('Download URL: ' + url); // https://exp.host/--/api/v2/snack/download/12345678
+console.log('Download URL: ' + url); // https://api.expo.dev/v2/snack/download/12345678
 ```
 
 # Transports

--- a/packages/snack-proxies/src/index.ts
+++ b/packages/snack-proxies/src/index.ts
@@ -2,20 +2,12 @@ import chalk from 'chalk';
 
 import { createProxy } from './proxy';
 
-Promise.all([
-  createProxy({
-    name: 'expo-www',
-    port: 3020,
-    localURL: 'http://localhost:3000',
-    stagingURL: 'https://staging.exp.host',
-  }),
-  createProxy({
-    name: 'snackager',
-    port: 3022,
-    localURL: 'http://localhost:3012',
-    stagingURL: 'https://staging-snackager.eascdn.net',
-  }),
-]).then(
-  () => console.log(chalk.green('All proxies started')),
-  (err) => console.error(chalk.red(`Failed to start proxies (${err})`)),
+createProxy({
+  name: 'snackager',
+  port: 3022,
+  localURL: 'http://localhost:3012',
+  stagingURL: 'https://staging-snackager.eascdn.net',
+}).then(
+  () => console.log(chalk.green('Snackager proxy started')),
+  (err) => console.error(chalk.red(`Failed to start snackager proxy (${err})`)),
 );

--- a/packages/snack-sdk/CHANGELOG.md
+++ b/packages/snack-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unpublished
 
+## 7.0.0
+
+### 🛠 Breaking changes
+
+- The SDK now uses the modern Expo API paths (`/v2/...`, `/graphql`) instead of the legacy paths (`/--/api/v2/...`, `/--/graphql`), and the default `apiURL` has been updated to `https://api.expo.dev`. Consumers using the default `apiURL` are unaffected.
+
 ## 4.0.1 - 2023-05-09
 
 ### 🐛 Bug fixes

--- a/packages/snack-sdk/package.json
+++ b/packages/snack-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snack-sdk",
-  "version": "6.7.0",
+  "version": "7.0.0",
   "description": "The Expo Snack SDK",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/snack-sdk/src/DevSession.ts
+++ b/packages/snack-sdk/src/DevSession.ts
@@ -62,7 +62,7 @@ export default class DevSession {
   private getRequest(close: boolean, user?: SnackUser, deviceId?: string) {
     const suffix = deviceId ? `?deviceId=${deviceId}` : '';
     const endpoint = close ? 'notify-close' : 'notify-alive';
-    const url = `${this.apiURL}/--/api/v2/development-sessions/${endpoint}${suffix}`;
+    const url = `${this.apiURL}/v2/development-sessions/${endpoint}${suffix}`;
 
     return {
       url,

--- a/packages/snack-sdk/src/FileUploader.ts
+++ b/packages/snack-sdk/src/FileUploader.ts
@@ -65,7 +65,7 @@ export default class FileUploader {
       let input;
       switch (file.type) {
         case 'CODE':
-          url = `${this.apiURL}/--/api/v2/snack/uploadCode`;
+          url = `${this.apiURL}/v2/snack/uploadCode`;
           input = {
             method: 'POST',
             body: JSON.stringify({ code: file.contents }),
@@ -73,7 +73,7 @@ export default class FileUploader {
           };
           break;
         case 'ASSET':
-          url = `${this.apiURL}/--/api/v2/snack/uploadAsset`;
+          url = `${this.apiURL}/v2/snack/uploadAsset`;
           if (
             (typeof FormData !== 'undefined' && file.contents instanceof FormData) ||
             (typeof file.contents === 'object' && file.contents.constructor?.name === 'FormData')

--- a/packages/snack-sdk/src/Session.ts
+++ b/packages/snack-sdk/src/Session.ts
@@ -398,7 +398,7 @@ export default class Snack {
 
       const previewPromise = this.getPreviewAsync();
 
-      const url = `${this.apiURL}/--/api/v2/snack/save`;
+      const url = `${this.apiURL}/v2/snack/save`;
       const response = await fetch(url, {
         method: 'POST',
         body: JSON.stringify(payload),
@@ -463,11 +463,11 @@ export default class Snack {
       await this.saveAsync(saveOptions);
       state = this.getState();
     }
-    return `${this.apiURL}/--/api/v2/snack/download/${state.id}`;
+    return `${this.apiURL}/v2/snack/download/${state.id}`;
   }
 
   private async uploadPreview(id: string, previewURL: string, status: boolean) {
-    const url = `${this.apiURL}/--/api/v2/snack/updateMetadata`;
+    const url = `${this.apiURL}/v2/snack/updateMetadata`;
     const payload = {
       id,
       previewLocation: previewURL,

--- a/packages/snack-sdk/src/WantedVersions.ts
+++ b/packages/snack-sdk/src/WantedVersions.ts
@@ -93,7 +93,6 @@ export class WantedDependencyVersions {
 
   /**
    * Fetch all remote versioned modules from the `/versions/latest` API endpoint.
-   * This doesn't work when running from a browser, as `/v2/versions/latest` is CORS blocked.
    */
   private fetchRemoteVersionedModules(sdkVersion: string): Promise<Record<string, string>> {
     return fetch(`${this.apiUrl}/v2/versions/latest`)

--- a/packages/snack-sdk/src/WantedVersions.ts
+++ b/packages/snack-sdk/src/WantedVersions.ts
@@ -93,10 +93,10 @@ export class WantedDependencyVersions {
 
   /**
    * Fetch all remote versioned modules from the `/versions/latest` API endpoint.
-   * This doesn't work when running from a browser, as `/--/api/v2/versions/latest` is CORS blocked.
+   * This doesn't work when running from a browser, as `/v2/versions/latest` is CORS blocked.
    */
   private fetchRemoteVersionedModules(sdkVersion: string): Promise<Record<string, string>> {
-    return fetch(`${this.apiUrl}/--/api/v2/versions/latest`)
+    return fetch(`${this.apiUrl}/v2/versions/latest`)
       .then((response) => response.json())
       .then((data) => this.normalizeRemoteVersionResponse(sdkVersion, data));
   }

--- a/packages/snack-sdk/src/__mocks__/www.ts
+++ b/packages/snack-sdk/src/__mocks__/www.ts
@@ -8,7 +8,7 @@ export default function createWww() {
   const app = new Koa();
   app.use(bodyParser());
   const router = new Router();
-  router.post('/--/api/v2/snack/save', (ctx) => {
+  router.post('/v2/snack/save', (ctx) => {
     try {
       // @ts-ignore
       const code: SnackFiles = ctx.request.body.code;
@@ -26,14 +26,14 @@ export default function createWww() {
       ctx.body = e.message;
     }
   });
-  router.post('/--/api/v2/snack/uploadAsset', (ctx) => {
+  router.post('/v2/snack/uploadAsset', (ctx) => {
     const hash = 'FDFDFDFDFDFDFD';
     ctx.body = {
       url: `https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/${hash}`,
       hash,
     };
   });
-  router.get('/--/api/v2/versions/latest', (ctx) => {
+  router.get('/v2/versions/latest', (ctx) => {
     ctx.body = {
       data: {
         sdkVersions: {

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -7,6 +7,6 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
       "{"session":{"url":"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A54.0.0&channel-name=production&snack-channel=10spnBnPxi"}}",
     ],
   },
-  "url": "https://exp.host/v2/development-sessions/notify-close?deviceId=1234",
+  "url": "https://api.expo.dev/v2/development-sessions/notify-close?deviceId=1234",
 }
 `;

--- a/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
+++ b/packages/snack-sdk/src/__tests__/__snapshots__/devsession-test.ts.snap
@@ -7,6 +7,6 @@ exports[`devsession receives sendBeaconCloseRequest 1`] = `
       "{"session":{"url":"exp://u.expo.dev/933fd9c0-1666-11e7-afca-d980795c5824?runtime-version=exposdk%3A54.0.0&channel-name=production&snack-channel=10spnBnPxi"}}",
     ],
   },
-  "url": "https://exp.host/--/api/v2/development-sessions/notify-close?deviceId=1234",
+  "url": "https://exp.host/v2/development-sessions/notify-close?deviceId=1234",
 }
 `;

--- a/packages/snack-sdk/src/__tests__/devsession-test.ts
+++ b/packages/snack-sdk/src/__tests__/devsession-test.ts
@@ -39,7 +39,7 @@ describe('devsession', () => {
 
   it('receives sendBeaconCloseRequest', async () => {
     const snack = new Snack({
-      apiURL: 'https://exp.host',
+      apiURL: 'https://api.expo.dev',
       channel: '10spnBnPxi',
     });
     expect(snack.getState().sendBeaconCloseRequest).toBeUndefined();
@@ -57,7 +57,7 @@ describe('devsession', () => {
 
   it('sends notify when calling setFocus', async () => {
     const snack = new Snack({
-      apiURL: 'https://exp.host',
+      apiURL: 'https://api.expo.dev',
       online: true,
       deviceId: '1234',
     });
@@ -70,7 +70,7 @@ describe('devsession', () => {
 
   it('sends notify with user session secret', async () => {
     const snack = new Snack({
-      apiURL: 'https://exp.host',
+      apiURL: 'https://api.expo.dev',
       online: true,
       deviceId: '1234',
       user: { sessionSecret: '{"some":"json"}' },
@@ -88,7 +88,7 @@ describe('devsession', () => {
 
   it('sends notify with user access token', async () => {
     const snack = new Snack({
-      apiURL: 'https://exp.host',
+      apiURL: 'https://api.expo.dev',
       online: true,
       deviceId: '1234',
       user: { accessToken: 'sometoken' },

--- a/packages/snack-sdk/src/__tests__/download-test.ts
+++ b/packages/snack-sdk/src/__tests__/download-test.ts
@@ -23,7 +23,7 @@ describe('download', () => {
     });
     const url = await snack.getDownloadURLAsync();
     expect(mockFetch).toBeCalled();
-    expect(url).toBe(`${defaultConfig.apiURL}/--/api/v2/snack/download/${SAVE_ID}`);
+    expect(url).toBe(`${defaultConfig.apiURL}/v2/snack/download/${SAVE_ID}`);
   });
 
   it('does not save when initial id is provided', async () => {
@@ -32,6 +32,6 @@ describe('download', () => {
     });
     const url = await snack.getDownloadURLAsync();
     expect(mockFetch).not.toBeCalled();
-    expect(url).toBe(`${defaultConfig.apiURL}/--/api/v2/snack/download/761293482`);
+    expect(url).toBe(`${defaultConfig.apiURL}/v2/snack/download/761293482`);
   });
 });

--- a/packages/snack-sdk/src/__tests__/snack-sdk.ts
+++ b/packages/snack-sdk/src/__tests__/snack-sdk.ts
@@ -7,7 +7,7 @@ switch (process.env.SNACK_ENV) {
     defaultConfig.snackpubURL = 'http://localhost:3013';
     break;
   case 'staging':
-    defaultConfig.apiURL = 'https://staging.exp.host';
+    defaultConfig.apiURL = 'https://staging-api.expo.dev';
     defaultConfig.snackagerURL = 'https://staging-snackager.eascdn.net';
     defaultConfig.snackpubURL = 'https://staging-snackpub.expo.dev';
     break;

--- a/packages/snack-sdk/src/__tests__/url-test.ts
+++ b/packages/snack-sdk/src/__tests__/url-test.ts
@@ -3,7 +3,7 @@ import { newestSdkVersion, oldestSdkVersion } from 'snack-content';
 
 import Snack, { SnackOptions } from './snack-sdk';
 
-const host = 'test.exp.host';
+const host = 'api.expo.test';
 const apiURL = `https://${host}`;
 const channel = '10spnBnPxi';
 const sdkVersion = newestSdkVersion;

--- a/packages/snack-sdk/src/defaultConfig.ts
+++ b/packages/snack-sdk/src/defaultConfig.ts
@@ -2,7 +2,7 @@ import { defaultSdkVersion } from 'snack-content';
 
 import { SnackState } from './types';
 
-export const apiURL: string = 'https://exp.host';
+export const apiURL: string = 'https://api.expo.dev';
 export const snackagerURL: string = 'https://snackager.eascdn.net';
 export const snackpubURL: string = 'https://snackpub.expo.dev';
 export const webPlayerURL: string = 'https://snack-runtime.eascdn.net/v2/%%SDK_VERSION%%';

--- a/snackager/k8s/production/snackager.env
+++ b/snackager/k8s/production/snackager.env
@@ -1,5 +1,5 @@
 CLOUDFRONT_URL=https://d37p21p3n8r8ug.cloudfront.net
 IMPORTS_S3_BUCKET=snack-git-imports
 S3_BUCKET=snackager-artifacts
-API_SERVER_URL=https://exp.host
+API_SERVER_URL=https://api.expo.dev
 IMPORT_SERVER_URL=https://snackager.eascdn.net

--- a/snackager/k8s/staging/snackager.env
+++ b/snackager/k8s/staging/snackager.env
@@ -1,5 +1,5 @@
 CLOUDFRONT_URL=https://ductmb1crhe2d.cloudfront.net
 IMPORTS_S3_BUCKET=snack-git-imports-staging
 S3_BUCKET=snackager-artifacts-staging
-API_SERVER_URL=https://staging.exp.host
+API_SERVER_URL=https://staging-api.expo.dev
 IMPORT_SERVER_URL=https://staging-snackager.eascdn.net

--- a/snackager/package.json
+++ b/snackager/package.json
@@ -54,7 +54,7 @@
     "semver-utils": "^1.1.4",
     "snack-content": "~3.7.0",
     "snack-require-context": "*",
-    "snack-sdk": "~6.7.0",
+    "snack-sdk": "~7.0.0",
     "source-map-support": "^0.4.15",
     "targz": "^1.0.1",
     "validate-npm-package-name": "^3.0.0",

--- a/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`git imports basic repository 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -40,7 +40,7 @@ exports[`git imports basic repository 1`] = `
 
 exports[`git imports repository created with main branch 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -78,7 +78,7 @@ exports[`git imports repository created with main branch 1`] = `
 
 exports[`git imports repository with app.config.js 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -114,11 +114,11 @@ exports[`git imports repository with app.config.js 1`] = `
 ]
 `;
 
-exports[`git imports repository with assets 1`] = `"https://test.exp.host/--/api/v2/snack/uploadAsset"`;
+exports[`git imports repository with assets 1`] = `"https://test.exp.host/v2/snack/uploadAsset"`;
 
 exports[`git imports repository with assets 2`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -160,7 +160,7 @@ exports[`git imports repository with assets 2`] = `
 
 exports[`git imports repository with custom branch 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -198,7 +198,7 @@ exports[`git imports repository with custom branch 1`] = `
 
 exports[`git imports repository with no sdkVersion 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -236,7 +236,7 @@ exports[`git imports repository with no sdkVersion 1`] = `
 
 exports[`git imports repository with too old sdkVersion 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {
@@ -274,7 +274,7 @@ exports[`git imports repository with too old sdkVersion 1`] = `
 
 exports[`git imports repository without app.json 1`] = `
 [
-  "https://test.exp.host/--/api/v2/snack/save",
+  "https://test.exp.host/v2/snack/save",
   {
     "body": {
       "code": {

--- a/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
+++ b/snackager/src/__e2e__/__snapshots__/git.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`git imports basic repository 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -40,7 +40,7 @@ exports[`git imports basic repository 1`] = `
 
 exports[`git imports repository created with main branch 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -78,7 +78,7 @@ exports[`git imports repository created with main branch 1`] = `
 
 exports[`git imports repository with app.config.js 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -114,11 +114,11 @@ exports[`git imports repository with app.config.js 1`] = `
 ]
 `;
 
-exports[`git imports repository with assets 1`] = `"https://test.exp.host/v2/snack/uploadAsset"`;
+exports[`git imports repository with assets 1`] = `"https://api.expo.test/v2/snack/uploadAsset"`;
 
 exports[`git imports repository with assets 2`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -160,7 +160,7 @@ exports[`git imports repository with assets 2`] = `
 
 exports[`git imports repository with custom branch 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -198,7 +198,7 @@ exports[`git imports repository with custom branch 1`] = `
 
 exports[`git imports repository with no sdkVersion 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -236,7 +236,7 @@ exports[`git imports repository with no sdkVersion 1`] = `
 
 exports[`git imports repository with too old sdkVersion 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {
@@ -274,7 +274,7 @@ exports[`git imports repository with too old sdkVersion 1`] = `
 
 exports[`git imports repository without app.json 1`] = `
 [
-  "https://test.exp.host/v2/snack/save",
+  "https://api.expo.test/v2/snack/save",
   {
     "body": {
       "code": {

--- a/snackager/src/config.ts
+++ b/snackager/src/config.ts
@@ -54,7 +54,7 @@ const config: Config = {
     url: env('CLOUDFRONT_URL'),
   },
   api: {
-    url: env('API_SERVER_URL', 'https://test.exp.host'),
+    url: env('API_SERVER_URL', 'https://api.expo.test'),
   },
 };
 

--- a/snackager/src/utils/packageBundle.ts
+++ b/snackager/src/utils/packageBundle.ts
@@ -386,7 +386,7 @@ export async function getBundledVersionAsync(
   packageName: string,
   sdkVersion: string,
 ): Promise<string | null> {
-  const url = `${config.api.url}/--/api/v2/sdks/${sdkVersion}/native-modules`;
+  const url = `${config.api.url}/v2/sdks/${sdkVersion}/native-modules`;
   const resp = await fetch(url);
   const bundledNativeModules = await resp.json();
   return (

--- a/website/README.md
+++ b/website/README.md
@@ -10,13 +10,20 @@ Start the website by running `yarn start` from the root of the repository.
 
 To view the website, open https://snack.expo.test (Expo employees, requires Universe set up via `install-tools`) or http://localhost:3011 (external contributors).
 
+The API server defaults to `https://proxy-staging-api.expo.test`. API requests only work for Expo employees. Override with `API_SERVER_URL` when starting:
+
+```sh
+API_SERVER_URL=https://api.expo.test yarn start
+API_SERVER_URL=https://proxy-production-api.expo.test yarn start
+```
+
 ## Running development services locally
 
 When you have access to the Expo Universe repository, you can choose to run certain Expo services locally.
 
 ### Expo API server (www)
 
-Start the `www` server. `snack-proxies` automatically detects the local server and routes all trafic to localhost:3000 when possible.
+Start the `www` server. To point Snack at it, set `API_SERVER_URL=https://api.expo.test` when starting (see "Getting started" above).
 
 ```sh
 # expo/universe
@@ -61,7 +68,7 @@ expo start:web
 
 Use ngrok to set up a tunnel to your locally-running www instance.
 
-1. Replace 'staging.exp.host' with your ngrok url, in the host of the Snack constructor (client/components/App.tsx).
+1. Replace 'staging-api.expo.dev' with your ngrok url, in the host of the Snack constructor (client/components/App.tsx).
 2. Restart local snack server.
 3. Send to device.
 

--- a/website/deploy/development/snack.env
+++ b/website/deploy/development/snack.env
@@ -1,7 +1,7 @@
 NODE_ENV=development
 LEGACY_SERVER_URL=http://expo.io.test
 SERVER_URL=https://expo.test
-API_SERVER_URL=http://localhost:3020
+API_SERVER_URL=https://api.expo.test
 SNACKPUB_URL=http://localhost:3013
 DEPLOY_ENVIRONMENT=development
 IMPORT_SERVER_URL=http://localhost:3022

--- a/website/deploy/development/snack.env
+++ b/website/deploy/development/snack.env
@@ -1,7 +1,6 @@
 NODE_ENV=development
 LEGACY_SERVER_URL=http://expo.io.test
 SERVER_URL=https://expo.test
-API_SERVER_URL=https://api.expo.test
 SNACKPUB_URL=http://localhost:3013
 DEPLOY_ENVIRONMENT=development
 IMPORT_SERVER_URL=http://localhost:3022

--- a/website/deploy/production/snack.env
+++ b/website/deploy/production/snack.env
@@ -1,6 +1,6 @@
 LEGACY_SERVER_URL=https://expo.io
 SERVER_URL=https://expo.dev
-API_SERVER_URL=https://exp.host
+API_SERVER_URL=https://api.expo.dev
 SNACKPUB_URL=https://snackpub.expo.dev
 SENTRY_ENVIRONMENT=staging
 LEGACY_SNACK_SERVER_URL=https://snack.expo.io

--- a/website/deploy/staging/snack.env
+++ b/website/deploy/staging/snack.env
@@ -1,6 +1,6 @@
 LEGACY_SERVER_URL=https://staging.expo.io
 SERVER_URL=https://staging.expo.dev
-API_SERVER_URL=https://staging.exp.host
+API_SERVER_URL=https://staging-api.expo.dev
 SNACKPUB_URL=https://staging-snackpub.expo.dev
 SENTRY_ENVIRONMENT=staging
 LEGACY_SNACK_SERVER_URL=https://staging.snack.expo.io

--- a/website/package.json
+++ b/website/package.json
@@ -6,8 +6,8 @@
   "main": "build/server",
   "scripts": {
     "start": "yarn watch",
-    "watch": "NODE_OPTIONS=--openssl-legacy-provider env-cmd -f deploy/development/snack.env tsnd --inspect=9211 --quiet src/server/index.tsx",
-    "build:dev": "env-cmd -f deploy/development/snack.env yarn build",
+    "watch": "NODE_OPTIONS=--openssl-legacy-provider API_SERVER_URL=${API_SERVER_URL:-https://proxy-staging-api.expo.test} env-cmd -f deploy/development/snack.env tsnd --inspect=9211 --quiet src/server/index.tsx",
+    "build:dev": "API_SERVER_URL=${API_SERVER_URL:-https://proxy-staging-api.expo.test} env-cmd -f deploy/development/snack.env yarn build",
     "build": "env-cmd -e production yarn build:server && yarn build:client",
     "build:server": "babel --source-maps --extensions '.ts,.tsx' --out-dir build/ src/",
     "build:client": "NODE_OPTIONS=--openssl-legacy-provider webpack",

--- a/website/package.json
+++ b/website/package.json
@@ -82,7 +82,7 @@
     "snack-babel-standalone": "^3.0.1",
     "snack-content": "~3.7.0",
     "snack-eslint-standalone": "^2.0.0",
-    "snack-sdk": "~6.7.0",
+    "snack-sdk": "~7.0.0",
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {

--- a/website/skaffold.yaml
+++ b/website/skaffold.yaml
@@ -15,7 +15,7 @@ build:
           node_version: 22.21.1
           LEGACY_SERVER_URL: https://staging.expo.io
           SERVER_URL: https://staging.expo.dev
-          API_SERVER_URL: https://staging.exp.host
+          API_SERVER_URL: https://staging-api.expo.dev
           SNACKPUB_URL: https://staging-snackpub.expo.dev
           APP_VERSION: staging-{{.GITHUB_SHA}}
           DEPLOY_ENVIRONMENT: staging
@@ -46,7 +46,7 @@ profiles:
               node_version: 22.21.1
               LEGACY_SERVER_URL: https://expo.io
               SERVER_URL: https://expo.dev
-              API_SERVER_URL: https://exp.host
+              API_SERVER_URL: https://api.expo.dev
               SNACKPUB_URL: https://snackpub.expo.dev
               APP_VERSION: production-{{.GITHUB_SHA}}
               DEPLOY_ENVIRONMENT: production

--- a/website/src/client/auth/authManager.tsx
+++ b/website/src/client/auth/authManager.tsx
@@ -236,7 +236,7 @@ async function _performGraphQLApiRequest<T>(
   if (options) {
     delete options.headers;
   }
-  const response = await fetch(`${process.env.API_SERVER_URL}/--/graphql`, {
+  const response = await fetch(`${process.env.API_SERVER_URL}/graphql`, {
     method: 'POST',
     headers: {
       Accept: 'application/json',

--- a/website/src/client/auth/withAuth.tsx
+++ b/website/src/client/auth/withAuth.tsx
@@ -48,7 +48,7 @@ const enhanceWithAuthMethods = (Comp: React.ComponentType<AuthProps>) => {
       if (!accessToken && !sessionSecret) {
         return;
       }
-      const endpoint = `${nullthrows(process.env.API_SERVER_URL)}/--/graphql`;
+      const endpoint = `${nullthrows(process.env.API_SERVER_URL)}/graphql`;
       try {
         const response = await fetch(`${endpoint}`, {
           method: 'POST',

--- a/website/src/client/components/App.tsx
+++ b/website/src/client/components/App.tsx
@@ -628,7 +628,7 @@ class Main extends React.Component<Props, State> {
         once = false;
         Analytics.getInstance().logEvent('DOWNLOADED_CODE');
 
-        const url = `${process.env.API_SERVER_URL}/--/api/v2/snack/download/${id}`;
+        const url = `${process.env.API_SERVER_URL}/v2/snack/download/${id}`;
 
         // Simulate link click to download file
         const element = document.createElement('a');

--- a/website/src/client/components/Import/ImportProductionModal.tsx
+++ b/website/src/client/components/Import/ImportProductionModal.tsx
@@ -66,7 +66,7 @@ export default class ImportProductionModal extends React.PureComponent<Props, St
         throw new Error('Invalid url');
       }
       const id = match[2];
-      const response = await fetch(`https://exp.host/--/api/v2/snack/${id}`, {
+      const response = await fetch(`https://api.expo.dev/v2/snack/${id}`, {
         headers: { 'Snack-Api-Version': '3.0.0' },
       });
 

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -59,7 +59,7 @@ const render = async (ctx: Context) => {
   if (id) {
     try {
       const response = await fetch(
-        `${nullthrows(process.env.API_SERVER_URL)}/--/api/v2/snack/${id}`,
+        `${nullthrows(process.env.API_SERVER_URL)}/v2/snack/${id}`,
         {
           headers: {
             'Snack-Api-Version': '3.0.0',

--- a/website/src/server/routes.tsx
+++ b/website/src/server/routes.tsx
@@ -58,15 +58,12 @@ const render = async (ctx: Context) => {
 
   if (id) {
     try {
-      const response = await fetch(
-        `${nullthrows(process.env.API_SERVER_URL)}/v2/snack/${id}`,
-        {
-          headers: {
-            'Snack-Api-Version': '3.0.0',
-            ...(expoSession ? { 'expo-session': decodeURIComponent(expoSession) } : {}),
-          },
-        }
-      );
+      const response = await fetch(`${nullthrows(process.env.API_SERVER_URL)}/v2/snack/${id}`, {
+        headers: {
+          'Snack-Api-Version': '3.0.0',
+          ...(expoSession ? { 'expo-session': decodeURIComponent(expoSession) } : {}),
+        },
+      });
 
       const text = await response.text();
       const json = JSON.parse(text);


### PR DESCRIPTION
# Why

For cookie-based auth to work, the API server url needs to be updated from exp.host to api.expo.dev (which shares the top-level domain with snack.expo.dev). api.expo.dev accepts requests in a different format than exp.host.

# How

snack-sdk

- Changed default apiUrl to api.expo.dev
- Use the modern path format
- Updated docs since this is a breaking change

snack-proxies

- removed www from snack-proxies. No longer used. Instead, snack website runs against proxy-staging-api.expo.test, but this can be overriden with API_SERVER_URL

snackager

- passes new api server url to snack-sdk

website

- passes new api server url to snack-sdk
- updates its own API requests


# Test Plan
Used snack.expo.test locally and verified that thing worked as expected, but we don't have e2e test coverage for this. 