### PR TITLE
[staging] Pin snack / snackager / snackpub to the dev node pool

### DIFF
--- a/snackager/k8s/staging/deployment-dev-pool.yaml
+++ b/snackager/k8s/staging/deployment-dev-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snackager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: dev
+      tolerations:
+      - key: dedicated
+        value: dev
+        effect: NoSchedule

--- a/snackager/k8s/staging/kustomization.yaml
+++ b/snackager/k8s/staging/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - external-secret-private-key.yaml
 patchesStrategicMerge:
 - service-backend.yaml
+- deployment-dev-pool.yaml
 configMapGenerator:
 - name: snackager-config
   behavior: merge

--- a/snackpub/k8s/staging/deployment-dev-pool.yaml
+++ b/snackpub/k8s/staging/deployment-dev-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snackpub
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: dev
+      tolerations:
+      - key: dedicated
+        value: dev
+        effect: NoSchedule

--- a/snackpub/k8s/staging/kustomization.yaml
+++ b/snackpub/k8s/staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - external-secret-env.yaml
 patchesStrategicMerge:
   - service-backend.yaml
+  - deployment-dev-pool.yaml
 secretGenerator:
   - name: snackpub-env
     behavior: merge

--- a/website/deploy/staging/deployment-dev-pool.yaml
+++ b/website/deploy/staging/deployment-dev-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snack
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: dev
+      tolerations:
+      - key: dedicated
+        value: dev
+        effect: NoSchedule

--- a/website/deploy/staging/kustomization.yaml
+++ b/website/deploy/staging/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 - ../base
 patchesStrategicMerge:
 - service-backend.yaml
+- deployment-dev-pool.yaml
 configMapGenerator:
 - name: snack
   behavior: merge


### PR DESCRIPTION
## What
Move the **staging** snack, snackager and snackpub deployments off the shared NAP pools onto the dedicated **`development`** GKE node pool: `nodeSelector: pool=dev` + toleration `dedicated=dev:NoSchedule`.

## Why
Node-pool consolidation — staging workloads belong on the `development` pool, off NAP.

## Compatibility (verified live)
- **Stateless** (no PVCs) → no pd-balanced/Hyperdisk attach issue on the c4d-standard-8 `development` nodes.
- `development` taint = `dedicated=dev:NoSchedule` (only) → toleration is sufficient.
- Staging overlays render with `pool=dev` + `dedicated=dev`; production overlays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)