### PR TITLE
[production] Pin snack / snackager / snackpub to the prod node pool

### DIFF
--- a/snackager/k8s/production/deployment-prod-pool.yaml
+++ b/snackager/k8s/production/deployment-prod-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snackager
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: prod
+      tolerations:
+      - key: dedicated
+        value: prod
+        effect: NoSchedule

--- a/snackager/k8s/production/kustomization.yaml
+++ b/snackager/k8s/production/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - external-secret-private-key.yaml
 patchesStrategicMerge:
 - deployment-increase-replicas.yaml
+- deployment-prod-pool.yaml
 - service-backend.yaml
 configMapGenerator:
 - name: snackager-config

--- a/snackpub/k8s/production/deployment-prod-pool.yaml
+++ b/snackpub/k8s/production/deployment-prod-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snackpub
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: prod
+      tolerations:
+      - key: dedicated
+        value: prod
+        effect: NoSchedule

--- a/snackpub/k8s/production/kustomization.yaml
+++ b/snackpub/k8s/production/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 patchesStrategicMerge:
   - service-backend.yaml
   - deployment-replicas.yaml
+  - deployment-prod-pool.yaml
 secretGenerator:
   - name: snackpub-env
     behavior: merge

--- a/website/deploy/production/deployment-prod-pool.yaml
+++ b/website/deploy/production/deployment-prod-pool.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snack
+spec:
+  template:
+    spec:
+      nodeSelector:
+        pool: prod
+      tolerations:
+      - key: dedicated
+        value: prod
+        effect: NoSchedule

--- a/website/deploy/production/kustomization.yaml
+++ b/website/deploy/production/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - vertical-pod-autoscaler.yaml
 patchesStrategicMerge:
 - deployment-replicas.yaml
+- deployment-prod-pool.yaml
 - service-backend.yaml
 configMapGenerator:
 - name: snack


### PR DESCRIPTION
## What
Move the **production snack, snackager, snackpub** production workload(s) off the shared NAP pools onto the dedicated **`prod`** GKE node pool (general-central): `nodeSelector: pool=prod` + toleration `dedicated=prod:NoSchedule`.

## Why
Node-pool consolidation — production workloads belong on the `prod` pool, off NAP.

## Compatibility (verified against the live cluster)
- **Stateless** — no PVCs, so no pd-balanced/Hyperdisk attach issue on the c4d-standard-8 `prod` nodes.
- `prod` pool taint = `dedicated=prod:NoSchedule` → the added toleration is sufficient.
- Additive patch (base has no nodeSelector) → pool-only selector, no machine-family/iam pins. Production overlay render validated; staging overlays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)