### PR TITLE
staging: pin snack/snackager/snackpub to CAST AI dev-ondemand (ENG-21836)

### DIFF
--- a/snackager/k8s/staging/deployment-dev-pool.yaml
+++ b/snackager/k8s/staging/deployment-dev-pool.yaml
@@ -6,8 +6,13 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: dev
+        $patch: replace
+        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
+        scheduling.cast.ai/node-template: dev-ondemand
       tolerations:
       - key: dedicated
         value: dev
+        effect: NoSchedule
+      - key: scheduling.cast.ai/scoped-autoscaler
+        operator: Exists
         effect: NoSchedule

--- a/snackpub/k8s/staging/deployment-dev-pool.yaml
+++ b/snackpub/k8s/staging/deployment-dev-pool.yaml
@@ -6,8 +6,13 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: dev
+        $patch: replace
+        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
+        scheduling.cast.ai/node-template: dev-ondemand
       tolerations:
       - key: dedicated
         value: dev
+        effect: NoSchedule
+      - key: scheduling.cast.ai/scoped-autoscaler
+        operator: Exists
         effect: NoSchedule

--- a/website/deploy/staging/deployment-dev-pool.yaml
+++ b/website/deploy/staging/deployment-dev-pool.yaml
@@ -6,8 +6,13 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: dev
+        $patch: replace
+        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
+        scheduling.cast.ai/node-template: dev-ondemand
       tolerations:
       - key: dedicated
         value: dev
+        effect: NoSchedule
+      - key: scheduling.cast.ai/scoped-autoscaler
+        operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
## Why
Dev consolidation (ENG-21836): move the snack staging tier off the GKE development pool onto the CAST AI dev-ondemand template so the dev pool can be retired.
## How
Swap the staging nodeSelector to scheduling.cast.ai/node-template: dev-ondemand (replacing pool: dev) and add the scheduling.cast.ai/scoped-autoscaler toleration, for snackpub, snackager, and snack. Same pattern as universe #29346.
## Test Plan
On deploy, watch each Deployment roll onto dev-ondemand nodes and go Ready, off the development pool, zero downtime (RollingUpdate surge). Rollback = revert the selector.