### PR TITLE
staging: move snack/snackager/snackpub to the dev-spot CAST template (ENG-21836 wave 1)

### DIFF
--- a/snackager/k8s/staging/deployment-dev-pool.yaml
+++ b/snackager/k8s/staging/deployment-dev-pool.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       nodeSelector:
         $patch: replace
-        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
-        scheduling.cast.ai/node-template: dev-ondemand
+        # spot wave 1 (ENG-21836): stateless staging tolerates preemption, move to the spot template.
+        scheduling.cast.ai/node-template: dev-spot
       tolerations:
       - key: dedicated
         value: dev

--- a/snackpub/k8s/staging/deployment-dev-pool.yaml
+++ b/snackpub/k8s/staging/deployment-dev-pool.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       nodeSelector:
         $patch: replace
-        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
-        scheduling.cast.ai/node-template: dev-ondemand
+        # spot wave 1 (ENG-21836): stateless staging tolerates preemption, move to the spot template.
+        scheduling.cast.ai/node-template: dev-spot
       tolerations:
       - key: dedicated
         value: dev

--- a/website/deploy/staging/deployment-dev-pool.yaml
+++ b/website/deploy/staging/deployment-dev-pool.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       nodeSelector:
         $patch: replace
-        # dev consolidation (ENG-21836): pin staging to the on-demand dev-ondemand CAST AI template.
-        scheduling.cast.ai/node-template: dev-ondemand
+        # spot wave 1 (ENG-21836): stateless staging tolerates preemption, move to the spot template.
+        scheduling.cast.ai/node-template: dev-spot
       tolerations:
       - key: dedicated
         value: dev


### PR DESCRIPTION
## Why
Spot phase of ENG-21836, wave 1 covers the lowest-risk staging workloads. All 3 snack services are stateless, single replica, 30-120s shutdown, staging blast radius only. 

## How
Selector flip dev-ondemand to dev-spot in the 3 staging patches, nothing else. Tolerations already in place, and dev-spot falls back to on-demand on spot stockout.

## Test Plan
- render verified, all 3 deployments go to dev-spot
- merge auto-deploys staging, watch the trio land on spot nodes with 0 restarts
- rollback = revert this PR