### PR TITLE
[website] Allow overscroll-behavior on embedded snack

### DIFF
--- a/website/src/server/pages/Document.tsx
+++ b/website/src/server/pages/Document.tsx
@@ -105,7 +105,6 @@ export default function Document(props: Props) {
                 font-family: var(--font-normal);
                 font-size: 14px;
                 line-height: 1.42857143;
-                overscroll-behavior: none;
               }
 
               div {


### PR DESCRIPTION
# Why

This PR addresses this [issue](https://github.com/facebook/react-native-website/issues/5001) raised in the [React Native Website repository](https://github.com/facebook/react-native-website/tree/main) regarding the embedded snack's scroll behavior.

As I mentioned on the linked issue, this issue appears on Chromea and Firefox (and maybe Edge?) - but not on Safari.

# How

Removed `overscroll-behavior: none` from the `body` element. This allows the user to continue scrolling the page when they have scrolled to the end of the code block on an embedded snack. Alternatively, if we want to keep the CSS property we could change it to `overscroll-behavior: auto`.

# Test Plan

The easiest way to test this feature is to go a page on the React Native website (i.e. https://reactnative.dev/docs/flatlist#example) with an embedded snack, inspect the snack, and remove `overscroll-behavior: none` from the body element inside the iframe. Once the CSS property is removed, scroll to the end of the code block on the embedded snack and continue scrolling - the page should scroll as expected.

Here are some screen recordings showing before and after the property is removed.

**Before**
<img width="600" height="386" alt="snack-scroll-behavior-before" src="https://github.com/user-attachments/assets/ed3856b5-1f15-4d98-ba4c-3b358eb9dfe3" />


**After**
<img width="640" height="480" alt="snack-scroll-behavior-after" src="https://github.com/user-attachments/assets/09b0ff97-1ab1-42b7-8b04-51f7420bc3b6" />
