### PR TITLE
fix: memory leak in embedded Snack

### DIFF
--- a/website/src/server/EmbeddedSnackScript.tsx
+++ b/website/src/server/EmbeddedSnackScript.tsx
@@ -14,6 +14,37 @@ export const script = `
     return;
   }
 
+  var messageListeners = new Map();
+  var messageListenerObserver = new MutationObserver(function() {
+    messageListeners.forEach(function(listener, iframe) {
+      if (!iframe.isConnected) {
+        removeMessageListener(iframe);
+      }
+    });
+  });
+
+  function removeMessageListener(iframe) {
+    var listener = messageListeners.get(iframe);
+    if (listener) {
+      window.removeEventListener('message', listener);
+      messageListeners.delete(iframe);
+      if (messageListeners.size === 0) {
+        messageListenerObserver.disconnect();
+      }
+    }
+  }
+
+  function addMessageListener(iframe, listener) {
+    if (messageListeners.size === 0) {
+      messageListenerObserver.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+    messageListeners.set(iframe, listener);
+    window.addEventListener('message', listener);
+  }
+
   var ExpoSnack = {
     append: function(container, options) {
       options = options || {};
@@ -120,21 +151,31 @@ export const script = `
       iframe.allowTransparency = true;
       iframe.dataset.snackIframe = true;
 
-      container.appendChild(iframe);
-
       if (options.code || options.files || options.dependencies) {
-        window.addEventListener('message', function(event) {
+        var listener = function(event) {
           var eventName = event.data[0];
           var data = event.data[1];
           if (eventName === 'expoFrameLoaded' && data.iframeId === iframeId) {
-            iframe.contentWindow.postMessage(['expoDataEvent', {
-              iframeId: iframeId,
-              dependencies: options.dependencies,
-              code: options.code,
-              files: options.files,
-            }], '*')
+            try {
+              iframe.contentWindow.postMessage(['expoDataEvent', {
+                iframeId: iframeId,
+                dependencies: options.dependencies,
+                code: options.code,
+                files: options.files,
+              }], '*')
+            } finally {
+              removeMessageListener(iframe);
+            }
           }
-        });
+        };
+        addMessageListener(iframe, listener);
+      }
+
+      try {
+        container.appendChild(iframe);
+      } catch (error) {
+        removeMessageListener(iframe);
+        throw error;
       }
     },
 
@@ -142,6 +183,7 @@ export const script = `
       var iframe = container.querySelector('iframe[data-snack-iframe]');
 
       if (iframe) {
+        removeMessageListener(iframe);
         iframe.parentNode.removeChild(iframe);
       }
     },

--- a/website/src/server/__tests__/EmbeddedSnackScript.test.ts
+++ b/website/src/server/__tests__/EmbeddedSnackScript.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+
+export {};
+
+type ExpoSnackApi = {
+  append(container: HTMLElement): void;
+  remove(container: HTMLElement): void;
+};
+
+const getExpoSnack = (): ExpoSnackApi =>
+  (window as unknown as { ExpoSnack: ExpoSnackApi }).ExpoSnack;
+
+const appendInlineSnack = () => {
+  const container = document.createElement('div');
+  container.dataset.snackCode = encodeURIComponent('export default function App() {}');
+  document.body.appendChild(container);
+  getExpoSnack().append(container);
+
+  const iframe = container.querySelector<HTMLIFrameElement>('iframe[data-snack-iframe]');
+  if (!iframe) {
+    throw new Error('Expected an embedded Snack iframe');
+  }
+
+  const iframeId = new URL(iframe.src).searchParams.get('iframeId');
+  if (!iframeId) {
+    throw new Error('Expected the embedded Snack iframe to have an id');
+  }
+
+  return { container, iframe, iframeId };
+};
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.SNACK_SERVER_URL = 'https://snack.expo.dev';
+  document.body.replaceChildren();
+  delete (window as unknown as { ExpoSnack?: ExpoSnackApi }).ExpoSnack;
+  delete (window as unknown as { ExpoSketch?: ExpoSnackApi }).ExpoSketch;
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { script } = require('../EmbeddedSnackScript') as { script: string };
+  // eslint-disable-next-line no-eval
+  window.eval(script);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('removes the message listener after sending data to the iframe', () => {
+  const removeEventListener = jest.spyOn(window, 'removeEventListener');
+  const { iframe, iframeId } = appendInlineSnack();
+  const postMessage = jest.spyOn(iframe.contentWindow!, 'postMessage').mockImplementation();
+  const loadedEvent = new MessageEvent('message', {
+    data: ['expoFrameLoaded', { iframeId }],
+  });
+
+  window.dispatchEvent(loadedEvent);
+  window.dispatchEvent(loadedEvent);
+
+  expect(postMessage).toHaveBeenCalledTimes(1);
+  expect(removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+});
+
+it('removes the message listener when removing an iframe before it loads', () => {
+  const removeEventListener = jest.spyOn(window, 'removeEventListener');
+  const { container, iframe } = appendInlineSnack();
+
+  getExpoSnack().remove(container);
+
+  expect(container.contains(iframe)).toBe(false);
+  expect(removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+});
+
+it('removes the message listener when the host removes the container', async () => {
+  const removeEventListener = jest.spyOn(window, 'removeEventListener');
+  const { container } = appendInlineSnack();
+
+  container.remove();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+});
+
+it('registers the message listener before inserting the iframe', () => {
+  const removeEventListener = jest.spyOn(window, 'removeEventListener');
+  const container = document.createElement('div');
+  container.dataset.snackCode = encodeURIComponent('export default function App() {}');
+  document.body.appendChild(container);
+  const appendChild = container.appendChild.bind(container);
+
+  jest.spyOn(container, 'appendChild').mockImplementation((node) => {
+    const result = appendChild(node);
+    const iframe = node as HTMLIFrameElement;
+    const iframeId = new URL(iframe.src).searchParams.get('iframeId');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: ['expoFrameLoaded', { iframeId }],
+      })
+    );
+    return result;
+  });
+
+  getExpoSnack().append(container);
+
+  expect(removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+});


### PR DESCRIPTION
### Details

Inline embedded Snacks register a global `message` callback that captures their iframe while waiting for `expoFrameLoaded`. When a host removes the container during client-side navigation, the callback stays registered and keeps the detached iframe reachable.

### Change

Track pending callbacks per iframe, unregister them after the handshake or explicit removal, and observe host-driven DOM removal so abandoned embeds are cleaned up. Register the callback before insertion to avoid missing a synchronous load message.

### Before

When navigating between the React Native Introduction and Core Components pages 37 times, the embedded Snack message callback grows by 74:

<img width="1400" height="100" alt="before" src="https://github.com/user-attachments/assets/0e902bd5-fcc6-4618-a515-c5456ca1e590" />

### After

No more matching embedded Snack message callback growth is detected.

<img width="1400" height="60" alt="after" src="https://github.com/user-attachments/assets/23b3ce90-a869-4158-bfcb-e632b7f8e4c0" />

### Test Video

[react-native-docs-core-components.webm](https://github.com/user-attachments/assets/9fcc8e82-de8f-421a-ad09-3494f8970e82)
